### PR TITLE
v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.1.1
+- *Fixed:* The `DatabaseParameterCollection.AddParameter` now explicitly sets the `DbParameter.Value` to `DbNull.Value` where the value passed in is `null`.
+
 ## v3.1.0
 - *Enhancement:* Added `Hosting.ServiceBase` class for a self-orchestrated service to execute for a specified `MaxIterations`; provides an alternative to using a `HostedService`. Useful for the likes of timer trigger Azure Functions for eample.
 - *Enhancement:* Added `EventOutboxService` as an alternative to `EventOutboxHostedService`; related to (and leverages) above to achieve same outcome.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.1.0</Version>
+		<Version>3.1.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx.Database/DatabaseParameterCollection.cs
+++ b/src/CoreEx.Database/DatabaseParameterCollection.cs
@@ -55,7 +55,7 @@ namespace CoreEx.Database
         {
             var p = Database.Provider.CreateParameter() ?? throw new InvalidOperationException($"The {nameof(DbProviderFactory)}.{nameof(DbProviderFactory.CreateParameter)} returned a null.");
             p.ParameterName = ParameterizeName(name);
-            p.Value = value;
+            p.Value = value ?? DBNull.Value;
             p.Direction = direction;
 
             _parameters.Add(p);
@@ -75,7 +75,7 @@ namespace CoreEx.Database
             var p = Database.Provider.CreateParameter() ?? throw new InvalidOperationException($"The {nameof(DbProviderFactory)}.{nameof(DbProviderFactory.CreateParameter)} returned a null.");
             p.ParameterName = ParameterizeName(name);
             p.DbType = dbType;
-            p.Value = value;
+            p.Value = value ?? DBNull.Value;
             p.Direction = direction;
 
             _parameters.Add(p);


### PR DESCRIPTION
- *Fixed:* The `DatabaseParameterCollection.AddParameter` now explicitly sets the `DbParameter.Value` to `DbNull.Value` where the value passed in is `null`.