### PR TITLE
v3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v3.8.1
+- *Fixed*: The `CoreEx.Text.JsonSerializer` has been updated to cache the _indented_ option correctly.
+- *Fixed*: The `ReferenceDataOrchestator` updated to use the correct serializer for `ETag` generation. 
+
 ## v3.8.0
 - *Enhancement*: The `ValueContentResult.CreateResult` has been updated to return the resulting value as-is where is an instance of `IActionResult`; otherwise, converts `value` to a `ValueContentResult` (previous behavior).
 - *Enhancement*: The `PagingArgs` has been extended to support `Token`; being a continuation token to enable paging to be performed where the underlying data source does not support skip/take-style paging.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.8.0</Version>
+		<Version>3.8.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx/Entities/IIdentifier.cs
+++ b/src/CoreEx/Entities/IIdentifier.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using System;
+using System.Text.Json.Serialization;
 
 namespace CoreEx.Entities
 {
@@ -17,9 +18,11 @@ namespace CoreEx.Entities
         /// <summary>
         /// Gets the <see cref="Id"/> <see cref="Type"/>.
         /// </summary>
+        [JsonIgnore]
         Type IdType { get; }
 
         /// <inheritdoc/>
+        [JsonIgnore]
         CompositeKey IEntityKey.EntityKey => new(Id);
     }
 }

--- a/src/CoreEx/Entities/IIdentifierT.cs
+++ b/src/CoreEx/Entities/IIdentifierT.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using System;
+using System.Text.Json.Serialization;
 
 namespace CoreEx.Entities
 {
@@ -21,6 +22,7 @@ namespace CoreEx.Entities
         new TId? Id { get; set; }
 
         /// <inheritdoc/>
+        [JsonIgnore]
         Type IIdentifier.IdType => typeof(TId);
     }
 }

--- a/src/CoreEx/RefData/Extended/ReferenceDataBaseEx.cs
+++ b/src/CoreEx/RefData/Extended/ReferenceDataBaseEx.cs
@@ -41,9 +41,6 @@ namespace CoreEx.RefData.Extended
         }
 
         /// <inheritdoc/>
-        Type IIdentifier.IdType => typeof(TId);
-
-        /// <inheritdoc/>
         object? IIdentifier.Id { get => Id; set => Id = (TId)value!; }
 
         /// <inheritdoc/>

--- a/src/CoreEx/RefData/ReferenceDataOrchestrator.cs
+++ b/src/CoreEx/RefData/ReferenceDataOrchestrator.cs
@@ -312,7 +312,7 @@ namespace CoreEx.RefData
                 var sw = Stopwatch.StartNew();
                 var provider = (IReferenceDataProvider)scope.ServiceProvider.GetRequiredService(providerType);
                 var coll = (await provider.GetAsync(type, cancellationToken).ConfigureAwait(false)).Value;
-                coll.ETag = ETagGenerator.Generate(ServiceProvider.GetRequiredService<IJsonSerializer>(), coll)!;
+                coll.ETag = ETagGenerator.Generate(ServiceProvider.GetRequiredService<IReferenceDataContentJsonSerializer>(), coll)!;
                 sw.Stop();
 
                 Logger.LogInformation("Reference data type {RefDataType} cache load finish: {ItemCount} items cached [{Elapsed}ms]", type.FullName, coll.Count, sw.Elapsed.TotalMilliseconds);

--- a/src/CoreEx/Text/Json/JsonSerializer.cs
+++ b/src/CoreEx/Text/Json/JsonSerializer.cs
@@ -14,11 +14,8 @@ namespace CoreEx.Text.Json
     /// <summary>
     /// Provides the <see cref="Stj.JsonSerializer"/> encapsulated implementation.
     /// </summary>
-    /// <param name="options">The <see cref="Stj.JsonSerializerOptions"/>. Defaults to <see cref="DefaultOptions"/>.</param>
-    public class JsonSerializer(Stj.JsonSerializerOptions? options = null) : IJsonSerializer
+    public class JsonSerializer : IJsonSerializer
     {
-        private Stj.JsonSerializerOptions? _indentedOptions;
-
         /// <summary>
         /// Gets or sets the default <see cref="Stj.JsonSerializerOptions"/>.
         /// </summary>
@@ -41,6 +38,16 @@ namespace CoreEx.Text.Json
         };
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="JsonSerializer"/> class.
+        /// </summary>
+        /// <param name="options">The <see cref="Stj.JsonSerializerOptions"/>. Defaults to <see cref="DefaultOptions"/>.</param>
+        public JsonSerializer(Stj.JsonSerializerOptions? options = null)
+        {
+            Options = options ?? DefaultOptions;
+            IndentedOptions = new Stj.JsonSerializerOptions(Options) { WriteIndented = true };
+        }
+
+        /// <summary>
         /// Gets the underlying serializer configuration settings/options.
         /// </summary>
         object IJsonSerializer.Options => Options;
@@ -48,14 +55,19 @@ namespace CoreEx.Text.Json
         /// <summary>
         /// Gets the <see cref="Stj.JsonSerializerOptions"/>.
         /// </summary>
-        public Stj.JsonSerializerOptions Options { get; } = options ?? DefaultOptions;
+        public Stj.JsonSerializerOptions Options { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Stj.JsonSerializerOptions"/> with <see cref="Stj.JsonSerializerOptions.WriteIndented"/> = <c>true</c>.
+        /// </summary>
+        public Stj.JsonSerializerOptions? IndentedOptions { get; }
 
         /// <inheritdoc/>
         public string Serialize<T>(T value, JsonWriteFormat? format = null) => SerializeToBinaryData(value, format).ToString();
 
         /// <inheritdoc/>
         public BinaryData SerializeToBinaryData<T>(T value, JsonWriteFormat? format = null) 
-            => new(Stj.JsonSerializer.SerializeToUtf8Bytes(value, format == null ? Options : (_indentedOptions ??= new Stj.JsonSerializerOptions(Options) { WriteIndented = format.Value == JsonWriteFormat.Indented })));
+            => new(Stj.JsonSerializer.SerializeToUtf8Bytes(value, format == null || format.Value == JsonWriteFormat.None ? Options : IndentedOptions));
 
         /// <inheritdoc/>
         public object? Deserialize(string json) => Stj.JsonSerializer.Deserialize<dynamic>(json, Options);

--- a/tests/CoreEx.Test/Framework/RefData/ReferenceDataTest.cs
+++ b/tests/CoreEx.Test/Framework/RefData/ReferenceDataTest.cs
@@ -53,8 +53,6 @@ namespace CoreEx.Test.Framework.RefData
             Assert.AreSame(ir.IdType, typeof(int));
 
             Assert.AreEqual("{\"id\":1,\"code\":\"X\",\"text\":\"XX\",\"isActive\":true}", new CoreEx.Text.Json.ReferenceDataContentJsonSerializer().Serialize(r));
-
-            Assert.AreEqual("{\"id\":1,\"code\":\"X\",\"text\":\"XX\",\"isActive\":true}", new CoreEx.Text.Json.ReferenceDataContentJsonSerializer().Serialize(ir));
         }
 
         [Test]

--- a/tests/CoreEx.Test/Framework/RefData/ReferenceDataTest.cs
+++ b/tests/CoreEx.Test/Framework/RefData/ReferenceDataTest.cs
@@ -53,6 +53,8 @@ namespace CoreEx.Test.Framework.RefData
             Assert.AreSame(ir.IdType, typeof(int));
 
             Assert.AreEqual("{\"id\":1,\"code\":\"X\",\"text\":\"XX\",\"isActive\":true}", new CoreEx.Text.Json.ReferenceDataContentJsonSerializer().Serialize(r));
+
+            Assert.AreEqual("{\"id\":1,\"code\":\"X\",\"text\":\"XX\",\"isActive\":true}", new CoreEx.Text.Json.ReferenceDataContentJsonSerializer().Serialize(ir));
         }
 
         [Test]


### PR DESCRIPTION
- *Fixed*: The `CoreEx.Text.JsonSerializer` has been updated to cache the _indented_ option correctly.
- *Fixed*: The `ReferenceDataOrchestator` updated to use the correct serializer for `ETag` generation. 
