### PR TITLE
v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Represents the **NuGet** versions.
 
+## v3.1.0
+- *Enhancement:* Added `Hosting.ServiceBase` class for a self-orchestrated service to execute for a specified `MaxIterations`; provides an alternative to using a `HostedService`. Useful for the likes of timer trigger Azure Functions for eample.
+- *Enhancement:* Added `EventOutboxService` as an alternative to `EventOutboxHostedService`; related to (and leverages) above to achieve same outcome.
+- *Fixed:* `Database.OnDbException` was incorrectly converting the unhandled exception to a `Result`; will now throw as expected.
+
 ## v3.0.0
 - *Enhancement:* Added new `CoreEx.Results` namespace with primary `Result` and `Result<T>` classes to enable [monadic](https://en.wikipedia.org/wiki/Monad_(functional_programming)) error-handling, often referred to [Railway-oriented programming](https://swlaschin.gitbooks.io/fsharpforfunandprofit/content/posts/recipe-part2.html); see [`CoreEx.Results`](./src/CoreEx/Results/README.md) for more implementation details. Thanks [Adi](https://github.com/AdiThakker) for inspiring and guiding on this change. Related changes as follows:
   - *Enhancement:* `EventSubscriberBase`, `SubscriberBase` and `SubscriberBase<T>` modified to include `EventSubscriberArgs` (`Dictionary<string, object?>`) to allow other parameters to be passed in. The `ReceiveAsync` methods now support the args as a parameter, and must return a `Result` to better support errors; breaking change. 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.0.0</Version>
+		<Version>3.1.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx.Database.MySql/MySqlDatabase.cs
+++ b/src/CoreEx.Database.MySql/MySqlDatabase.cs
@@ -47,10 +47,7 @@ namespace CoreEx.Database.MySql
         /// <inheritdoc/>
         protected override Result? OnDbException(DbException dbex)
         {
-            if (!ThrowTransformedException)
-                return base.OnDbException(dbex);
-
-            if (dbex is MySqlException sex)
+            if (ThrowTransformedException && dbex is MySqlException sex)
             {
                 var msg = sex.Message?.TrimEnd();
                 if (string.IsNullOrEmpty(msg))

--- a/src/CoreEx.Database.SqlServer/Outbox/EventOutboxHostedService.cs
+++ b/src/CoreEx.Database.SqlServer/Outbox/EventOutboxHostedService.cs
@@ -18,7 +18,7 @@ namespace CoreEx.Database.SqlServer.Outbox
     public class EventOutboxHostedService : SynchronizedTimerHostedServiceBase<EventOutboxHostedService>
     {
         private TimeSpan? _interval;
-        private int? _maxQuerySize;
+        private int? _maxDequeueSize;
         private string? _name;
 
         /// <summary>
@@ -98,8 +98,8 @@ namespace CoreEx.Database.SqlServer.Outbox
         /// <remarks>Will default to <see cref="SettingsBase"/> configuration, a) <see cref="TimerHostedServiceBase.ServiceName"/> : <see cref="MaxDequeueSizeName"/>, then b) <see cref="MaxDequeueSizeName"/>, where specified; otherwise, 10.</remarks>
         public int MaxDequeueSize
         {
-            get => _maxQuerySize ?? Settings.GetValue<int?>($"{ServiceName}:{MaxDequeueSizeName}".Replace(".", "_")) ?? Settings.GetValue<int?>(MaxDequeueSizeName.Replace(".", "_")) ?? 10;
-            set => _maxQuerySize = value;
+            get => _maxDequeueSize ?? Settings.GetValue<int?>($"{ServiceName}:{MaxDequeueSizeName}".Replace(".", "_")) ?? Settings.GetValue<int?>(MaxDequeueSizeName.Replace(".", "_")) ?? 10;
+            set => _maxDequeueSize = value;
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace CoreEx.Database.SqlServer.Outbox
         protected override async Task SynchronizedExecuteAsync(IServiceProvider scopedServiceProvider, CancellationToken cancellationToken = default)
         {
             if (EventOutboxDequeueFactory == null)
-                throw new NotImplementedException($"The {nameof(EventOutboxDequeueFactory)} property must be configured to create an instance of the {nameof(EventOutboxDequeueBase)}.");
+                throw new InvalidOperationException($"The {nameof(EventOutboxDequeueFactory)} property must be configured to create an instance of the {nameof(EventOutboxDequeueBase)}.");
 
             try
             {

--- a/src/CoreEx.Database.SqlServer/Outbox/EventOutboxService.cs
+++ b/src/CoreEx.Database.SqlServer/Outbox/EventOutboxService.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Configuration;
+using CoreEx.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.Database.SqlServer.Outbox
+{
+    /// <summary>
+    /// Provides the <see cref="EventOutboxDequeueBase"/> dequeue and publish self-service capabilities.
+    /// </summary>
+    /// <remarks>This will instantiate an <see cref="EventOutboxDequeueBase"/> using the underlying <see cref="ServiceProvider"/> and invoke <see cref="EventOutboxDequeueBase.DequeueAndSendAsync(int, string?, string?, CancellationToken)"/>.</remarks>
+    public class EventOutboxService : ServiceBase
+    {
+        private string? _name;
+        private int? _maxIterations;
+        private int? _maxDequeueSize;
+
+        /// <summary>
+        /// Gets or sets the configuration name for <see cref="MaxDequeueSize"/>. Defaults to '<c>MaxDequeueSize</c>'.
+        /// </summary>
+        public string MaxDequeueSizeName { get; set; } = "MaxDequeueSize";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EventOutboxService"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+        /// <param name="logger">The <see cref="ILogger"/>.</param>
+        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
+        /// <param name="partitionKey">The optional partition key.</param>
+        /// <param name="destination">The optional destination name (i.e. queue or topic).</param>
+        public EventOutboxService(IServiceProvider serviceProvider, ILogger<EventOutboxService> logger, SettingsBase? settings = null, string? partitionKey = null, string? destination = null)
+            : base(serviceProvider, logger, settings)
+        {
+            PartitionKey = partitionKey;
+            Destination = destination;
+        }
+
+        /// <summary>
+        /// Gets the optional partition key.
+        /// </summary>
+        public string? PartitionKey { get; }
+
+        /// <summary>
+        /// Gets the optional destination name (i.e. queue or topic).
+        /// </summary>
+        public string? Destination { get; }
+
+        /// <summary>
+        /// Gets the service name (used for the likes of configuration and logging).
+        /// </summary>
+        public override string ServiceName => _name ??= $"{GetType().Name}{(PartitionKey == null ? "" : $".{PartitionKey}")}";
+
+        /// <inheritdoc/>
+        /// <remarks>Will default to <see cref="SettingsBase"/> configuration, a) <see cref="ServiceBase.ServiceName"/> : <see cref="ServiceBase.MaxIterationsName"/>, then b) <see cref="ServiceBase.MaxIterationsName"/>, where specified; otherwise, <see cref="ServiceBase.DefaultMaxIterations"/>.</remarks>
+        public override int MaxIterations
+        {
+            get => _maxIterations ?? Settings.GetValue<int?>($"{ServiceName}:{MaxIterationsName}".Replace(".", "_")) ?? Settings.GetValue<int?>(MaxIterationsName.Replace(".", "_")) ?? DefaultMaxIterations;
+            set => _maxIterations = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum dequeue size to limit the number of events that are dequeued within a single operation.
+        /// </summary>
+        /// <remarks>Will default to <see cref="SettingsBase"/> configuration, a) <see cref="ServiceBase.ServiceName"/> : <see cref="MaxDequeueSizeName"/>, then b) <see cref="MaxDequeueSizeName"/>, where specified; otherwise, 10.</remarks>
+        public int MaxDequeueSize
+        {
+            get => _maxDequeueSize ?? Settings.GetValue<int?>($"{ServiceName}:{MaxDequeueSizeName}".Replace(".", "_")) ?? Settings.GetValue<int?>(MaxDequeueSizeName.Replace(".", "_")) ?? 10;
+            set => _maxDequeueSize = value;
+        }
+
+        /// <summary>
+        /// Get or sets the function to create an instance of <see cref="EventOutboxDequeueBase"/>.
+        /// </summary>
+        public Func<IServiceProvider, EventOutboxDequeueBase>? EventOutboxDequeueFactory { get; set; }
+
+        /// <summary>
+        /// Executes the <see cref="EventOutboxDequeueFactory"/> instance to perform the <see cref="EventOutboxDequeueBase.DequeueAndSendAsync(int, string?, string?, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="scopedServiceProvider">The scoped <see cref="IServiceProvider"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns><c>true</c> indicates to execute the next iteration (i.e. continue); otherwise, <c>false</c> to stop.</returns>
+        protected override async Task<bool> ExecuteAsync(IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
+        {
+            if (EventOutboxDequeueFactory == null)
+                throw new InvalidOperationException($"The {nameof(EventOutboxDequeueFactory)} property must be configured to create an instance of the {nameof(EventOutboxDequeueBase)}.");
+
+            var eod = EventOutboxDequeueFactory(scopedServiceProvider) ?? throw new InvalidOperationException($"The {nameof(EventOutboxDequeueFactory)} function must return an instance of {nameof(EventOutboxDequeueBase)}.");
+            var sent = await eod.DequeueAndSendAsync(MaxDequeueSize, PartitionKey, Destination, cancellationToken).ConfigureAwait(false);
+            return sent > 0;
+        }
+    }
+}

--- a/src/CoreEx.Database.SqlServer/SqlServerDatabase.cs
+++ b/src/CoreEx.Database.SqlServer/SqlServerDatabase.cs
@@ -104,10 +104,7 @@ namespace CoreEx.Database.SqlServer
         /// <inheritdoc/>
         protected override Result? OnDbException(DbException dbex)
         {
-            if (!ThrowTransformedException)
-                return base.OnDbException(dbex);
-
-            if (dbex is SqlException sex)
+            if (ThrowTransformedException && dbex is SqlException sex)
             {
                 var msg = sex.Message?.TrimEnd();
                 if (string.IsNullOrEmpty(msg))

--- a/src/CoreEx.Database/Database.cs
+++ b/src/CoreEx.Database/Database.cs
@@ -139,7 +139,7 @@ namespace CoreEx.Database
         /// <remarks>Provides an opportunity to inspect and handle the exception before it is returned. A resulting <see cref="Result"/> that is <see cref="Result.IsSuccess"/> is not considered sensical; therefore, will result in the originating
         /// exception being thrown.
         /// <para>Where overridding and the <see cref="DbException"/> is not specifically handled then invoke the base to ensure any standard handling is executed.</para></remarks>
-        protected virtual Result? OnDbException(DbException dbex) => Result.Fail(dbex);
+        protected virtual Result? OnDbException(DbException dbex) => null;
 
         /// <inheritdoc/>
         public void Dispose()

--- a/src/CoreEx/Abstractions/Resource.cs
+++ b/src/CoreEx/Abstractions/Resource.cs
@@ -55,7 +55,7 @@ namespace CoreEx.Abstractions
         /// <param name="resourceName">The embedded resource name (matches to the end of the fully qualifed resource name).</param>
         /// <param name="assembly">The <see cref="Assembly"/> that contains the embedded resource; defaults to <see cref="Assembly.GetCallingAssembly"/>.</param>
         /// <returns>The <see cref="StreamReader"/>; otherwise, an <see cref="ArgumentException"/> will be thrown.</returns>
-        public static StreamReader GetStreamReader(string resourceName, Assembly? assembly = null) => new(GetStream(resourceName, assembly));
+        public static StreamReader GetStreamReader(string resourceName, Assembly? assembly = null) => new(GetStream(resourceName, assembly ?? Assembly.GetCallingAssembly()));
 
         /// <summary>
         /// Gets the named embedded resource <see cref="StreamReader"/> from the <see name="Assembly"/> inferred from the <typeparamref name="TResource"/> <see cref="Type"/>.

--- a/src/CoreEx/Hosting/ServiceBase.cs
+++ b/src/CoreEx/Hosting/ServiceBase.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.Hosting
+{
+    /// <summary>
+    /// Represents the base class for a self-orchestrated service to <see cref="ExecuteAsync(CancellationToken)"/> for a specified <see cref="MaxIterations"/>.
+    /// </summary>
+    public abstract class ServiceBase
+    {
+        private string? _name;
+        private int? _maxIterations;
+
+        /// <summary>
+        /// The configuration settings name for <see cref="MaxIterations"/>.
+        /// </summary>
+        public const string MaxIterationsName = nameof(MaxIterations);
+
+        /// <summary>
+        /// Gets or sets the default used where the specified <see cref="MaxIterations"/> is less than or equal to zero. Defaults to <b>one</b> iteration.
+        /// </summary>
+        public static int DefaultMaxIterations { get; set; } = 1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBase"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The <see cref="IServiceProvider"/>.</param>
+        /// <param name="logger">The <see cref="ILogger"/>.</param>
+        /// <param name="settings">The <see cref="SettingsBase"/>; defaults to instance from the <paramref name="serviceProvider"/> where not specified.</param>
+        public ServiceBase(IServiceProvider serviceProvider, ILogger logger, SettingsBase? settings = null)
+        {
+            ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            Settings = settings ?? ServiceProvider.GetService<SettingsBase>() ?? new DefaultSettings(ServiceProvider.GetRequiredService<IConfiguration>());
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IServiceProvider"/>.
+        /// </summary>
+        protected IServiceProvider ServiceProvider;
+
+        /// <summary>
+        /// Gets the <see cref="SettingsBase"/>.
+        /// </summary>
+        protected SettingsBase Settings { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ILogger"/>.
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        /// <summary>
+        /// Gets the service name (used for the likes of configuration and logging).
+        /// </summary>
+        /// <remarks>Defaults to the <see cref="Type"/> <see cref="MemberInfo.Name"/>.</remarks>
+        public virtual string ServiceName => _name ??= GetType().Name;
+
+        /// <summary>
+        /// Gets or sets the maximum number of iterations per execution.
+        /// </summary>
+        public virtual int MaxIterations
+        {
+            get => _maxIterations ?? DefaultMaxIterations;
+            set => _maxIterations = value <= 0 ? DefaultMaxIterations : value;
+        }
+
+        /// <summary>
+        /// <see cref="ExecuteAsync(IServiceProvider, CancellationToken)"/> up to the specified number of <see cref="MaxIterations"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <remarks>Each invocation of the <see cref="ExecuteAsync(IServiceProvider, CancellationToken)"/> will be managed within the context of a new Dependency Injection (DI) <see cref="ServiceProviderServiceExtensions.CreateScope">scope</see> that is passed for direct usage.</remarks>
+        public async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            for (int i = 0; i < MaxIterations; i++)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    return;
+
+                // Create a scope in which to perform the execution.
+                using var scope = ServiceProvider.CreateScope();
+                CoreEx.ExecutionContext.Reset();
+
+                try
+                {
+                    if (!await ExecuteAsync(scope.ServiceProvider, cancellationToken).ConfigureAwait(false))
+                        return;
+                }
+                catch (Exception ex)
+                {
+                    if (ex is TaskCanceledException || (ex is AggregateException aex && aex.InnerException is TaskCanceledException))
+                        return;
+
+                    Logger.LogCritical(ex, "{ServiceName} failure as a result of an unexpected exception: {Error}", ServiceName, ex.Message);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Invoked to perform the per-iteration work.
+        /// </summary>
+        /// <param name="scopedServiceProvider">The scoped <see cref="IServiceProvider"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns><c>true</c> indicates to execute the next iteration (i.e. continue); otherwise, <c>false</c> to stop.</returns>
+        /// <remarks>Each invocation of the <see cref="ExecuteAsync(IServiceProvider, CancellationToken)"/> will be managed within the context of a new Dependency Injection (DI) <see cref="ServiceProviderServiceExtensions.CreateScope">scope</see> that is passed for direct usage.</remarks>
+        protected abstract Task<bool> ExecuteAsync(IServiceProvider scopedServiceProvider, CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
- *Enhancement:* Added `Hosting.ServiceBase` class for a self-orchestrated service to execute for a specified `MaxIterations`; provides an alternative to using a `HostedService`. Useful for the likes of timer trigger Azure Functions for eample.
- *Enhancement:* Added `EventOutboxService` as an alternative to `EventOutboxHostedService`; related to (and leverages) above to achieve same outcome.
- *Fixed:* `Database.OnDbException` was incorrectly converting the unhandled exception to a `Result`; will now throw as expected.