### PR TITLE
v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v3.4.1
+- *Fixed:* The `IEfDb.With` fixed (as extension methods) to also support the `with` value being passed into the corresponding `Action<T>` to simplify usage (only a subset of common intrinsic types supported, both nullable and non-nullable overloads).
+- *Fixed:* Missing `Result.CacheSet` and `Result.CacheRemove` extension methods added to `CoreEx.Results` to fully enable `IRequestCaching` in addition to existing `Result.CacheGetOrAddAsync`.
+
 ## v3.4.0
 - *Enhancement:* Added `IEventSubscriberInstrumentation` (and related `EventSubscriberInstrumentationBase`) to enable `EventSubscriberBase.Instrumentation` monitoring of the subscriber as applicable.
 - *Enhancement:* Previous `EventSubscriberInvoker` exception/error handling moved into individual subscribers for greater control; a new `ErrorHandler` added to encapsulate the consistent handling of the underlying exceptions/errors. This was internal and should have no impact.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.4.0</Version>
+		<Version>3.4.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx.EntityFrameworkCore/EfDb.cs
+++ b/src/CoreEx.EntityFrameworkCore/EfDb.cs
@@ -243,7 +243,7 @@ namespace CoreEx.EntityFrameworkCore
         /// <inheritdoc/>
         public void With<T>(T with, Action action)
         {
-            if (Comparer<T>.Default.Compare(with, default!) != 0 && Comparer<T>.Default.Compare(with, default!) != 0)
+            if (with is not null && Comparer<T>.Default.Compare(with, default!) != 0)
             {
                 if (with is not string && with is System.Collections.IEnumerable ie && !ie.GetEnumerator().MoveNext())
                     return;

--- a/src/CoreEx.EntityFrameworkCore/EfDbExtensions.cs
+++ b/src/CoreEx.EntityFrameworkCore/EfDbExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using CoreEx.Entities;
+using CoreEx.RefData;
 using CoreEx.Results;
 
 namespace CoreEx.EntityFrameworkCore
@@ -232,6 +233,196 @@ namespace CoreEx.EntityFrameworkCore
         /// <remarks>Where the model implements <see cref="ILogicallyDeleted"/> then this will update the <see cref="ILogicallyDeleted.IsDeleted"/> with <c>true</c> versus perform a physical deletion.</remarks>
         public static Task<Result> DeleteWithResultAsync<T, TModel>(this IEfDb efDb, CompositeKey key, CancellationToken cancellationToken = default) where T : class, IEntityKey where TModel : class, new()
             => efDb.DeleteWithResultAsync<T, TModel>(new EfDbArgs(efDb.DbArgs), key, cancellationToken);
+
+        #endregion
+
+        #region With
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, string? with, Action<string> action) => efDb.With(with, () => action(with!));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, int? with, Action<int> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, int with, Action<int> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, short? with, Action<short> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, short with, Action<short> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, long? with, Action<long> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, long with, Action<long> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, decimal? with, Action<decimal> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, decimal with, Action<decimal> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, float? with, Action<float> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, float with, Action<float> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, double? with, Action<double> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, double with, Action<double> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, DateTime? with, Action<DateTime> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, DateTime with, Action<DateTime> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, TimeSpan? with, Action<TimeSpan> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, TimeSpan with, Action<TimeSpan> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, bool? with, Action<bool> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, bool with, Action<bool> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, char? with, Action<char> action) => efDb.With(with, () => action(with!.Value));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>default</c>.
+        /// </summary>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With(this IEfDb efDb, char with, Action<char> action) => efDb.With(with, () => action(with));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TRef">The <see cref="IReferenceData"/> <see cref="Type"/>.</typeparam>
+        /// <param name="efDb"></param>
+        /// <param name="with"></param>
+        /// <param name="action"></param>
+        public static void With<TRef>(this IEfDb efDb, TRef? with, Action<TRef> action) where TRef : IReferenceData => efDb.With(with, () => action(with!));
+
+        /// <summary>
+        /// Invokes the <paramref name="action"/> when the <paramref name="with"/> is not <c>null</c>.
+        /// </summary>
+        /// <typeparam name="TRef">The <see cref="IReferenceData"/> <see cref="Type"/>.</typeparam>
+        /// <param name="efDb">The <see cref="IEfDb"/>.</param>
+        /// <param name="with">The value with which to verify.</param>
+        /// <param name="action">The <see cref="Action"/> to invoke when there is a valid <paramref name="with"/> value.</param>
+        public static void With<TRef>(this IEfDb efDb, ReferenceDataCodeList<TRef>? with, Action<ReferenceDataCodeList<TRef>> action) where TRef : class, IReferenceData, new() => efDb.With(with, () => action(with!));
 
         #endregion
     }

--- a/src/CoreEx/Caching/README.md
+++ b/src/CoreEx/Caching/README.md
@@ -13,5 +13,3 @@ To provide additional capabilities to cache data to improve runtime performance.
 ## Request cache
 
 The [`IRequestCache`](./IRequestCache.cs) interface and corresponding [`RequestCache`](./RequestCache.cs) implementation are intended to provide generic short-lived request caching; for example, to reduce data chattiness within the context of a request scope.
-
-

--- a/src/CoreEx/Caching/ResultExtensions.cs
+++ b/src/CoreEx/Caching/ResultExtensions.cs
@@ -17,11 +17,11 @@ namespace CoreEx.Caching
         /// </summary>
         /// <typeparam name="T">The <see cref="Result{T}"/> <see cref="Type"/>.</typeparam>
         /// <param name="result">The <see cref="Result"/>.</param>
-        /// <param name="cache">The <see cref="IRequestCache"/></param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
         /// <param name="key">The key of the value to get or add.</param>
         /// <param name="addFactory">The factory function to create the <see cref="Result{T}"/>.</param>
         /// <returns>The resulting <see cref="Result{T}"/>.</returns>
-        /// <remarks>The caching is only performed where the corresponding results are all <see cref="IResult.IsSuccess"/>.</remarks>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
         public static Task<Result<T>> CacheGetOrAddAsync<T>(this Result result, IRequestCache cache, object? key, Func<Task<Result<T>>> addFactory)
             => CacheGetOrAddAsync(result, cache, new CompositeKey(key), addFactory);
 
@@ -30,11 +30,11 @@ namespace CoreEx.Caching
         /// </summary>
         /// <typeparam name="T">The <see cref="Result{T}"/> <see cref="Type"/>.</typeparam>
         /// <param name="result">The <see cref="Result"/>.</param>
-        /// <param name="cache">The <see cref="IRequestCache"/></param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
         /// <param name="key">The key of the value to get or add.</param>
         /// <param name="addFactory">The factory function to create the <see cref="Result{T}"/>.</param>
         /// <returns>The resulting <see cref="Result{T}"/>.</returns>
-        /// <remarks>The caching is only performed where the corresponding results are all <see cref="IResult.IsSuccess"/>.</remarks>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
         public static Task<Result<T>> CacheGetOrAddAsync<T>(this Result result, IRequestCache cache, CompositeKey key, Func<Task<Result<T>>> addFactory)
             => Task.FromResult(result).CacheGetOrAddAsync(cache, key, addFactory);
 
@@ -43,11 +43,11 @@ namespace CoreEx.Caching
         /// </summary>
         /// <typeparam name="T">The <see cref="Result{T}"/> <see cref="Type"/>.</typeparam>
         /// <param name="result">The <see cref="Result"/>.</param>
-        /// <param name="cache">The <see cref="IRequestCache"/></param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
         /// <param name="key">The key of the value to get or add.</param>
         /// <param name="addFactory">The factory function to create the <see cref="Result{T}"/>.</param>
         /// <returns>The resulting <see cref="Result{T}"/>.</returns>
-        /// <remarks>The caching is only performed where the corresponding results are all <see cref="IResult.IsSuccess"/>.</remarks>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
         public static Task<Result<T>> CacheGetOrAddAsync<T>(this Task<Result> result, IRequestCache cache, object? key, Func<Task<Result<T>>> addFactory)
             => CacheGetOrAddAsync(result, cache, new CompositeKey(key), addFactory);
 
@@ -56,11 +56,11 @@ namespace CoreEx.Caching
         /// </summary>
         /// <typeparam name="T">The <see cref="Result{T}"/> <see cref="Type"/>.</typeparam>
         /// <param name="result">The <see cref="Result"/>.</param>
-        /// <param name="cache">The <see cref="IRequestCache"/></param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
         /// <param name="key">The key of the value to get or add.</param>
         /// <param name="addFactory">The factory function to create the <see cref="Result{T}"/>.</param>
         /// <returns>The resulting <see cref="Result{T}"/>.</returns>
-        /// <remarks>The caching is only performed where the corresponding results are all <see cref="IResult.IsSuccess"/>.</remarks>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
         public static async Task<Result<T>> CacheGetOrAddAsync<T>(this Task<Result> result, IRequestCache cache, CompositeKey key, Func<Task<Result<T>>> addFactory)
         {
             if (cache == null) throw new ArgumentNullException(nameof(cache));
@@ -79,6 +79,152 @@ namespace CoreEx.Caching
                     return Result.Ok(v);
                 });
             });
+        }
+
+        /// <summary>
+        /// Sets (caches) the <see cref="Result{T}.Value"/> into the supplied <paramref name="cache"/> (using the underlying <see cref="IEntityKey.EntityKey"/>).
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Result{T}"/> <see cref="Type"/> which must be an <see cref="IEntityKey"/>.</typeparam>
+        /// <param name="result">The <see cref="Result{T}"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <returns>The resulting <see cref="Result{T}"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Result<T> CacheSet<T>(this Result<T> result, IRequestCache cache) where T : IEntityKey
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(r => { cache.SetValue(r); });
+        }
+
+        /// <summary>
+        /// Sets (caches) the <see cref="Result{T}.Value"/> into the supplied <paramref name="cache"/> using the specified <paramref name="key"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Result{T}"/> <see cref="Type"/>.</typeparam>
+        /// <param name="result">The <see cref="Result{T}"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <param name="key">The key of the value to set.</param>
+        /// <returns>The resulting <see cref="Result{T}"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Result<T> CacheSet<T>(this Result<T> result, IRequestCache cache, CompositeKey key)
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(r => { cache.SetValue(key, r); });
+        }
+
+        /// <summary>
+        /// Sets (caches) the <see cref="Result{T}.Value"/> into the supplied <paramref name="cache"/> (using the underlying <see cref="IEntityKey.EntityKey"/>).
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Result{T}"/> <see cref="Type"/> which must be an <see cref="IEntityKey"/>.</typeparam>
+        /// <param name="result">The <see cref="Result{T}"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <returns>The resulting <see cref="Result{T}"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Task<Result<T>> CacheSet<T>(this Task<Result<T>> result, IRequestCache cache) where T : IEntityKey
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(r => { cache.SetValue(r); });
+        }
+
+        /// <summary>
+        /// Sets (caches) the <see cref="Result{T}.Value"/> into the supplied <paramref name="cache"/> using the specified <paramref name="key"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Result{T}"/> <see cref="Type"/>.</typeparam>
+        /// <param name="result">The <see cref="Result{T}"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <param name="key">The key of the value to set.</param>
+        /// <returns>The resulting <see cref="Result{T}"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Task<Result<T>> CacheSet<T>(this Task<Result<T>> result, IRequestCache cache, CompositeKey key)
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(r => { cache.SetValue(key, r); });
+        }
+
+        /// <summary>
+        /// Removes the cached value associated with the specified <see cref="Type"/> and <paramref name="key"/>.
+        /// </summary>
+        /// <typeparam name="T">The cached value <see cref="Type"/>.</typeparam>
+        /// <param name="result">The <see cref="Result"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <param name="key">The key of the value to remove.</param>
+        /// <returns>The resulting <see cref="Result"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Result CacheRemove<T>(this Result result, IRequestCache cache, CompositeKey key)
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(() => { cache.Remove<T>(key); });
+        }
+
+        /// <summary>
+        /// Removes the cached value associated with the specified <see cref="Type"/> and <paramref name="key"/>.
+        /// </summary>
+        /// <typeparam name="T">The cached value <see cref="Type"/>.</typeparam>
+        /// <param name="result">The <see cref="Result"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <param name="key">The key of the value to remove.</param>
+        /// <returns>The resulting <see cref="Result"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Result CacheRemove<T>(this Result result, IRequestCache cache, object? key)
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(() => { cache.Remove<T>(key); });
+        }
+
+        /// <summary>
+        /// Removes the cached value associated with the specified <see cref="Type"/> (using the underlying <see cref="IEntityKey.EntityKey"/>).
+        /// </summary>
+        /// <typeparam name="T">The cached value <see cref="Type"/>.</typeparam>
+        /// <param name="result">The <see cref="Result{T}"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <returns>The resulting <see cref="Result{T}"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Result<T> CacheRemove<T>(this Result<T> result, IRequestCache cache) where T : IEntityKey
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(r => { cache.Remove<T>(r is null ? CompositeKey.Empty : r.EntityKey); });
+        }
+
+        /// <summary>
+        /// Removes the cached value associated with the specified <see cref="Type"/> and <paramref name="key"/>.
+        /// </summary>
+        /// <typeparam name="T">The cached value <see cref="Type"/>.</typeparam>
+        /// <param name="result">The <see cref="Result"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <param name="key">The key of the value to remove.</param>
+        /// <returns>The resulting <see cref="Result"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Task<Result> CacheRemove<T>(this Task<Result> result, IRequestCache cache, CompositeKey key)
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(() => { cache.Remove<T>(key); });
+        }
+
+        /// <summary>
+        /// Removes the cached value associated with the specified <see cref="Type"/> and <paramref name="key"/>.
+        /// </summary>
+        /// <typeparam name="T">The cached value <see cref="Type"/>.</typeparam>
+        /// <param name="result">The <see cref="Result"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <param name="key">The key of the value to remove.</param>
+        /// <returns>The resulting <see cref="Result"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Task<Result> CacheRemove<T>(this Task<Result> result, IRequestCache cache, object? key)
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(() => { cache.Remove<T>(key); });
+        }
+
+        /// <summary>
+        /// Removes the cached value associated with the specified <see cref="Type"/> (using the underlying <see cref="IEntityKey.EntityKey"/>).
+        /// </summary>
+        /// <typeparam name="T">The cached value <see cref="Type"/>.</typeparam>
+        /// <param name="result">The <see cref="Result{T}"/>.</param>
+        /// <param name="cache">The <see cref="IRequestCache"/>.</param>
+        /// <returns>The resulting <see cref="Result{T}"/>.</returns>
+        /// <remarks>The caching is only performed where the corresponding <paramref name="result"/> has <see cref="IResult.IsSuccess"/>.</remarks>
+        public static Task<Result<T>> CacheRemove<T>(this Task<Result<T>> result, IRequestCache cache) where T : IEntityKey
+        {
+            if (cache == null) throw new ArgumentNullException(nameof(cache));
+            return result.Then(r => { cache.Remove<T>(r is null ? CompositeKey.Empty : r.EntityKey); });
         }
     }
 }

--- a/src/CoreEx/Results/README.md
+++ b/src/CoreEx/Results/README.md
@@ -80,6 +80,7 @@ Method | Description
 `AuthorizationError()` | Creates a failure result with the [`AuthorizationException`](../AuthorizationException.cs).
 `ConcurrencyError()` | Creates a failure result with the [`ConcurrencyException`](../ConcurrencyException.cs).
 `ConflictError()` | Creates a failure result with the [`ConflictException`](../ConflictException.cs).
+`DataConsistencyError` | Creates a failure result with the [`DataConsistencyException`](../DataConsistencyException.cs).
 `DuplicateError()` | Creates a failure result with the [`DuplicateException`](../DuplicateException.cs).
 `NotFoundError()` | Creates a failure result with the [`NotFoundException`](../NotFoundException.cs).
 `TransientError()` | Creates a failure result with the [`TransientException`](../TransientException.cs).
@@ -123,11 +124,11 @@ Method | Description
 [`Any()`](./AnyExtensions.cs), `AnyAsync()`, `AnyAs()`, `AnyAsAsync()` | Executes the specified function regardless of the result state.
 [`AsResult()`](./ResultsExtensions.cs), `AsResultAsync()` | Converts (binds) the `Result<T>` to a `Result` (i.e. loses the `Value`); or a `Result<T>` to a `Result<U>`.
 
-By convention methods that are named with the following have the following characteristics.
+By convention the methods above that are named with the following have the described characteristics.
 
 Convention | Description
 -|-
-`As` | Supports _explicit_ conversion between types to minimize unintentional data loss and/or unexpected side-effects.
+`As` | Supports _explicit_ [as-based](#as-based-conversion) conversion between types to minimize unintentional data loss and/or unexpected side-effects.
 `Async` | Supports asynchronous execution (versus synchronous). Note that all internal asynchronous executions are invoked with a [`ConfigureAwait(false)`](https://devblogs.microsoft.com/dotnet/configureawait-faq/#what-does-configureawaitfalse-do).
 `From` | Supports [`IToResult`](./IToResult.cs), [`IToResult<T>`](./IToResultT.cs) and [`ITypedToResult`](./ITypedToResult.cs) result conversion.
 


### PR DESCRIPTION
- *Fixed:* The `IEfDb.With` fixed (as extension methods) to also support the `with` value being passed into the corresponding `Action<T>` to simplify usage (only a subset of common intrinsic types supported, both nullable and non-nullable overloads).
- *Fixed:* Missing `Result.CacheSet` and `Result.CacheRemove` extension methods added to `CoreEx.Results` to fully enable `IRequestCaching` in addition to existing `Result.CacheGetOrAddAsync`.