### PR TITLE
v3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v3.8.0
+- *Enhancement*: The `ValueContentResult.CreateResult` has been updated to return the resulting value as-is where is an instance of `IActionResult`; otherwise, converts `value` to a `ValueContentResult` (previous behavior).
+- *Enhancement*: The `PagingArgs` has been extended to support `Token`; being a continuation token to enable paging to be performed where the underlying data source does not support skip/take-style paging.
+
 ## v3.7.2
 - *Fixed*: The `ReferenceDataMultiCollection` and `ReferenceDataMultiItem` have been replaced with the `ReferenceDataMultiDictionary` as existing resulted in an unintended format with which to return the data. This fix also removed the need for the `ReferenceDataMultiCollectionConverterFactory` as custom serialization for this is no longer required.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.7.2</Version>
+		<Version>3.8.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0-beta.5" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/My.Hr/My.Hr.Api/Startup.cs
+++ b/samples/My.Hr/My.Hr.Api/Startup.cs
@@ -62,7 +62,7 @@ public class Startup
         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
         {
             services.AddOpenTelemetry().UseAzureMonitor();
-            services.Configure<AspNetCoreInstrumentationOptions>(options => options.RecordException = true);
+            //services.Configure<AspNetCoreInstrumentationOptions>(options => options.RecordException = true);
             services.ConfigureOpenTelemetryTracerProvider((sp, builder) => builder.AddSource("CoreEx.*"));
         }
 
@@ -73,7 +73,7 @@ public class Startup
             var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
             options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
             options.OperationFilter<AcceptsBodyOperationFilter>();  // Needed to support AcceptsBodyAttribue where body parameter not explicitly defined.
-            options.OperationFilter<PagingOperationFilter>(PagingOperationFilterFields.PageSizeCount);  // Needed to support PagingAttribue where PagingArgs parameter not explicitly defined.
+            options.OperationFilter<PagingOperationFilter>(PagingOperationFilterFields.TokenTake);  // Needed to support PagingAttribue where PagingArgs parameter not explicitly defined.
         });
     }
 

--- a/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
+++ b/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.3.12" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.3.14" />
     <PackageReference Include="Microsoft.Tye.Extensions.Configuration" Version="0.10.0-alpha.21420.1" />
   </ItemGroup>
 

--- a/samples/My.Hr/My.Hr.Functions/My.Hr.Functions.csproj
+++ b/samples/My.Hr/My.Hr.Functions/My.Hr.Functions.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.5.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
+++ b/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/src/CoreEx.AspNetCore/Http/HttpResultExtensions.cs
+++ b/src/CoreEx.AspNetCore/Http/HttpResultExtensions.cs
@@ -150,15 +150,22 @@ namespace CoreEx.AspNetCore.Http
             if (paging == null)
                 return;
 
-            if (paging.IsSkipTake)
+            switch (paging.Option)
             {
-                headers[HttpConsts.PagingSkipHeaderName] = paging.Skip.ToString(CultureInfo.InvariantCulture);
-                headers[HttpConsts.PagingTakeHeaderName] = paging.Take.ToString(CultureInfo.InvariantCulture);
-            }
-            else
-            {
-                headers[HttpConsts.PagingPageNumberHeaderName] = paging.Page!.Value.ToString(CultureInfo.InvariantCulture);
-                headers[HttpConsts.PagingPageSizeHeaderName] = paging.Take.ToString(CultureInfo.InvariantCulture);
+                case PagingOption.SkipAndTake:
+                    headers[HttpConsts.PagingSkipHeaderName] = paging.Skip!.Value.ToString(CultureInfo.InvariantCulture);
+                    headers[HttpConsts.PagingTakeHeaderName] = paging.Take.ToString(CultureInfo.InvariantCulture);
+                    break;
+
+                case PagingOption.PageAndSize:
+                    headers[HttpConsts.PagingPageNumberHeaderName] = paging.Page!.Value.ToString(CultureInfo.InvariantCulture);
+                    headers[HttpConsts.PagingPageSizeHeaderName] = paging.Take.ToString(CultureInfo.InvariantCulture);
+                    break;
+
+                default:
+                    headers[HttpConsts.PagingTokenHeaderName] = paging.Token;
+                    headers[HttpConsts.PagingTakeHeaderName] = paging.Take.ToString(CultureInfo.InvariantCulture);
+                    break;
             }
 
             if (paging.TotalCount.HasValue)

--- a/src/CoreEx.AspNetCore/WebApis/PagingOperationFilter.cs
+++ b/src/CoreEx.AspNetCore/WebApis/PagingOperationFilter.cs
@@ -48,11 +48,14 @@ namespace CoreEx.AspNetCore.WebApis
             if (Fields.HasFlag(PagingOperationFilterFields.Skip))
                 operation.Parameters.Add(CreateParameter(HttpConsts.PagingArgsSkipQueryStringName, "The specified number of elements in a sequence to bypass.", "number"));
 
-            if (Fields.HasFlag(PagingOperationFilterFields.Take))
-                operation.Parameters.Add(CreateParameter(HttpConsts.PagingArgsTakeQueryStringName, "The specified number of contiguous elements from the start of a sequence.", "number"));
-
             if (Fields.HasFlag(PagingOperationFilterFields.Page))
                 operation.Parameters.Add(CreateParameter(HttpConsts.PagingArgsPageQueryStringName, "The page number for the elements in a sequence to select.", "number"));
+
+            if (Fields.HasFlag(PagingOperationFilterFields.Token))
+                operation.Parameters.Add(CreateParameter(HttpConsts.PagingArgsTokenQueryStringName, "The token to get the next page of elements.", "string"));
+
+            if (Fields.HasFlag(PagingOperationFilterFields.Take))
+                operation.Parameters.Add(CreateParameter(HttpConsts.PagingArgsTakeQueryStringName, "The specified number of contiguous elements from the start of a sequence.", "number"));
 
             if (Fields.HasFlag(PagingOperationFilterFields.Size))
                 operation.Parameters.Add(CreateParameter(HttpConsts.PagingArgsSizeQueryStringName, "The page size being the specified number of contiguous elements from the start of a sequence.", "number"));

--- a/src/CoreEx.AspNetCore/WebApis/PagingOperationFilterFields.cs
+++ b/src/CoreEx.AspNetCore/WebApis/PagingOperationFilterFields.cs
@@ -38,6 +38,11 @@ namespace CoreEx.AspNetCore.WebApis
         Count = 16,
 
         /// <summary>
+        /// Indicates to include <see cref="PagingArgs.Token"/> field (named <see cref="HttpConsts.PagingArgsTokenQueryStringName"/>).
+        /// </summary>
+        Token = 32,
+
+        /// <summary>
         /// Indicates to include <see cref="Skip"/> and <see cref="Take"/> fields.
         /// </summary>
         SkipTake = Skip | Take,
@@ -58,8 +63,18 @@ namespace CoreEx.AspNetCore.WebApis
         PageSizeCount = Page | Size | Count,
 
         /// <summary>
+        /// Indicates to include <see cref="Token"/> and <see cref="Take"/> fields.
+        /// </summary>
+        TokenTake = Token | Take,
+
+        /// <summary>
+        /// Indicates to include <see cref="Token"/>, <see cref="Take"/> and <see cref="Count"/> fields.
+        /// </summary>
+        TokenTakeCount = Token | Size | Count,
+
+        /// <summary>
         /// Indicates to include all fields.
         /// </summary>
-        All = Skip | Take | Page | Size | Count
+        All = Skip | Take | Page | Size | Count | Token
     }
 }

--- a/src/CoreEx.AspNetCore/WebApis/WebApi.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApi.cs
@@ -21,24 +21,18 @@ namespace CoreEx.AspNetCore.WebApis
     /// <summary>
     /// Provides the core (<see cref="HttpMethods.Get"/>, <see cref="HttpMethods.Post"/>, <see cref="HttpMethods.Put"/> and <see cref="HttpMethods.Delete"/>) Web API execution encapsulation.
     /// </summary>
-    public partial class WebApi : WebApiBase
+    /// <param name="executionContext">The <see cref="ExecutionContext"/>.</param>
+    /// <param name="settings">The <see cref="SettingsBase"/>.</param>
+    /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
+    /// <param name="logger">The <see cref="ILogger"/>.</param>
+    /// <param name="invoker">The <see cref="WebApiInvoker"/>; defaults where not specified.</param>
+    /// <param name="jsonMergePatch">The <see cref="IJsonMergePatch"/> to support the <see cref="HttpMethods.Patch"/> operations.</param>
+    public partial class WebApi(ExecutionContext executionContext, SettingsBase settings, IJsonSerializer jsonSerializer, ILogger<WebApi> logger, WebApiInvoker? invoker = null, IJsonMergePatch? jsonMergePatch = null) : WebApiBase(executionContext, settings, jsonSerializer, logger, invoker)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WebApi"/> class.
-        /// </summary>
-        /// <param name="executionContext">The <see cref="ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        /// <param name="invoker">The <see cref="WebApiInvoker"/>; defaults where not specified.</param>
-        /// <param name="jsonMergePatch">The <see cref="IJsonMergePatch"/> to support the <see cref="HttpMethods.Patch"/> operations.</param>
-        public WebApi(ExecutionContext executionContext, SettingsBase settings, IJsonSerializer jsonSerializer, ILogger<WebApi> logger, WebApiInvoker? invoker = null, IJsonMergePatch? jsonMergePatch = null)
-            : base(executionContext, settings, jsonSerializer, logger, invoker) => JsonMergePatch = jsonMergePatch;
-
         /// <summary>
         /// Gets the <see cref="IJsonMergePatch"/>.
         /// </summary>
-        public IJsonMergePatch? JsonMergePatch { get; }
+        public IJsonMergePatch? JsonMergePatch { get; } = jsonMergePatch;
 
         /// <summary>
         /// Indicates whether to convert a <see cref="NotFoundException"/> to the default <see cref="HttpStatusCode"/> on delete (see <see cref="DeleteAsync(HttpRequest, Func{WebApiParam, CancellationToken, Task}, HttpStatusCode, OperationType, CancellationToken)"/>.

--- a/src/CoreEx.AspNetCore/WebApis/WebApiRequestOptions.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiRequestOptions.cs
@@ -109,16 +109,19 @@ namespace CoreEx.AspNetCore.WebApis
             long? skip = HttpExtensions.ParseLongValue(GetNamedQueryString(query, HttpConsts.PagingArgsSkipQueryStringNames));
             long? take = HttpExtensions.ParseLongValue(GetNamedQueryString(query, HttpConsts.PagingArgsTakeQueryStringNames));
             long? page = skip.HasValue ? null : HttpExtensions.ParseLongValue(GetNamedQueryString(query, HttpConsts.PagingArgsPageQueryStringNames));
+            string? token = GetNamedQueryString(query, HttpConsts.PagingArgsTokenQueryStringNames);
             bool isGetCount = HttpExtensions.ParseBoolValue(GetNamedQueryString(query, HttpConsts.PagingArgsCountQueryStringNames));
 
-            if (skip == null && take == null && page == null && !isGetCount)
+            if (skip == null && take == null && page == null && string.IsNullOrEmpty(token) && !isGetCount)
                 return null;
 
             PagingArgs paging;
-            if (skip == null && page == null)
-                paging = (take.HasValue) ? PagingArgs.CreateSkipAndTake(0, take) : new PagingArgs();
+            if (!string.IsNullOrEmpty(token))
+                paging = PagingArgs.CreateTokenAndTake(token, take);
+            else if (skip == null && page == null)
+                paging = take.HasValue ? PagingArgs.CreateSkipAndTake(0, take) : new PagingArgs();
             else
-                paging = (skip.HasValue) ? PagingArgs.CreateSkipAndTake(skip.Value, take) : PagingArgs.CreatePageAndSize(page == null ? 0 : page.Value, take);
+                paging = skip.HasValue ? PagingArgs.CreateSkipAndTake(skip.Value, take) : PagingArgs.CreatePageAndSize(page == null ? 0 : page.Value, take);
 
             paging.IsGetCount = isGetCount;
             return paging;

--- a/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
+++ b/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.7" />
   </ItemGroup>
 

--- a/src/CoreEx.FluentValidation/CoreEx.FluentValidation.csproj
+++ b/src/CoreEx.FluentValidation/CoreEx.FluentValidation.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.8.1" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.OData/ODataQuery.cs
+++ b/src/CoreEx.OData/ODataQuery.cs
@@ -254,7 +254,10 @@ namespace CoreEx.OData
 
                 if (paging is not null)
                 {
-                    q = q.Skip(paging.Skip).Top(paging.Take);
+                    if (paging.Option == PagingOption.TokenAndTake)
+                        throw new InvalidOperationException("PagingOption.TokenAndTake is not supported for OData.");
+
+                    q = q.Skip(paging.Skip!.Value).Top(paging.Take);
                     if (paging.IsGetCount && args.IsPagingGetCountSupported)
                         ann = new Soc.ODataFeedAnnotations();
                 }

--- a/src/CoreEx.Solace/CoreEx.Solace.csproj
+++ b/src/CoreEx.Solace/CoreEx.Solace.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SolaceSystems.Solclient.Messaging" Version="10.22.0" />
+    <PackageReference Include="SolaceSystems.Solclient.Messaging" Version="10.23.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
+++ b/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.0.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
+++ b/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
@@ -18,7 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx" Version="4.0.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="UnitTestEx" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreEx.UnitTesting/Json/ToCoreExJsonSerializerMapper.cs
+++ b/src/CoreEx.UnitTesting/Json/ToCoreExJsonSerializerMapper.cs
@@ -11,15 +11,10 @@ namespace UnitTestEx.Json
     /// Provides a wrapper for <see cref="IJsonSerializer"/> to <see cref="CoreEx.Json.IJsonSerializer"/>.
     /// </summary>
     /// <remarks>Only the compatible capabilities have been implemented.</remarks>
-    public class ToCoreExJsonSerializerMapper : CoreEx.Json.IJsonSerializer
+    /// <param name="testJsonSerializer">The <see cref="IJsonSerializer"/>.</param>
+    public class ToCoreExJsonSerializerMapper(IJsonSerializer testJsonSerializer) : CoreEx.Json.IJsonSerializer
     {
-        private readonly IJsonSerializer _testJsonSerializer;
-
-        /// <summary>
-        /// Initializes a new <see cref="ToCoreExJsonSerializerMapper"/> instance.
-        /// </summary>
-        /// <param name="testJsonSerializer">The <see cref="UnitTestEx.Json.IJsonSerializer"/>.</param>
-        public ToCoreExJsonSerializerMapper(IJsonSerializer testJsonSerializer) => _testJsonSerializer = testJsonSerializer ?? throw new ArgumentNullException(nameof(testJsonSerializer));
+        private readonly IJsonSerializer _testJsonSerializer = testJsonSerializer ?? throw new ArgumentNullException(nameof(testJsonSerializer));
 
         /// <inheritdoc/>
         public object Options => _testJsonSerializer.Options;

--- a/src/CoreEx.UnitTesting/Json/ToUnitTestExJsonSerializerMapper.cs
+++ b/src/CoreEx.UnitTesting/Json/ToUnitTestExJsonSerializerMapper.cs
@@ -11,15 +11,10 @@ namespace UnitTestEx.Json
     /// Provides a wrapper for <see cref="CoreEx.Json.IJsonSerializer"/> to <see cref="IJsonSerializer"/>.
     /// </summary>
     /// <remarks>Only the compatible capabilities have been implemented.</remarks>
-    public class ToUnitTestExJsonSerializerMapper : IJsonSerializer, CoreEx.Json.IJsonSerializer
+    /// <param name="coreJsonSerializer">The <see cref="CoreEx.Json.IJsonSerializer"/>.</param>
+    public class ToUnitTestExJsonSerializerMapper(CoreEx.Json.IJsonSerializer coreJsonSerializer) : IJsonSerializer, CoreEx.Json.IJsonSerializer
     {
-        private readonly CoreEx.Json.IJsonSerializer _coreJsonSerializer;
-
-        /// <summary>
-        /// Initializes a new <see cref="ToUnitTestExJsonSerializerMapper"/> instance.
-        /// </summary>
-        /// <param name="coreJsonSerializer">The <see cref="CoreEx.Json.IJsonSerializer"/>.</param>
-        public ToUnitTestExJsonSerializerMapper(CoreEx.Json.IJsonSerializer coreJsonSerializer) => _coreJsonSerializer = coreJsonSerializer ?? throw new ArgumentNullException(nameof(coreJsonSerializer));
+        private readonly CoreEx.Json.IJsonSerializer _coreJsonSerializer = coreJsonSerializer ?? throw new ArgumentNullException(nameof(coreJsonSerializer));
 
         /// <inheritdoc/>
         public object Options => _coreJsonSerializer.Options;

--- a/src/CoreEx/Abstractions/IQueryableExtensions.cs
+++ b/src/CoreEx/Abstractions/IQueryableExtensions.cs
@@ -19,7 +19,16 @@ namespace System.Linq
         /// <param name="query">The query.</param>
         /// <param name="paging">The <see cref="PagingArgs"/>.</param>
         /// <returns>The query.</returns>
-        public static IQueryable<T> WithPaging<T>(this IQueryable<T> query, PagingArgs? paging) => paging == null ? query.WithPaging(0, null) : query.WithPaging(paging.Skip, paging.Take);
+        public static IQueryable<T> WithPaging<T>(this IQueryable<T> query, PagingArgs? paging)
+        {
+            if (paging is null)
+                return query.WithPaging(0, null);
+
+            if (paging.Option == PagingOption.TokenAndTake)
+                throw new ArgumentException("PagingArgs.Option must not be PagingOption.TokenAndTake.", nameof(paging));
+
+            return query.WithPaging(paging.Skip!.Value, paging.Take);
+        }
 
         /// <summary>
         /// Adds paging to the query using the specified <paramref name="skip"/> and <paramref name="take"/>.

--- a/src/CoreEx/Entities/PagingOption.cs
+++ b/src/CoreEx/Entities/PagingOption.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+namespace CoreEx.Entities
+{
+    /// <summary>
+    /// Represents the <see cref="PagingArgs"/> option.
+    /// </summary>
+    public enum PagingOption
+    {
+        /// <summary>
+        /// Indicates that the <see cref="PagingArgs.CreatePageAndSize(long, long?, bool?)"/> was used to instantiate.
+        /// </summary>
+        PageAndSize,
+
+        /// <summary>
+        /// Indicates that the <see cref="PagingArgs.CreateSkipAndTake(long, long?, bool?)"/> was used to instantiate.
+        /// </summary>
+        SkipAndTake,
+
+        /// <summary>
+        /// Indicates that the <see cref="PagingArgs.CreateTokenAndTake(string?, long?, bool?)"/> was used to instantiate.
+        /// </summary>
+        TokenAndTake
+    }
+}

--- a/src/CoreEx/Entities/PagingResult.cs
+++ b/src/CoreEx/Entities/PagingResult.cs
@@ -12,22 +12,31 @@ namespace CoreEx.Entities
     public class PagingResult : PagingArgs
     {
         /// <summary>
-        /// Creates a <see cref="PagingArgs"/> for a specified page number and size.
+        /// Creates a <see cref="PagingResult"/> for a specified page number and size.
         /// </summary>
         /// <param name="page">The <see cref="PagingArgs.Page"/> number.</param>
         /// <param name="size">The page <see cref="Size"/> (defaults to <see cref="PagingArgs.DefaultTake"/>).</param>
         /// <param name="isGetCount">Indicates whether to get the total count (see <see cref="TotalCount"/>) when performing the underlying query (defaults to <see cref="PagingArgs.DefaultIsGetCount"/> where <c>null</c>).</param>
-        /// <returns>The <see cref="PagingArgs"/>.</returns>
+        /// <returns>The <see cref="PagingResult"/>.</returns>
         public static new PagingResult CreatePageAndSize(long page, long? size = null, bool? isGetCount = null) => new(PagingArgs.CreatePageAndSize(page, size, isGetCount));
 
         /// <summary>
-        /// Creates a <see cref="PagingArgs"/> for a specified skip and take.
+        /// Creates a <see cref="PagingResult"/> for a specified skip and take.
         /// </summary>
         /// <param name="skip">The <see cref="PagingArgs.Skip"/> value.</param>
         /// <param name="take">The <see cref="PagingArgs.Take"/> value (defaults to <see cref="PagingArgs.DefaultTake"/>).</param>
         /// <param name="isGetCount">Indicates whether to get the total count (see <see cref="TotalCount"/>) when performing the underlying query (defaults to <see cref="PagingArgs.DefaultIsGetCount"/> where <c>null</c>).</param>
-        /// <returns>The <see cref="PagingArgs"/>.</returns>
+        /// <returns>The <see cref="PagingResult"/>.</returns>
         public static new PagingResult CreateSkipAndTake(long skip, long? take = null, bool? isGetCount = null) => new(PagingArgs.CreateSkipAndTake(skip, take, isGetCount));
+
+        /// <summary>
+        /// Creates a <see cref="PagingResult"/> for a specified token and take.
+        /// </summary>
+        /// <param name="token">The <see cref="PagingArgs.Token"/> to use to get the next page of elements.</param>
+        /// <param name="take">The <see cref="PagingArgs.Take"/> value (defaults to <see cref="PagingArgs.DefaultTake"/>).</param>
+        /// <param name="isGetCount">Indicates whether to get the total count (see <see cref="PagingResult.TotalCount"/>) when performing the underlying query (defaults to <see cref="PagingArgs.DefaultIsGetCount"/> where <c>null</c>).</param>
+        /// <returns>The <see cref="PagingResult"/>.</returns>
+        public static new PagingResult CreateTokenAndTake(string token, long? take = null, bool? isGetCount = null) => new(PagingArgs.CreateTokenAndTake(token, take, isGetCount));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PagingResult"/> class from a <paramref name="pagingArgs"/> and optional <paramref name="totalCount"/>.
@@ -42,6 +51,7 @@ namespace CoreEx.Entities
             Skip = pagingArgs.Skip;
             Take = pagingArgs.Take;
             Page = pagingArgs.Page;
+            Token = pagingArgs.Token;
             IsGetCount = pagingArgs.IsGetCount;
             TotalCount = (totalCount.HasValue && totalCount.Value < 0) ? null : totalCount;
         }
@@ -58,9 +68,9 @@ namespace CoreEx.Entities
         public long? TotalCount { get; set; }
 
         /// <summary>
-        /// Gets the calculated total pages for all elements in the sequence (needs <see cref="TotalCount"/> and <see cref="PagingArgs.Take"/> values as well as not being an <see cref="PagingArgs.IsSkipTake"/>).
+        /// Gets the calculated total pages for all elements in the sequence where the <see cref="PagingArgs.Option"/> is equal to <see cref="PagingOption.PageAndSize"/>.
         /// </summary>
         [JsonIgnore()]
-        public long? TotalPages => !IsSkipTake && TotalCount.HasValue ? (long)System.Math.Ceiling(TotalCount.Value / (double)Take) : null;
+        public long? TotalPages => Option == PagingOption.PageAndSize && TotalCount.HasValue ? (long)System.Math.Ceiling(TotalCount.Value / (double)Take) : null;
     }
 }

--- a/src/CoreEx/Http/HttpConsts.cs
+++ b/src/CoreEx/Http/HttpConsts.cs
@@ -43,6 +43,11 @@ namespace CoreEx.Http
         public static string PagingTakeHeaderName { get; set; } = "x-paging-take";
 
         /// <summary>
+        /// Gets or sets the header name for the <see cref="PagingResult"/> <see cref="PagingArgs.Token"/>.
+        /// </summary>
+        public static string PagingTokenHeaderName { get; set; } = "x-paging-token";
+
+        /// <summary>
         /// Gets or sets the header name for the <see cref="PagingResult"/> <see cref="PagingResult.TotalCount"/>.
         /// </summary>
         public static string PagingTotalCountHeaderName { get; set; } = "x-paging-total-count";
@@ -97,6 +102,11 @@ namespace CoreEx.Http
         public static string PagingArgsTakeQueryStringName { get; set; } = "$take";
 
         /// <summary>
+        /// Gets or sets the <see cref="HttpRequestOptions.Paging"/> <see cref="PagingArgs.Token"/> query string name.
+        /// </summary>
+        public static string PagingArgsTokenQueryStringName { get; set; } = "$token";
+
+        /// <summary>
         /// Gets or sets the <see cref="HttpRequestOptions.Paging"/> <see cref="PagingArgs.IsGetCount"/> query string name.
         /// </summary>
         public static string PagingArgsCountQueryStringName { get; set; } = "$count";
@@ -129,7 +139,12 @@ namespace CoreEx.Http
         /// <summary>
         /// Gets or sets the list of possible <see cref="PagingArgs.Take"/> query string names.
         /// </summary>
-        public static List<string> PagingArgsTakeQueryStringNames { get; set; } = new List<string>(new string[] { "$take", "$top", "$size", "$pageSize", "$limit", "paging-take", "paging-size" });
+        public static List<string> PagingArgsTakeQueryStringNames { get; set; } = new List<string>(new string[] { "$take", "$top", "$size", "$pageSize", "$limit", "paging-take", "paging-size", "paging-limit" });
+
+        /// <summary>
+        /// Gets or sets the list of possible <see cref="PagingArgs.Take"/> query string names.
+        /// </summary>
+        public static List<string> PagingArgsTokenQueryStringNames { get; set; } = new List<string>(new string[] { "$token", "$after", "$cursor", "paging-token", "paging-after", "paging-cursor" });
 
         /// <summary>
         /// Gets or sets the list of possible <see cref="PagingArgs.IsGetCount"/> query string names.

--- a/src/CoreEx/Http/HttpExtensions.cs
+++ b/src/CoreEx/Http/HttpExtensions.cs
@@ -115,8 +115,11 @@ namespace CoreEx.Http
         {
             var skip = ParseLongValue(TryGetHeaderValue(response, HttpConsts.PagingSkipHeaderName, out var vs) ? vs : null);
             var page = skip.HasValue ? null : ParseLongValue(TryGetHeaderValue(response, HttpConsts.PagingPageNumberHeaderName, out var vpn) ? vpn : null);
+            var token = TryGetHeaderValue(response, HttpConsts.PagingTokenHeaderName, out var vtk) ? vtk : null;
 
-            if (skip.HasValue)
+            if (!string.IsNullOrEmpty(token))
+                result = new PagingResult(PagingArgs.CreateTokenAndTake(token, ParseLongValue(TryGetHeaderValue(response, HttpConsts.PagingTakeHeaderName, out var vt) ? vt : null)));
+            else if (skip.HasValue)
                 result = new PagingResult(PagingArgs.CreateSkipAndTake(skip.Value, ParseLongValue(TryGetHeaderValue(response, HttpConsts.PagingTakeHeaderName, out var vt) ? vt : null)));
             else if (page.HasValue)
                 result = new PagingResult(PagingArgs.CreatePageAndSize(page.Value, ParseLongValue(TryGetHeaderValue(response, HttpConsts.PagingPageSizeHeaderName, out var vps) ? vps : null)));

--- a/src/CoreEx/Http/HttpRequestOptions.cs
+++ b/src/CoreEx/Http/HttpRequestOptions.cs
@@ -55,6 +55,12 @@ namespace CoreEx.Http
         public string QueryStringNamePagingArgsTake { get; set; } = HttpConsts.PagingArgsTakeQueryStringName;
 
         /// <summary>
+        /// Gets or sets the <see cref="Paging"/> <see cref="PagingArgs.Token"/> query string name.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="HttpConsts.PagingArgsTokenQueryStringName"/>.</remarks>
+        public string QueryStringNamePagingArgsToken { get; set; } = HttpConsts.PagingArgsTokenQueryStringName;
+
+        /// <summary>
         /// Gets or sets the <see cref="Paging"/> <see cref="PagingArgs.IsGetCount"/> query string name.
         /// </summary>
         /// <remarks>Defaults to <see cref="HttpConsts.PagingArgsCountQueryStringName"/>.</remarks>
@@ -152,15 +158,23 @@ namespace CoreEx.Http
 
             if (Paging != null)
             {
-                if (Paging.IsSkipTake)
+                switch (Paging.Option)
                 {
-                    AddNameValuePair(sb, QueryStringNamePagingArgsSkip, Paging.Skip.ToString(), false);
-                    AddNameValuePair(sb, QueryStringNamePagingArgsTake, Paging.Take.ToString(), false);
-                }
-                else
-                {
-                    AddNameValuePair(sb, QueryStringNamePagingArgsPage, Paging.Page?.ToString() ?? 1.ToString(), false);
-                    AddNameValuePair(sb, QueryStringNamePagingArgsSize, Paging.Size.ToString(), false);
+                    case PagingOption.SkipAndTake:
+                        AddNameValuePair(sb, QueryStringNamePagingArgsSkip, Paging.Skip?.ToString(), false);
+                        AddNameValuePair(sb, QueryStringNamePagingArgsTake, Paging.Take.ToString(), false);
+                        break;
+
+                    case PagingOption.PageAndSize:
+                        AddNameValuePair(sb, QueryStringNamePagingArgsPage, Paging.Page?.ToString() ?? 1.ToString(), false);
+                        AddNameValuePair(sb, QueryStringNamePagingArgsSize, Paging.Size.ToString(), false);
+                        break;
+
+                    default:
+                        AddNameValuePair(sb, QueryStringNamePagingArgsToken, Paging.Token, false);
+                        AddNameValuePair(sb, QueryStringNamePagingArgsTake, Paging.Take.ToString(), false);
+                        break;
+
                 }
 
                 if (Paging.IsGetCount)
@@ -183,9 +197,9 @@ namespace CoreEx.Http
             if (!string.IsNullOrEmpty(UrlQueryString))
             {
                 if (qs is null)
-                    return UrlQueryString.StartsWith("?") ? UrlQueryString : $"?{(UrlQueryString.StartsWith("&") ? UrlQueryString[1..] : UrlQueryString)}";
+                    return UrlQueryString.StartsWith('?') ? UrlQueryString : $"?{(UrlQueryString.StartsWith('&') ? UrlQueryString[1..] : UrlQueryString)}";
                 else
-                    return $"{qs}{(UrlQueryString.StartsWith("&") ? UrlQueryString : $"&{UrlQueryString}")}";
+                    return $"{qs}{(UrlQueryString.StartsWith('&') ? UrlQueryString : $"&{UrlQueryString}")}";
             }
             else
                 return qs;

--- a/src/CoreEx/Json/Data/JsonDataReader.cs
+++ b/src/CoreEx/Json/Data/JsonDataReader.cs
@@ -30,7 +30,7 @@ namespace CoreEx.Json.Data
 
         private class YamlNodeTypeResolver : INodeTypeResolver
         {
-            private static readonly string[] boolValues = { "true", "false" };
+            private static readonly string[] boolValues = ["true", "false"];
 
             /// <inheritdoc/>
             bool INodeTypeResolver.Resolve(NodeEvent? nodeEvent, ref Type currentType)
@@ -184,7 +184,7 @@ namespace CoreEx.Json.Data
                         var item = Deserialize<T>(jd);
                         if (item != null)
                         {
-                            (items ??= new List<T>()).Add(item);
+                            (items ??= []).Add(item);
                             _args.IdentifierGenerator?.AssignIdentifierAsync(item);
                             ChangeLog.PrepareCreated(item, _executionContext);
                             PrepareReferenceData(typeof(T), item, jd, items.Count - 1);
@@ -217,7 +217,7 @@ namespace CoreEx.Json.Data
                         var item = Deserialize(type, jd);
                         if (item != null)
                         {
-                            (items ??= new List<object>()).Add(item);
+                            (items ??= []).Add(item);
                             _args.IdentifierGenerator?.AssignIdentifierAsync(item);
                             ChangeLog.PrepareCreated(item, _executionContext);
                             PrepareReferenceData(type, item, jd, items.Count - 1);
@@ -303,7 +303,7 @@ namespace CoreEx.Json.Data
             var str = je.GetString();
             if (!string.IsNullOrEmpty(str) && str.Length > 1 && str[0] == '^')
             {
-                if (str.StartsWith("^(") && str.EndsWith(")"))
+                if (str.StartsWith("^(") && str.EndsWith(')'))
                 {
                     var val = GetRuntimeValue(_args.Parameters, str[2..^1]);
                     if (val == null)
@@ -408,7 +408,7 @@ namespace CoreEx.Json.Data
             var part = parts[0];
             if (part.EndsWith("()"))
             {
-                var mi = type.GetMethod(part[0..^2], Array.Empty<Type>());
+                var mi = type.GetMethod(part[0..^2], []);
                 if (mi == null || mi.GetParameters().Length != 0)
                     return (null, $"Runtime value parameter '{param}' is invalid; specified method '{part}' is invalid.");
 

--- a/src/CoreEx/Json/Data/JsonDataReaderArgs.cs
+++ b/src/CoreEx/Json/Data/JsonDataReaderArgs.cs
@@ -74,11 +74,11 @@ namespace CoreEx.Json.Data
         ///   <item><see cref="IReferenceData.SortOrder"/> with function '<c>i => i + 1</c>' (increment by 1 from 1).</item>
         /// </list>
         /// </para></remarks>
-        public Dictionary<string, Func<int, object?>> RefDataColumnDefaults { get; } = new Dictionary<string, Func<int, object?>>();
+        public Dictionary<string, Func<int, object?>> RefDataColumnDefaults { get; } = [];
 
         /// <summary>
         /// Gets the runtime parameters.
         /// </summary>
-        public Dictionary<string, object?> Parameters { get; } = new();
+        public Dictionary<string, object?> Parameters { get; } = [];
     }
 }

--- a/src/CoreEx/Text/Json/JsonSerializer.cs
+++ b/src/CoreEx/Text/Json/JsonSerializer.cs
@@ -14,8 +14,11 @@ namespace CoreEx.Text.Json
     /// <summary>
     /// Provides the <see cref="Stj.JsonSerializer"/> encapsulated implementation.
     /// </summary>
-    public class JsonSerializer : IJsonSerializer
+    /// <param name="options">The <see cref="Stj.JsonSerializerOptions"/>. Defaults to <see cref="DefaultOptions"/>.</param>
+    public class JsonSerializer(Stj.JsonSerializerOptions? options = null) : IJsonSerializer
     {
+        private Stj.JsonSerializerOptions? _indentedOptions;
+
         /// <summary>
         /// Gets or sets the default <see cref="Stj.JsonSerializerOptions"/>.
         /// </summary>
@@ -38,12 +41,6 @@ namespace CoreEx.Text.Json
         };
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="JsonSerializer"/> class.
-        /// </summary>
-        /// <param name="options">The <see cref="Stj.JsonSerializerOptions"/>. Defaults to <see cref="DefaultOptions"/>.</param>
-        public JsonSerializer(Stj.JsonSerializerOptions? options = null) => Options = options ?? DefaultOptions;
-
-        /// <summary>
         /// Gets the underlying serializer configuration settings/options.
         /// </summary>
         object IJsonSerializer.Options => Options;
@@ -51,14 +48,14 @@ namespace CoreEx.Text.Json
         /// <summary>
         /// Gets the <see cref="Stj.JsonSerializerOptions"/>.
         /// </summary>
-        public Stj.JsonSerializerOptions Options { get; }
+        public Stj.JsonSerializerOptions Options { get; } = options ?? DefaultOptions;
 
         /// <inheritdoc/>
         public string Serialize<T>(T value, JsonWriteFormat? format = null) => SerializeToBinaryData(value, format).ToString();
 
         /// <inheritdoc/>
         public BinaryData SerializeToBinaryData<T>(T value, JsonWriteFormat? format = null) 
-            => new(Stj.JsonSerializer.SerializeToUtf8Bytes(value, format == null ? Options : new Stj.JsonSerializerOptions(Options) { WriteIndented = format.Value == JsonWriteFormat.Indented }));
+            => new(Stj.JsonSerializer.SerializeToUtf8Bytes(value, format == null ? Options : (_indentedOptions ??= new Stj.JsonSerializerOptions(Options) { WriteIndented = format.Value == JsonWriteFormat.Indented })));
 
         /// <inheritdoc/>
         public object? Deserialize(string json) => Stj.JsonSerializer.Deserialize<dynamic>(json, Options);

--- a/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
+++ b/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0">
@@ -34,7 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.0.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Cosmos.Test/TestSetUp.cs
+++ b/tests/CoreEx.Cosmos.Test/TestSetUp.cs
@@ -85,7 +85,7 @@ namespace CoreEx.Cosmos.Test
             await db.Persons1.ImportBatchAsync(jdr);
             await db.Persons2.ImportBatchAsync(jdr);
             await db.Persons3.ImportValueBatchAsync(jdr);
-            await db.ImportValueBatchAsync("Persons3", new Person1[] { new Person1 { Id = 100.ToGuid().ToString() } }); // Add other random "type" to Person3.
+            await db.ImportValueBatchAsync("Persons3", new Person1[] { new() { Id = 100.ToGuid().ToString() } }); // Add other random "type" to Person3.
 
             jdr = JsonDataReader.ParseYaml<CosmosDb>("RefData.yaml", new JsonDataReaderArgs(new Text.Json.ReferenceDataContentJsonSerializer()));
             await db.ImportValueBatchAsync("RefData", jdr, new Type[] { typeof(Gender) });

--- a/tests/CoreEx.Solace.Test/CoreEx.Solace.Test.csproj
+++ b/tests/CoreEx.Solace.Test/CoreEx.Solace.Test.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0">

--- a/tests/CoreEx.Test/CoreEx.Test.csproj
+++ b/tests/CoreEx.Test/CoreEx.Test.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.0.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Test/Framework/Abstractions/Reflection/TypeReflectorTest.cs
+++ b/tests/CoreEx.Test/Framework/Abstractions/Reflection/TypeReflectorTest.cs
@@ -85,13 +85,13 @@ namespace CoreEx.Test.Framework.Abstractions.Reflection
             var pr = tr.GetProperty("Addresses");
             Assert.IsNotNull(pr.GetTypeReflector());
 
-            var a = new List<Address> { new Address { Street = "s", City = "c" } };
+            var a = new List<Address> { new() { Street = "s", City = "c" } };
             var p = new Person { Addresses = a };
 
             var a2 = (List<Address>)pr.PropertyExpression.GetValue(p)!;
             Assert.AreEqual("s", a2[0].Street);
 
-            pr.PropertyExpression.SetValue(p, new List<Address> { new Address { Street = "s2", City = "c2" } });
+            pr.PropertyExpression.SetValue(p, new List<Address> { new() { Street = "s2", City = "c2" } });
             Assert.AreEqual("s2", p.Addresses[0].Street);
 
             pr.PropertyExpression.SetValue(p, null!);
@@ -196,10 +196,10 @@ namespace CoreEx.Test.Framework.Abstractions.Reflection
             Assert.IsTrue(pr.Compare(new List<Address>(), new List<Address>()));
 
             // No equality check for Address, so will all fail.
-            Assert.IsFalse(pr.Compare(new List<Address> { new Address() }, new List<Address> { new Address() }));
-            Assert.IsFalse(pr.Compare(null, new List<Address> { new Address() }));
-            Assert.IsFalse(pr.Compare(new List<Address> { new Address() }, null));
-            Assert.IsFalse(pr.Compare(new List<Address> { new Address() }, new List<Address> { new Address(), new Address() }));
+            Assert.IsFalse(pr.Compare(new List<Address> { new() }, new List<Address> { new() }));
+            Assert.IsFalse(pr.Compare(null, new List<Address> { new() }));
+            Assert.IsFalse(pr.Compare(new List<Address> { new() }, null));
+            Assert.IsFalse(pr.Compare(new List<Address> { new() }, new List<Address> { new(), new() }));
         }
 
         [Test]

--- a/tests/CoreEx.Test/Framework/Configuration/SettingsBaseTest.cs
+++ b/tests/CoreEx.Test/Framework/Configuration/SettingsBaseTest.cs
@@ -30,8 +30,8 @@ namespace CoreEx.Test.Framework.Configuration
         private IConfiguration CreateTestConfiguration()
         {
             Environment.SetEnvironmentVariable("this_is_a_unittest_underscore__key", "underscoreValue");
-            ConfigurationBuilder builder = new ConfigurationBuilder();
-            Dictionary<string, string> testSettings = new Dictionary<string, string>()
+            ConfigurationBuilder builder = new();
+            Dictionary<string, string> testSettings = new()
             {
                 {"SomethingGlobal", "foo"},
                 {"prefix1/key1", "value1"},

--- a/tests/CoreEx.Test/Framework/Entities/Extended/EntityBaseTest.cs
+++ b/tests/CoreEx.Test/Framework/Entities/Extended/EntityBaseTest.cs
@@ -797,7 +797,7 @@ namespace CoreEx.Test.Framework.Entities.Extended
             Assert.AreNotEqual(pd.GetHashCode(), pxd.GetHashCode());
         }
 
-        private DateTime CreateDateTime() => new DateTime(2000, 01, 01, 12, 45, 59);
+        private DateTime CreateDateTime() => new(2000, 01, 01, 12, 45, 59);
 
         public class Person : EntityBase, CoreEx.Entities.IPrimaryKey
         {
@@ -809,7 +809,7 @@ namespace CoreEx.Test.Framework.Entities.Extended
             public int Age { get => _age; set => SetValue(ref _age, value); }
             public ChangeLogEx? ChangeLog { get => _changeLog; set => SetValue(ref _changeLog, value); }
 
-            public CoreEx.Entities.CompositeKey PrimaryKey => new CoreEx.Entities.CompositeKey(Name);
+            public CoreEx.Entities.CompositeKey PrimaryKey => new(Name);
 
             protected override IEnumerable<IPropertyValue> GetPropertyValues()
             {

--- a/tests/CoreEx.Test/Framework/Entities/PagingArgsTest.cs
+++ b/tests/CoreEx.Test/Framework/Entities/PagingArgsTest.cs
@@ -1,0 +1,36 @@
+﻿using CoreEx.Entities;
+using NUnit.Framework;
+
+namespace CoreEx.Test.Framework.Entities
+{
+    [TestFixture]
+    public class PagingArgsTest
+    {
+        [Test]
+        public void CreateSkipAndTake()
+        {
+            var pa = PagingArgs.CreateSkipAndTake(10, 20);
+            Assert.That(pa.Skip, Is.EqualTo(10));
+            Assert.That(pa.Take, Is.EqualTo(20));
+            Assert.That(pa.Option, Is.EqualTo(PagingOption.SkipAndTake));
+        }
+
+        [Test]
+        public void CreatePageAndSize()
+        {
+            var pa = PagingArgs.CreatePageAndSize(10, 20);
+            Assert.That(pa.Page, Is.EqualTo(10));
+            Assert.That(pa.Size, Is.EqualTo(20));
+            Assert.That(pa.Option, Is.EqualTo(PagingOption.PageAndSize));
+        }
+
+        [Test]
+        public void CreateTokenAndTake()
+        {
+            var pa = PagingArgs.CreateTokenAndTake("blah-blah", 20);
+            Assert.That(pa.Token, Is.EqualTo("blah-blah"));
+            Assert.That(pa.Take, Is.EqualTo(20));
+            Assert.That(pa.Option, Is.EqualTo(PagingOption.TokenAndTake));
+        }
+    }
+}

--- a/tests/CoreEx.Test/Framework/Events/Subscribing/EventSubscriberAttributeTest.cs
+++ b/tests/CoreEx.Test/Framework/Events/Subscribing/EventSubscriberAttributeTest.cs
@@ -114,6 +114,6 @@ namespace CoreEx.Test.Framework.Events.Subscribing
             Assert.IsFalse(esa.IsMatch(edf, new EventData { Source = new Uri("http://host:5050/test/xyz", UriKind.Absolute) }));
         }
 
-        private EventData Create(string? subject, string? type, string? action) => new EventData { Subject = subject, Type = type, Action = action };
+        private EventData Create(string? subject, string? type, string? action) => new() { Subject = subject, Type = type, Action = action };
     }
 }

--- a/tests/CoreEx.Test/Framework/Json/JsonSerializerTest.cs
+++ b/tests/CoreEx.Test/Framework/Json/JsonSerializerTest.cs
@@ -94,7 +94,7 @@ namespace CoreEx.Test.Framework.Json
         [Test]
         public void SystemTextJson_TryApplyFilter_JsonString()
         {
-            var p = new Person { FirstName = "John", LastName = "Smith", Addresses = new List<Address> { new Address { Street = "One", City = "First" }, new Address { Street = "Two", City = "Second" } } };
+            var p = new Person { FirstName = "John", LastName = "Smith", Addresses = new List<Address> { new() { Street = "One", City = "First" }, new() { Street = "Two", City = "Second" } } };
 
             var js = new CoreEx.Text.Json.JsonSerializer() as IJsonSerializer;
             Assert.IsTrue(js.TryApplyFilter(p, new string[] { "LastName", "Addresses.City", "LastName" }, out string json, JsonPropertyFilter.Exclude));
@@ -122,7 +122,7 @@ namespace CoreEx.Test.Framework.Json
         [Test]
         public void SystemTextJson_TryApplyFilter_JsonObject()
         {
-            var p = new Person { FirstName = "John", LastName = "Smith", Addresses = new List<Address> { new Address { Street = "One", City = "First" }, new Address { Street = "Two", City = "Second" } } };
+            var p = new Person { FirstName = "John", LastName = "Smith", Addresses = new List<Address> { new() { Street = "One", City = "First" }, new() { Street = "Two", City = "Second" } } };
 
             var js = new CoreEx.Text.Json.JsonSerializer() as IJsonSerializer;
             Assert.IsTrue(js.TryApplyFilter(p, new string[] { "LastName", "Addresses.City", "LastName" }, out object json, JsonPropertyFilter.Exclude));
@@ -337,7 +337,7 @@ namespace CoreEx.Test.Framework.Json
         [Test]
         public void NewtonsoftJson_TryApplyFilter_JsonString()
         {
-            var p = new Person { FirstName = "John", LastName = "Smith", Addresses = new List<Address> { new Address { Street = "One", City = "First" }, new Address { Street = "Two", City = "Second" } } };
+            var p = new Person { FirstName = "John", LastName = "Smith", Addresses = new List<Address> { new() { Street = "One", City = "First" }, new() { Street = "Two", City = "Second" } } };
 
             var js = new CoreEx.Newtonsoft.Json.JsonSerializer() as IJsonSerializer;
             Assert.IsTrue(js.TryApplyFilter(p, new string[] { "LastName", "Addresses.City", "LastName" }, out string json, JsonPropertyFilter.Exclude));
@@ -365,7 +365,7 @@ namespace CoreEx.Test.Framework.Json
         [Test]
         public void NewtonsoftJson_TryApplyFilter_JsonObject()
         {
-            var p = new Person { FirstName = "John", LastName = "Smith", Addresses = new List<Address> { new Address { Street = "One", City = "First" }, new Address { Street = "Two", City = "Second" } } };
+            var p = new Person { FirstName = "John", LastName = "Smith", Addresses = new List<Address> { new() { Street = "One", City = "First" }, new() { Street = "Two", City = "Second" } } };
 
             var js = new CoreEx.Newtonsoft.Json.JsonSerializer() as IJsonSerializer;
             Assert.IsTrue(js.TryApplyFilter(p, new string[] { "LastName", "Addresses.City", "LastName" }, out object json, JsonPropertyFilter.Exclude));

--- a/tests/CoreEx.Test/Framework/Json/Merge/JsonMergePatchTest.cs
+++ b/tests/CoreEx.Test/Framework/Json/Merge/JsonMergePatchTest.cs
@@ -248,7 +248,7 @@ namespace CoreEx.Test.Framework.Json.Merge
         [Test]
         public void Merge_Property_NoKeys_ListNull()
         {
-            var td = new TestData { NoKeys = new List<SubData> { new SubData() } };
+            var td = new TestData { NoKeys = new List<SubData> { new() } };
             Assert.IsTrue(new JsonMergePatch().Merge(BinaryData.FromString("{ \"nokeys\": null }"), ref td));
             Assert.IsNull(td!.Values);
         }
@@ -256,7 +256,7 @@ namespace CoreEx.Test.Framework.Json.Merge
         [Test]
         public void Merge_Property_NoKeys_ListEmpty()
         {
-            var td = new TestData { NoKeys = new List<SubData> { new SubData() } };
+            var td = new TestData { NoKeys = new List<SubData> { new() } };
             Assert.IsTrue(new JsonMergePatch().Merge(BinaryData.FromString("{ \"nokeys\": [ ] }"), ref td));
             Assert.IsNotNull(td!.NoKeys);
             Assert.AreEqual(0, td.NoKeys!.Count);
@@ -265,7 +265,7 @@ namespace CoreEx.Test.Framework.Json.Merge
         [Test]
         public void Merge_Property_NoKeys_List()
         {
-            var td = new TestData { NoKeys = new List<SubData> { new SubData() } };
+            var td = new TestData { NoKeys = new List<SubData> { new() } };
             Assert.IsTrue(new JsonMergePatch().Merge(BinaryData.FromString("{ \"nokeys\": [ { \"code\": \"abc\", \"text\": \"xyz\" }, { }, null ] }"), ref td));
             Assert.IsNotNull(td!.NoKeys);
             Assert.AreEqual(3, td.NoKeys!.Count);
@@ -284,7 +284,7 @@ namespace CoreEx.Test.Framework.Json.Merge
         [Test]
         public void Merge_Property_Keys_ListNull()
         {
-            var td = new TestData { Keys = new List<KeyData> { new KeyData { Code = "abc", Text = "def" } } };
+            var td = new TestData { Keys = new List<KeyData> { new() { Code = "abc", Text = "def" } } };
             Assert.IsTrue(new JsonMergePatch().Merge(BinaryData.FromString("{ \"keys\": null }"), ref td));
 
             Assert.IsNull(td!.Keys);
@@ -293,7 +293,7 @@ namespace CoreEx.Test.Framework.Json.Merge
         [Test]
         public void Merge_Property_Keys_ListEmpty()
         {
-            var td = new TestData { Keys = new List<KeyData> { new KeyData { Code = "abc", Text = "def" } } };
+            var td = new TestData { Keys = new List<KeyData> { new() { Code = "abc", Text = "def" } } };
             Assert.IsTrue(new JsonMergePatch().Merge(BinaryData.FromString("{ \"keys\": [ ] }"), ref td));
 
             Assert.IsNotNull(td!.Keys);
@@ -303,7 +303,7 @@ namespace CoreEx.Test.Framework.Json.Merge
         [Test]
         public void Merge_Property_Keys_Null()
         {
-            var td = new TestData { Keys = new List<KeyData> { new KeyData { Code = "abc", Text = "def" } } };
+            var td = new TestData { Keys = new List<KeyData> { new() { Code = "abc", Text = "def" } } };
             Assert.IsTrue(new JsonMergePatch().Merge(BinaryData.FromString("{ \"keys\": [ null ] }"), ref td));
 
             Assert.IsNotNull(td!.Keys);
@@ -314,7 +314,7 @@ namespace CoreEx.Test.Framework.Json.Merge
         [Test]
         public void Merge_Property_Keys_Replace()
         {
-            var td = new TestData { Keys = new List<KeyData> { new KeyData { Code = "abc", Text = "def" } } };
+            var td = new TestData { Keys = new List<KeyData> { new() { Code = "abc", Text = "def" } } };
             Assert.IsTrue(new JsonMergePatch().Merge(BinaryData.FromString("{ \"keys\": [ { \"code\": \"abc\" }, { \"code\": \"uvw\", \"text\": \"xyz\" } ] }"), ref td));
 
             Assert.IsNotNull(td!.Keys);
@@ -329,7 +329,7 @@ namespace CoreEx.Test.Framework.Json.Merge
         public void Merge_Property_Keys_NoChanges()
         {
             // Note, although technically no changes, there is no means to verify without specific equality checking, so is seen as a change.
-            var td = new TestData { Keys = new List<KeyData> { new KeyData { Code = "abc", Text = "def" } } };
+            var td = new TestData { Keys = new List<KeyData> { new() { Code = "abc", Text = "def" } } };
             Assert.IsTrue(new JsonMergePatch().Merge(BinaryData.FromString("{ \"keys\": [ { \"code\": \"abc\", \"text\": \"def\" } ] }"), ref td));
 
             Assert.IsNotNull(td!.Keys);
@@ -790,7 +790,7 @@ namespace CoreEx.Test.Framework.Json.Merge
 
             for (int i = 0; i < 1000; i++)
             {
-                var td = new TestData { Values = new int[] { 1, 2, 3 }, Keys = new List<KeyData> { new KeyData { Code = "abc", Text = "def" } }, Dict = new Dictionary<string, string>() { { "a", "b" } }, Dict2 = new Dictionary<string, KeyData> { { "x", new KeyData { Code = "xx" } } } };
+                var td = new TestData { Values = new int[] { 1, 2, 3 }, Keys = new List<KeyData> { new() { Code = "abc", Text = "def" } }, Dict = new Dictionary<string, string>() { { "a", "b" } }, Dict2 = new Dictionary<string, KeyData> { { "x", new KeyData { Code = "xx" } } } };
                 new JsonMergePatch(new JsonMergePatchOptions { EntityKeyCollectionMergeApproach = EntityKeyCollectionMergeApproach.Merge, DictionaryMergeApproach = DictionaryMergeApproach.Merge }).Merge(BinaryData.FromString(text), ref td);
             }
         }
@@ -805,7 +805,7 @@ namespace CoreEx.Test.Framework.Json.Merge
 
             for (int i = 0; i < 1000; i++)
             {
-                var td = new TestData { Values = new int[] { 1, 2, 3 }, Keys = new List<KeyData> { new KeyData { Code = "abc", Text = "def" } }, Dict = new Dictionary<string, string>() { { "a", "b" } }, Dict2 = new Dictionary<string, KeyData> { { "x", new KeyData { Code = "xx" } } } };
+                var td = new TestData { Values = new int[] { 1, 2, 3 }, Keys = new List<KeyData> { new() { Code = "abc", Text = "def" } }, Dict = new Dictionary<string, string>() { { "a", "b" } }, Dict2 = new Dictionary<string, KeyData> { { "x", new KeyData { Code = "xx" } } } };
                 jmp.Merge(BinaryData.FromString(text), ref td);
             }
         }
@@ -919,7 +919,7 @@ namespace CoreEx.Test.Framework.Json.Merge
         [Test]
         public void Merge_RootArray_Complex()
         {
-            var arr = new SubData[] { new SubData { Code = "a", Text = "aa" }, new SubData { Code = "b", Text = "bb" } };
+            var arr = new SubData[] { new() { Code = "a", Text = "aa" }, new() { Code = "b", Text = "bb" } };
             var jmp = new JsonMergePatch();
 
             // No equality checker so will appear as changed - is a replacement.

--- a/tests/CoreEx.Test/Framework/Mapping/Converters/TypeToStringConverterTest.cs
+++ b/tests/CoreEx.Test/Framework/Mapping/Converters/TypeToStringConverterTest.cs
@@ -10,7 +10,7 @@ namespace CoreEx.Test.Framework.Mapping.Converters
     public class TypeToStringConverterTest
     {
         private const string GuidString = "382c74c3-721d-4f34-80e5-57657b6cbc27";
-        private readonly Guid GuidValue = new Guid(GuidString);
+        private readonly Guid GuidValue = new(GuidString);
 
         [Test]
         public void Convert()

--- a/tests/CoreEx.Test/Framework/UnitTesting/AgentTest.cs
+++ b/tests/CoreEx.Test/Framework/UnitTesting/AgentTest.cs
@@ -50,6 +50,17 @@ namespace CoreEx.Test.Framework.UnitTesting
                 .AssertNoContent();
         }
 
+        [Test]
+        public void Catalogue()
+        {
+            var test = ApiTester.Create<Startup>();
+            var x = test.Agent().With<ProductAgent>()
+                .Run(a => a.CatalogueAsync("abc"))
+                .AssertOK()
+                .AssertContentTypePlainText()
+                .AssertContent("Catalog for 'abc'.");
+        }
+
         public class ProductAgent : CoreEx.Http.TypedHttpClientBase<ProductAgent>
         {
             public ProductAgent(HttpClient client, IJsonSerializer jsonSerializer, CoreEx.ExecutionContext executionContext, SettingsBase settings, ILogger<ProductAgent> logger)
@@ -63,6 +74,9 @@ namespace CoreEx.Test.Framework.UnitTesting
 
             public Task<HttpResult<Product>> UpdateAsync(Product value, string id, CoreEx.Http.HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
                 => PutAsync<Product, Product>("products/{id}", value, requestOptions: requestOptions, args: new IHttpArg[] { new HttpArg<string>("id", id) }, cancellationToken: cancellationToken);
+
+            public Task<HttpResult> CatalogueAsync(string id, CoreEx.Http.HttpRequestOptions? requestOptions = null, CancellationToken cancellationToken = default)
+                => GetAsync("products/{id}/catalogue", requestOptions: requestOptions, args: new IHttpArg[] { new HttpArg<string>("id", id) }, cancellationToken: cancellationToken);
         }
     }
 }

--- a/tests/CoreEx.Test/Framework/UnitTesting/ValidationTest.cs
+++ b/tests/CoreEx.Test/Framework/UnitTesting/ValidationTest.cs
@@ -2,9 +2,12 @@
 using UnitTestEx.NUnit;
 using UnitTestEx;
 using UnitTestEx.Expectations;
+using CoreEx;
 using CoreEx.TestApi;
 using CoreEx.TestApi.Validation;
 using CoreEx.TestFunction.Models;
+using CoreEx.Localization;
+using CoreEx.Validation;
 
 namespace CoreEx.Test.Framework.UnitTesting
 {
@@ -26,6 +29,23 @@ namespace CoreEx.Test.Framework.UnitTesting
             GenericTester.Create<Startup>()
                 .ExpectSuccess()
                 .Validation().With<ProductValidator, Product>(new Product { Id = "abc", Name = "xyz", Price = 50.95m });
+        }
+
+        [Test]
+        public void Validate_OK_Provide()
+        {
+            GenericTester.Create<Startup>()
+                .ExpectSuccess()
+                .Validation().With(new ProductValidator(), new Product { Id = "abc", Name = "xyz", Price = 50.95m });
+        }
+
+        [Test]
+        public void Validate_Error_Provide()
+        {
+            GenericTester.Create()
+                .ReplaceSingleton<ITextProvider, ValidationTextProvider>()
+                .ExpectErrors("Name is required.", "Price must be between 0 and 100.")
+                .Validation().With(new ProductValidator(), new Product { Price = 450.95m });
         }
     }
 }

--- a/tests/CoreEx.Test/Framework/Validation/Rules/CollectionRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/CollectionRuleTest.cs
@@ -71,7 +71,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
             var v1 = await new TestItem[0].Validate("value").Collection(item: CollectionRuleItem.Create(iv)).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
 
-            v1 = await new TestItem[] { new TestItem() }.Validate("value").Collection(item: CollectionRuleItem.Create(iv)).ValidateAsync();
+            v1 = await new TestItem[] { new() }.Validate("value").Collection(item: CollectionRuleItem.Create(iv)).ValidateAsync();
             Assert.IsTrue(v1.HasErrors);
             Assert.AreEqual(1, v1.Messages!.Count);
             Assert.AreEqual("Identifier is required.", v1.Messages[0].Text);
@@ -98,7 +98,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Item_Null()
         {
-            var v1 = await new List<TestItem?> { new TestItem() }.Validate("value").Collection().ValidateAsync();
+            var v1 = await new List<TestItem?> { new() }.Validate("value").Collection().ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
 
             v1 = await new List<TestItem?>() { null }.Validate("value").Collection().ValidateAsync();
@@ -120,7 +120,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
             var v1 = await new TestItem[0].Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(x => x.Id)).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
 
-            var tis = new TestItem[] { new TestItem { Id = "ABC", Text = "Abc" }, new TestItem { Id = "DEF", Text = "Def" }, new TestItem { Id = "GHI", Text = "Ghi" } };
+            var tis = new TestItem[] { new() { Id = "ABC", Text = "Abc" }, new() { Id = "DEF", Text = "Def" }, new() { Id = "GHI", Text = "Ghi" } };
 
             v1 = await tis.Validate("value").Collection(item:  CollectionRuleItem.Create(iv).DuplicateCheck(x => x.Id)).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
@@ -142,7 +142,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
             var v1 = await new TestItem2[0].Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck()).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
 
-            var tis = new TestItem2[] { new TestItem2 { Part1 = "ABC", Part2 = 1, Text = "Abc" }, new TestItem2 { Part1 = "DEF", Part2 = 1, Text = "Def" }, new TestItem2 { Part1 = "GHI", Part2 = 1, Text = "Ghi" } };
+            var tis = new TestItem2[] { new() { Part1 = "ABC", Part2 = 1, Text = "Abc" }, new() { Part1 = "DEF", Part2 = 1, Text = "Def" }, new() { Part1 = "GHI", Part2 = 1, Text = "Ghi" } };
 
             v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck()).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
@@ -164,7 +164,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
             var v1 = await new TestItem[0].Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(true)).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
 
-            var tis = new TestItem[] { new TestItem { Id = "ABC", Text = "Abc" }, new TestItem { Id = "DEF", Text = "Def" }, new TestItem { Id = "GHI", Text = "Ghi" } };
+            var tis = new TestItem[] { new() { Id = "ABC", Text = "Abc" }, new() { Id = "DEF", Text = "Def" }, new() { Id = "GHI", Text = "Ghi" } };
 
             v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(true)).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
@@ -184,7 +184,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
             var v1 = await new TestItem3[0].Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
 
-            var tis = new TestItem3[] { new TestItem3 { Id = 1.ToGuid() }, new TestItem3 { Id = 2.ToGuid() }, new TestItem3 { Id = 3.ToGuid() } };
+            var tis = new TestItem3[] { new() { Id = 1.ToGuid() }, new() { Id = 2.ToGuid() }, new() { Id = 3.ToGuid() } };
 
             v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
@@ -208,7 +208,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
             var v1 = await new TestItem3[0].Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
 
-            var tis = new TestItem3[] { new TestItem3 { Id = Guid.Empty }, new TestItem3 { Id = 2.ToGuid() }, new TestItem3 { Id = Guid.Empty } };
+            var tis = new TestItem3[] { new() { Id = Guid.Empty }, new() { Id = 2.ToGuid() }, new() { Id = Guid.Empty } };
 
             v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
             Assert.IsFalse(v1.HasErrors);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/MandatoryRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/MandatoryRuleTest.cs
@@ -67,7 +67,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Entity()
         {
-            Foo? foo = new Foo();
+            Foo? foo = new();
             var v1 = await foo.Validate("value").Mandatory().ValidateAsync();
             Assert.IsFalse(v1.HasErrors);
 

--- a/tests/CoreEx.Test/Framework/Validation/Rules/NoneRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/NoneRuleTest.cs
@@ -59,7 +59,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Entity()
         {
-            Foo? foo = new Foo();
+            Foo? foo = new();
             var v1 = await foo.Validate("value").None().ValidateAsync();
             Assert.IsTrue(v1.HasErrors);
             Assert.AreEqual(1, v1.Messages!.Count);

--- a/tests/CoreEx.Test/Framework/Validation/ValidatorTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/ValidatorTest.cs
@@ -445,7 +445,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Coll_Validator_MaxCount()
         {
             var vxc = Validator.CreateCollection<List<TestItem>, TestItem>(minCount: 1, maxCount: 2, item: CollectionRuleItem.Create(new TestItemValidator()));
-            var tc = new List<TestItem> { new TestItem { Id = "A", Text = "aaa" }, new TestItem { Id = "B", Text = "bbb" }, new TestItem { Id = "C", Text = "ccc" } };
+            var tc = new List<TestItem> { new() { Id = "A", Text = "aaa" }, new() { Id = "B", Text = "bbb" }, new() { Id = "C", Text = "ccc" } };
 
             var r = await vxc.ValidateAsync(tc);
 
@@ -466,7 +466,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Coll_Validator_MinCount()
         {
             var vxc = Validator.CreateCollection<List<TestItem>, TestItem>(minCount: 3, item: CollectionRuleItem.Create(new TestItemValidator()));
-            var tc = new List<TestItem> { new TestItem { Id = "A", Text = "A" }, new TestItem { Id = "B", Text = "B" } };
+            var tc = new List<TestItem> { new() { Id = "A", Text = "A" }, new() { Id = "B", Text = "B" } };
 
             var r = await vxc.ValidateAsync(tc);
 
@@ -481,7 +481,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Coll_Validator_Duplicate()
         {
             var vxc = Validator.CreateCollection<List<TestItem>, TestItem>(item: CollectionRuleItem.Create(new TestItemValidator()).DuplicateCheck(x => x.Id));
-            var tc = new List<TestItem> { new TestItem { Id = "A", Text = "A" }, new TestItem { Id = "A", Text = "A" } };
+            var tc = new List<TestItem> { new() { Id = "A", Text = "A" }, new() { Id = "A", Text = "A" } };
 
             var r = await vxc.ValidateAsync(tc);
 
@@ -496,7 +496,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Coll_Validator_OK()
         {
             var vxc = Validator.CreateCollection<List<TestItem>, TestItem>(minCount: 1, maxCount: 2, item: CollectionRuleItem.Create(new TestItemValidator()).DuplicateCheck(x => x.Id));
-            var tc = new List<TestItem> { new TestItem { Id = "A", Text = "A" }, new TestItem { Id = "B", Text = "B" } };
+            var tc = new List<TestItem> { new() { Id = "A", Text = "A" }, new() { Id = "B", Text = "B" } };
 
             var r = await vxc.ValidateAsync(tc);
 

--- a/tests/CoreEx.Test/Framework/WebApis/WebApiRequestOptionsTest.cs
+++ b/tests/CoreEx.Test/Framework/WebApis/WebApiRequestOptionsTest.cs
@@ -38,7 +38,7 @@ namespace CoreEx.Test.Framework.WebApis
             var ro = new HttpRequestOptions { ETag = "etag-value", IncludeText = true, IncludeInactive = true, Paging = PagingArgs.CreateSkipAndTake(20, 25, true), UrlQueryString = "fruit=apples" }.Include("fielda", "fieldb").Exclude("fieldc");
             
             hr.ApplyRequestOptions(ro);
-            Assert.NotNull("?$skip=20&$take=25&$count=true&$fields=fielda,fieldb&$exclude=fieldc&$text=true&$inactive=true&fruit=apples", hr.QueryString.Value);
+            Assert.AreEqual("?$skip=20&$take=25&$count=true&$fields=fielda,fieldb&$exclude=fieldc&$text=true&$inactive=true&fruit=apples", hr.QueryString.Value);
 
             var wro = hr.GetRequestOptions();
 
@@ -51,6 +51,32 @@ namespace CoreEx.Test.Framework.WebApis
             Assert.AreEqual(new string[] { "fieldc" }, wro.ExcludeFields);
             Assert.NotNull(wro.Paging);
             Assert.AreEqual(20, wro.Paging!.Skip);
+            Assert.AreEqual(25, wro.Paging.Take);
+            Assert.IsTrue(wro.Paging.IsGetCount);
+        }
+
+
+        [Test]
+        public void GetRequestOptions_Configured_TokenPaging()
+        {
+            using var test = FunctionTester.Create<Startup>();
+            var hr = test.CreateHttpRequest(HttpMethod.Get, "https://unittest");
+            var ro = new HttpRequestOptions { ETag = "etag-value", IncludeText = true, IncludeInactive = true, Paging = PagingArgs.CreateTokenAndTake("token", 25, true), UrlQueryString = "fruit=apples" }.Include("fielda", "fieldb").Exclude("fieldc");
+
+            hr.ApplyRequestOptions(ro);
+            Assert.AreEqual("?$token=token&$take=25&$count=true&$fields=fielda,fieldb&$exclude=fieldc&$text=true&$inactive=true&fruit=apples", hr.QueryString.Value);
+
+            var wro = hr.GetRequestOptions();
+
+            Assert.NotNull(wro);
+            Assert.AreSame(hr, wro.Request);
+            Assert.AreEqual("etag-value", wro.ETag);
+            Assert.IsTrue(wro.IncludeText);
+            Assert.IsTrue(wro.IncludeInactive);
+            Assert.AreEqual(new string[] { "fielda", "fieldb" }, wro.IncludeFields);
+            Assert.AreEqual(new string[] { "fieldc" }, wro.ExcludeFields);
+            Assert.NotNull(wro.Paging);
+            Assert.AreEqual("token", wro.Paging!.Token);
             Assert.AreEqual(25, wro.Paging.Take);
             Assert.IsTrue(wro.Paging.IsGetCount);
         }

--- a/tests/CoreEx.Test/Framework/Wildcards/WildcardTest.cs
+++ b/tests/CoreEx.Test/Framework/Wildcards/WildcardTest.cs
@@ -266,14 +266,14 @@ namespace CoreEx.Test.Framework.Wildcards
         {
             return new List<Person>
             {
-                new Person { First = "Amy", Last = "Johnson" },
-                new Person { First = "Jenny", Last = "Smith" },
-                new Person { First = "Gerry", Last = "McQuire" },
-                new Person { First = "Gary", Last = "Lawson" },
-                new Person { First = "Simon", Last = "Reynolds" },
-                new Person { First = "Amanada", Last = "Gray" },
-                new Person { First = "B", Last = "P" },
-                new Person { First = null, Last = null }
+                new() { First = "Amy", Last = "Johnson" },
+                new() { First = "Jenny", Last = "Smith" },
+                new() { First = "Gerry", Last = "McQuire" },
+                new() { First = "Gary", Last = "Lawson" },
+                new() { First = "Simon", Last = "Reynolds" },
+                new() { First = "Amanada", Last = "Gray" },
+                new() { First = "B", Last = "P" },
+                new() { First = null, Last = null }
             };
         }
 

--- a/tests/CoreEx.TestApi/Controllers/ProductController.cs
+++ b/tests/CoreEx.TestApi/Controllers/ProductController.cs
@@ -5,6 +5,7 @@ using CoreEx.TestFunction.Services;
 using CoreEx.TestFunction.Validators;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
+using System;
 
 namespace CoreEx.TestApi.Controllers
 {
@@ -35,5 +36,9 @@ namespace CoreEx.TestApi.Controllers
         [HttpDelete]
         [Route("{id}")]
         public Task<IActionResult> DeleteAsync(string id) => _webApi.DeleteAsync(Request, _ => _service.DeleteProductAsync(id));
+
+        [HttpGet]
+        [Route("{id}/catalogue")]
+        public Task<IActionResult> GetCatalogueAsync(string id) => _webApi.GetAsync<FileContentResult>(Request, _ => _service.GetCatalogueAsync(id));
     }
 }

--- a/tests/CoreEx.TestFunction/Services/ProductService.cs
+++ b/tests/CoreEx.TestFunction/Services/ProductService.cs
@@ -1,7 +1,9 @@
 ﻿using AutoMapper;
 using CoreEx.TestFunction.Models;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace CoreEx.TestFunction.Services
@@ -52,6 +54,12 @@ namespace CoreEx.TestFunction.Services
         {
             _logger.LogInformation($"Deleting product {id}.");
             return Task.CompletedTask;
+        }
+
+        public Task<FileContentResult> GetCatalogueAsync(string id)
+        {
+            var fcr = new FileContentResult(Encoding.ASCII.GetBytes($"Catalog for '{id}'."), "text/plain");
+            return Task.FromResult(fcr);
         }
     }
 }


### PR DESCRIPTION
- *Enhancement*: The `ValueContentResult.CreateResult` has been updated to return the resulting value as-is where is an instance of `IActionResult`; otherwise, converts `value` to a `ValueContentResult` (previous behavior).
- *Enhancement*: The `PagingArgs` has been extended to support `Token`; being a continuation token to enable paging to be performed where the underlying data source does not support skip/take-style paging.