### PR TITLE
v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.3.1
+- *Fixed:* `ServiceBusSubscriber` was not correctly bubbling (not handling) exceptions where `UnhandledHandling` was set to `ErrorHandling.None`. Was incorrectly treating same as `ErrorHandling.ThrowSubscriberException` and automatically dead-lettering and continuing.
+
 ## v3.3.0
 - *Enhancement:* [Distributed tracing](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-instrumentation-walkthroughs#best-practices) has been added via the `InvokerBase` set of classes throughout `CoreEx` to ensure coverage and consistency of implementation. A new `InvokeArgs` has been added to house the [`ActivitySource`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource) instance; this also provides for further extension opportunities limiting future potential breaking changes.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.3.0</Version>
+		<Version>3.3.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriberInvoker.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriberInvoker.cs
@@ -147,6 +147,10 @@ namespace CoreEx.Azure.ServiceBus
                 return true; // Keep throwing; i.e. bubble exception.
             }
 
+            // Where the unhandled handling is set to None then keep bubbling; do not dead-letter.
+            if (invoker.UnhandledHandling == Events.Subscribing.ErrorHandling.None)
+                return true; 
+
             // Dead-letter the unhandled exception.
             await DeadLetterExceptionAsync(invoker, message, messageActions, ErrorType.UnhandledError.ToString(), exception, cancellationToken).ConfigureAwait(false);
             return false;


### PR DESCRIPTION
- *Fixed:* `ServiceBusSubscriber` was not correctly bubbling (not handling) exceptions where `UnhandledHandling` was set to `ErrorHandling.None`. Was incorrectly treating same as `ErrorHandling.ThrowSubscriberException` and automatically dead-lettering and continuing.