### PR TITLE
v3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v3.10.0
+- *Enhancement*: The `WebApiPublisher` publishing methods have been simplified (breaking change), primarily through the use of a new _argument_ that encapsulates the various related options. This will enable the addition of further options in the future without resulting in breaking changes or adding unneccessary complexities. The related [`README`](./src/CoreEx.AspNetCore/WebApis/README.md) has been updated to document.
+- *Enhancement*: Added `ValidationUseJsonNames` to `SettingsBase` (defaults to `true`) to allow setting `ValidationArgs.DefaultUseJsonNames` to be configurable.
+
 ## v3.9.0
 - *Enhancement*: A new `Abstractions.ServiceBusMessageActions` has been created to encapsulate either a `Microsoft.Azure.WebJobs.ServiceBus.ServiceBusMessageActions` (existing [_in-process_](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library) function support) or `Microsoft.Azure.Functions.Worker.ServiceBusMessageActions` (new [_isolated_](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide) function support) and used internally. Implicit conversion is enabled to simplify usage; existing projects will need to be recompiled. The latter capability does not support `RenewAsync` and as such this capability is no longer leveraged for consistency; review documented [`PeekLock`](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger?tabs=python-v2%2Cisolated-process%2Cnodejs-v4%2Cextensionv5&pivots=programming-language-csharp#peeklock-behavior) behavior to get desired outcome.
 - *Enhancement*: The `Result`, `Result<T>`, `PagingArgs` and `PagingResult` have had `IEquatable` added to enable equality comparisons.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.9.0</Version>
+		<Version>3.10.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/My.Hr/My.Hr.Functions/Functions/HttpTriggerQueueVerificationFunction.cs
+++ b/samples/My.Hr/My.Hr.Functions/Functions/HttpTriggerQueueVerificationFunction.cs
@@ -33,5 +33,5 @@ public class HttpTriggerQueueVerificationFunction
     [OpenApiRequestBody(MediaTypeNames.Application.Json, typeof(EmployeeVerificationRequest), Description = "The **EmployeeVerification** payload")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.Accepted, contentType: MediaTypeNames.Text.Plain, bodyType: typeof(string), Description = "The OK response")]
     public Task<IActionResult> RunAsync([HttpTrigger(AuthorizationLevel.Function, "post", Route = "employee/verify")] HttpRequest request)
-        => _webApiPublisher.PublishAsync(request, _settings.VerificationQueueName, validator: new EmployeeVerificationValidator().Wrap());
+        => _webApiPublisher.PublishAsync(request, new WebApiPublisherArgs<EmployeeVerificationRequest>(_settings.VerificationQueueName) { Validator = new EmployeeVerificationValidator().Wrap() });
 }

--- a/src/CoreEx.AspNetCore/Abstractions/AspNetCoreServiceCollectionExtensions.cs
+++ b/src/CoreEx.AspNetCore/Abstractions/AspNetCoreServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Checks that the <see cref="IServiceCollection"/> is not null.
         /// </summary>
-        private static IServiceCollection CheckServices(IServiceCollection services) => services ?? throw new ArgumentNullException(nameof(services));
+        private static IServiceCollection CheckServices(IServiceCollection services) => services.ThrowIfNull(nameof(services));
 
         /// <summary>
         /// Adds the <see cref="WebApi"/> as a scoped service.

--- a/src/CoreEx.AspNetCore/HealthChecks/HealthService.cs
+++ b/src/CoreEx.AspNetCore/HealthChecks/HealthService.cs
@@ -15,21 +15,11 @@ namespace CoreEx.AspNetCore.HealthChecks
     /// <summary>
     /// Provides the Health Check service.
     /// </summary>
-    public class HealthService
+    public class HealthService(SettingsBase settings, HealthCheckService healthCheckService, IJsonSerializer jsonSerializer)
     {
-        private readonly SettingsBase _settings;
-        private readonly HealthCheckService _healthCheckService;
-        private readonly IJsonSerializer _jsonSerializer;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HealthService"/> class.
-        /// </summary>
-        public HealthService(SettingsBase settings, HealthCheckService healthCheckService, IJsonSerializer jsonSerializer)
-        {
-            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
-            _healthCheckService = healthCheckService ?? throw new ArgumentNullException(nameof(healthCheckService));
-            _jsonSerializer = jsonSerializer ?? throw new ArgumentNullException(nameof(jsonSerializer));
-        }
+        private readonly SettingsBase _settings = settings.ThrowIfNull(nameof(settings));
+        private readonly HealthCheckService _healthCheckService = healthCheckService.ThrowIfNull(nameof(healthCheckService));
+        private readonly IJsonSerializer _jsonSerializer = jsonSerializer.ThrowIfNull(nameof(jsonSerializer));
 
         /// <summary>
         /// Runs the health check and returns JSON result.

--- a/src/CoreEx.AspNetCore/Http/HttpResultExtensions.cs
+++ b/src/CoreEx.AspNetCore/Http/HttpResultExtensions.cs
@@ -38,8 +38,7 @@ namespace CoreEx.AspNetCore.Http
         /// <remarks>This will automatically invoke <see cref="ApplyETag(HttpRequest, string)"/> where there is an <see cref="HttpRequestOptions.ETag"/> value.</remarks>
         public static HttpRequest ApplyRequestOptions(this HttpRequest httpRequest, HttpRequestOptions? requestOptions)
         {
-            if (httpRequest == null)
-                throw new ArgumentNullException(nameof(httpRequest));
+            httpRequest.ThrowIfNull(nameof(httpRequest));
 
             if (requestOptions == null)
                 return httpRequest;
@@ -87,8 +86,7 @@ namespace CoreEx.AspNetCore.Http
         /// <returns>The <see cref="HttpRequestJsonValue{T}"/>.</returns>
         public static async Task<HttpRequestJsonValue<T>> ReadAsJsonValueAsync<T>(this HttpRequest httpRequest, IJsonSerializer jsonSerializer, bool valueIsRequired = true, IValidator<T>? validator = null, CancellationToken cancellationToken = default)
         {
-            if (httpRequest == null)
-                throw new ArgumentNullException(nameof(httpRequest));
+            httpRequest.ThrowIfNull(nameof(httpRequest));
 
             var content = await BinaryData.FromStreamAsync(httpRequest.Body, cancellationToken).ConfigureAwait(false);
             var jv = new HttpRequestJsonValue<T>();
@@ -97,7 +95,7 @@ namespace CoreEx.AspNetCore.Http
             try
             {
                 if (content.ToMemory().Length > 0)
-                    jv.Value = (jsonSerializer ?? throw new ArgumentNullException(nameof(jsonSerializer))).Deserialize<T>(content)!;
+                    jv.Value = jsonSerializer.ThrowIfNull(nameof(jsonSerializer)).Deserialize<T>(content)!;
 
                 if (valueIsRequired && jv.Value == null)
                     jv.ValidationException = new ValidationException($"{InvalidJsonMessagePrefix} Value is mandatory.");
@@ -138,7 +136,7 @@ namespace CoreEx.AspNetCore.Http
         /// </summary>
         /// <param name="httpRequest">The <see cref="HttpRequest"/>.</param>
         /// <returns>The <see cref="WebApiRequestOptions"/>.</returns>
-        public static WebApiRequestOptions GetRequestOptions(this HttpRequest httpRequest) => new(httpRequest ?? throw new ArgumentNullException(nameof(httpRequest)));
+        public static WebApiRequestOptions GetRequestOptions(this HttpRequest httpRequest) => new(httpRequest.ThrowIfNull(nameof(httpRequest)));
 
         /// <summary>
         /// Adds the <see cref="PagingArgs"/> to the <see cref="IHeaderDictionary"/>.

--- a/src/CoreEx.AspNetCore/WebApis/AcceptsBodyAttribute.cs
+++ b/src/CoreEx.AspNetCore/WebApis/AcceptsBodyAttribute.cs
@@ -9,29 +9,20 @@ namespace CoreEx.AspNetCore.WebApis
     /// An attribute that specifies the expected request <b>body</b> <see cref="Type"/> that the action/operation accepts and the supported request content types.
     /// </summary>
     /// <remarks>The is used to enable <i>Swagger/Swashbuckle</i> generated documentation where the operation does not explicitly define the body as a method parameter; i.e. via <see cref="Microsoft.AspNetCore.Mvc.FromBodyAttribute"/>.</remarks>
+    /// <param name="type">The <b>body</b> <see cref="Type"/>.</param>
+    /// <param name="contentTypes">The <b>body</b> content type(s). Defaults to <see cref="MediaTypeNames.Application.Json"/>.</param>
+    /// <exception cref="ArgumentNullException"></exception>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public sealed class AcceptsBodyAttribute : Attribute
+    public sealed class AcceptsBodyAttribute(Type type, params string[] contentTypes) : Attribute
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AcceptsBodyAttribute"/> class.
-        /// </summary>
-        /// <param name="type">The <b>body</b> <see cref="Type"/>.</param>
-        /// <param name="contentTypes">The <b>body</b> content type(s). Defaults to <see cref="MediaTypeNames.Application.Json"/>.</param>
-        /// <exception cref="ArgumentNullException"></exception>
-        public AcceptsBodyAttribute(Type type, params string[] contentTypes)
-        {
-            BodyType = type ?? throw new ArgumentNullException(nameof(type));
-            ContentTypes = contentTypes.Length == 0 ? new string[] { MediaTypeNames.Application.Json } : contentTypes;
-        }
-
         /// <summary>
         /// Gets the <b>body</b> <see cref="Type"/>.
         /// </summary>
-        public Type BodyType { get; }
+        public Type BodyType { get; } = type.ThrowIfNull(nameof(type));
 
         /// <summary>
         /// Gets the <b>body</b> content type(s).
         /// </summary>
-        public string[] ContentTypes { get; }
+        public string[] ContentTypes { get; } = contentTypes.Length == 0 ? [MediaTypeNames.Application.Json] : contentTypes;
     }
 }

--- a/src/CoreEx.AspNetCore/WebApis/ExtendedStatusCodeResult.cs
+++ b/src/CoreEx.AspNetCore/WebApis/ExtendedStatusCodeResult.cs
@@ -12,14 +12,9 @@ namespace CoreEx.AspNetCore.WebApis
     /// <summary>
     /// Represents an extended <see cref="StatusCodeResult"/> that enables customization of the <see cref="HttpResponse"/>.
     /// </summary>
-    public class ExtendedStatusCodeResult : StatusCodeResult
+    /// <param name="statusCode">The <see cref="HttpStatusCode"/>.</param>
+    public class ExtendedStatusCodeResult(HttpStatusCode statusCode) : StatusCodeResult((int)statusCode)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ExtendedStatusCodeResult"/> class.
-        /// </summary>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/>.</param>
-        public ExtendedStatusCodeResult(HttpStatusCode statusCode) : base((int)statusCode) { }
-
         /// <summary>
         /// Gets or sets the <see cref="Microsoft.AspNetCore.Http.Headers.ResponseHeaders.Location"/> <see cref="Uri"/>.
         /// </summary>

--- a/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherArgs.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Events;
+using CoreEx.Mapping;
+using CoreEx.Results;
+using CoreEx.Validation;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Enables the <see cref="WebApiPublisher"/> arguments.
+    /// </summary>
+    /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different then a <see cref="Mapper"/> will be required).</typeparam>
+    public interface IWebApiPublisherArgs<TValue, TEventValue>
+    {
+        /// <summary>
+        /// Indicates whether the <typeparamref name="TValue"/> and <typeparamref name="TEventValue"/> are the same <see cref="Type"/>.
+        /// </summary>
+        internal bool AreSameType => typeof(TValue) == typeof(TEventValue);
+
+        /// <summary>
+        /// Gets or sets the optional event destintion name (e.g. Queue or Topic name).
+        /// </summary>
+        /// <remarks>Will leverage either <see cref="IEventPublisher.Publish(EventData[])"/> or <see cref="IEventPublisher.PublishNamed(string, EventData[])"/> depending on whether name is specified or not.</remarks>
+        string? EventName { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="HttpStatusCode"/> where successful.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="HttpStatusCode.Accepted"/>.</remarks>
+        HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets or sets the optional validator.
+        /// </summary>
+        IValidator<TValue>? Validator { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="CoreEx.OperationType"/>.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="OperationType.Unspecified"/>.</remarks>
+        OperationType OperationType { get; }
+
+        /// <summary>
+        /// Gets or sets the on before validation <typeparamref name="TValue"/> modifier function.
+        /// </summary>
+        /// <remarks>Enables the value to be modified before validation. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? OnBeforeValidationAsync { get; }
+
+        /// <summary>
+        /// Gets or sets the after validation / on before event <typeparamref name="TValue"/> modifier function.
+        /// </summary>
+        /// <remarks>Enables the value to be modified after validation. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? OnBeforeEventAsync { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="EventData"/> modifier function.
+        /// </summary>
+        /// <remarks>Enables the corresponding <see cref="EventData"/> to be modified prior to publish.</remarks>
+        Action<EventData>? OnEvent { get; }
+
+        /// <summary>
+        /// Gets or sets the <typeparamref name="TValue"/> to <typeparamref name="TEventValue"/> <see cref="IMapper{TSource, TDestination}"/> override.
+        /// </summary>
+        /// <remarks>Where <c>null</c> the <see cref="WebApiPublisher.Mapper"/> will be used to get the corresponding <see cref="IMapper{TSource, TDestination}"/> instance to perform the underlying mapping.</remarks>
+        IMapper<TValue, TEventValue>? Mapper { get; }
+        
+        /// <summary>
+        /// Gets or sets the function to override the creation of the success <see cref="IActionResult"/>.
+        /// </summary>
+        /// <remarks>Defaults to a <see cref="ExtendedStatusCodeResult"/> using the defined <see cref="StatusCode"/>.</remarks>
+        Func<IActionResult>? CreateSuccessResult { get; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherCollectionArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherCollectionArgs.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Configuration;
+using CoreEx.Events;
+using CoreEx.Mapping;
+using CoreEx.Results;
+using CoreEx.Validation;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Enables the <see cref="WebApiPublisher"/> collection-based arguments.
+    /// </summary>
+    /// <typeparam name="TColl">The request JSON collection <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TEventItem">The <typeparamref name="TItem"/>-equivalent <see cref="EventData.Value"/> <see cref="Type"/> (where different then a <see cref="Mapper"/> will be required).</typeparam>
+    public interface IWebApiPublisherCollectionArgs<TColl, TItem, TEventItem> where TColl : IEnumerable<TItem>
+    {
+        /// <summary>
+        /// Indicates whether the <typeparamref name="TItem"/> and <typeparamref name="TEventItem"/> are the same <see cref="Type"/>.
+        /// </summary>
+        internal bool AreSameType => typeof(TItem) == typeof(TEventItem);
+
+        /// <summary>
+        /// Gets or sets the optional event destintion name (e.g. Queue or Topic name).
+        /// </summary>
+        /// <remarks>Will leverage either <see cref="IEventPublisher.Publish(EventData[])"/> or <see cref="IEventPublisher.PublishNamed(string, EventData[])"/> depending on whether name is specified or not.</remarks>
+        string? EventName { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="HttpStatusCode"/> where successful.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="HttpStatusCode.Accepted"/>.</remarks>
+        HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets or sets the maximum collection size.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="SettingsBase.MaxPublishCollSize"/>.</remarks>
+        int? MaxCollectionSize { get; }
+
+        /// <summary>
+        /// Gets or sets the optional validator
+        /// </summary>
+        IValidator<TColl>? Validator { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="CoreEx.OperationType"/>.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="OperationType.Unspecified"/>.</remarks>
+        OperationType OperationType { get; }
+
+        /// <summary>
+        /// Gets or sets the on before validation <typeparamref name="TColl"/> modifier function.
+        /// </summary>
+        /// <remarks>Enables the value to be modified before validation. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        Func<WebApiParam<TColl>, CancellationToken, Task<Result>>? OnBeforeValidationAsync { get; }
+
+        /// <summary>
+        /// Gets or sets the after validation / on before event <typeparamref name="TColl"/> modifier function.
+        /// </summary>
+        /// <remarks>Enables the value to be modified after validation. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        Func<WebApiParam<TColl>, CancellationToken, Task<Result>>? OnBeforeEventAsync { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="EventData"/> modifier function.
+        /// </summary>
+        /// <remarks>Enables the corresponding <see cref="EventData"/> to be modified prior to publish.</remarks>
+        Action<EventData>? OnEvent { get; }
+
+        /// <summary>
+        /// Gets or sets the <typeparamref name="TItem"/> to <typeparamref name="TEventItem"/> <see cref="IMapper{TSource, TDestination}"/> override.
+        /// </summary>
+        /// <remarks>Where <c>null</c> the <see cref="WebApiPublisher.Mapper"/> will be used to get the corresponding <see cref="IMapper{TSource, TDestination}"/> instance to perform the underlying mapping.</remarks>
+        IMapper<TItem, TEventItem>? Mapper { get; }
+
+        /// <summary>
+        /// Gets or sets the function to override the creation of the success <see cref="IActionResult"/>.
+        /// </summary>
+        /// <remarks>Defaults to a <see cref="ExtendedStatusCodeResult"/> using the defined <see cref="StatusCode"/>.</remarks>
+        Func<IActionResult>? CreateSuccessResult { get; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/ReferenceDataContentWebApi.cs
+++ b/src/CoreEx.AspNetCore/WebApis/ReferenceDataContentWebApi.cs
@@ -13,18 +13,12 @@ namespace CoreEx.AspNetCore.WebApis
     /// Provides the core (<see cref="HttpMethods.Get"/>, <see cref="HttpMethods.Post"/>, <see cref="HttpMethods.Put"/> and <see cref="HttpMethods.Delete"/>) Web API execution encapsulation that uses the <see cref="IReferenceDataContentJsonSerializer"/>
     /// to allow <see cref="IReferenceData"/> types to serialize contents.
     /// </summary>
-    public class ReferenceDataContentWebApi : WebApi
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WebApi"/> class.
-        /// </summary>
-        /// <param name="executionContext">The <see cref="ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        /// <param name="invoker">The <see cref="WebApiInvoker"/>; defaults where not specified.</param>
-        /// <param name="jsonMergePatch">The <see cref="IJsonMergePatch"/> to support the <see cref="HttpMethods.Patch"/> operations.</param>
-        public ReferenceDataContentWebApi(ExecutionContext executionContext, SettingsBase settings, IReferenceDataContentJsonSerializer jsonSerializer, ILogger<WebApi> logger, WebApiInvoker? invoker = null, IJsonMergePatch? jsonMergePatch = null)
-            : base(executionContext, settings, jsonSerializer, logger, invoker, jsonMergePatch) { }
-    }
+    /// <param name="executionContext">The <see cref="ExecutionContext"/>.</param>
+    /// <param name="settings">The <see cref="SettingsBase"/>.</param>
+    /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
+    /// <param name="logger">The <see cref="ILogger"/>.</param>
+    /// <param name="invoker">The <see cref="WebApiInvoker"/>; defaults where not specified.</param>
+    /// <param name="jsonMergePatch">The <see cref="IJsonMergePatch"/> to support the <see cref="HttpMethods.Patch"/> operations.</param>
+    public class ReferenceDataContentWebApi(ExecutionContext executionContext, SettingsBase settings, IReferenceDataContentJsonSerializer jsonSerializer, ILogger<WebApi> logger, WebApiInvoker? invoker = null, IJsonMergePatch? jsonMergePatch = null)
+        : WebApi(executionContext, settings, jsonSerializer, logger, invoker, jsonMergePatch) { }
 }

--- a/src/CoreEx.AspNetCore/WebApis/ValueContentResult.cs
+++ b/src/CoreEx.AspNetCore/WebApis/ValueContentResult.cs
@@ -34,7 +34,7 @@ namespace CoreEx.AspNetCore.WebApis
         /// <param name="etag">The related <see cref="IETag.ETag"/>.</param>
         /// <param name="pagingResult">The related <see cref="ICollectionResult.Paging"/>.</param>
         /// <param name="location">The <see cref="Microsoft.AspNetCore.Http.Headers.ResponseHeaders.Location"/> <see cref="Uri"/>.</param>
-        private ValueContentResult(string content, HttpStatusCode statusCode, string? etag, PagingResult? pagingResult, Uri? location)
+        public ValueContentResult(string content, HttpStatusCode statusCode, string? etag, PagingResult? pagingResult, Uri? location)
         {
             Content = content;
             ContentType = MediaTypeNames.Application.Json;

--- a/src/CoreEx.AspNetCore/WebApis/WebApi.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApi.cs
@@ -90,11 +90,8 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> RunAsync<TValue>(HttpRequest request, Func<WebApiParam<TValue>, CancellationToken, Task<IActionResult>> function, OperationType operationType = OperationType.Unspecified,
             bool valueIsRequired = true, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -136,14 +133,11 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> GetAsync<TResult>(HttpRequest request, Func<WebApiParam, CancellationToken, Task<TResult>> function, HttpStatusCode statusCode = HttpStatusCode.OK, 
             HttpStatusCode alternateStatusCode = HttpStatusCode.NotFound, OperationType operationType = OperationType.Read, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsGet(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Get}' to use {nameof(GetAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -180,14 +174,11 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> PostAsync(HttpRequest request, Func<WebApiParam, CancellationToken, Task> function, HttpStatusCode statusCode = HttpStatusCode.OK, OperationType operationType = OperationType.Create,
             Func<Uri>? locationUri = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPost(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PostAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -270,14 +261,11 @@ namespace CoreEx.AspNetCore.WebApis
         private async Task<IActionResult> PostInternalAsync<TValue>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task> function, HttpStatusCode statusCode = HttpStatusCode.OK,
             OperationType operationType = OperationType.Create, bool valueIsRequired = true, IValidator<TValue>? validator = null, Func<Uri>? locationUri = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPost(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PostAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -320,14 +308,11 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> PostAsync<TResult>(HttpRequest request, Func<WebApiParam, CancellationToken, Task<TResult>> function, HttpStatusCode statusCode = HttpStatusCode.OK,
             HttpStatusCode alternateStatusCode = HttpStatusCode.NoContent, OperationType operationType = OperationType.Create, Func<TResult, Uri>? locationUri = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPost(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PostAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -418,14 +403,11 @@ namespace CoreEx.AspNetCore.WebApis
         private async Task<IActionResult> PostInternalAsync<TValue, TResult>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task<TResult>> function, HttpStatusCode statusCode = HttpStatusCode.OK, HttpStatusCode alternateStatusCode = HttpStatusCode.NoContent,
             OperationType operationType = OperationType.Create, bool valueIsRequired = true, IValidator<TValue>? validator = null, Func<TResult, Uri>? locationUri = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPost(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PostAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -512,14 +494,11 @@ namespace CoreEx.AspNetCore.WebApis
         private async Task<IActionResult> PutInternalAsync<TValue>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task> function, HttpStatusCode statusCode = HttpStatusCode.NoContent,
             OperationType operationType = OperationType.Update, bool valueIsRequired = true, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPut(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Put}' to use {nameof(PutAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -610,14 +589,11 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> PutInternalAsync<TValue, TResult>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task<TResult>> function, HttpStatusCode statusCode = HttpStatusCode.OK,
             HttpStatusCode alternateStatusCode = HttpStatusCode.NoContent, OperationType operationType = OperationType.Update, bool valueIsRequired = true, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPut(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Put}' to use {nameof(PutAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -704,17 +680,12 @@ namespace CoreEx.AspNetCore.WebApis
         private async Task<IActionResult> PutInternalAsync<TValue>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam, CancellationToken, Task<TValue?>> get, Func<WebApiParam<TValue>, CancellationToken, Task<TValue>> put, HttpStatusCode statusCode = HttpStatusCode.OK,
             OperationType operationType = OperationType.Update, IValidator<TValue>? validator = null, bool simulatedConcurrency = false, CancellationToken cancellationToken = default) where TValue : class
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            get.ThrowIfNull(nameof(get));
+            put.ThrowIfNull(nameof(put));
 
             if (!HttpMethods.IsPut(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Put}' to use {nameof(PutAsync)}.", nameof(request));
-
-            if (get == null)
-                throw new ArgumentNullException(nameof(get));
-
-            if (put == null)
-                throw new ArgumentNullException(nameof(put));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -785,14 +756,11 @@ namespace CoreEx.AspNetCore.WebApis
         /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
         public async Task<IActionResult> DeleteAsync(HttpRequest request, Func<WebApiParam, CancellationToken, Task> function, HttpStatusCode statusCode = HttpStatusCode.NoContent, OperationType operationType = OperationType.Delete, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsDelete(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Delete}' to use {nameof(DeleteAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -844,20 +812,15 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> PatchAsync<TValue>(HttpRequest request, Func<WebApiParam, CancellationToken, Task<TValue?>> get, Func<WebApiParam<TValue>, CancellationToken, Task<TValue>> put, HttpStatusCode statusCode = HttpStatusCode.OK,
             OperationType operationType = OperationType.Update, IValidator<TValue>? validator = null, bool simulatedConcurrency = false, CancellationToken cancellationToken = default) where TValue : class
         {
+            request.ThrowIfNull(nameof(request));
+            get.ThrowIfNull(nameof(get));
+            put.ThrowIfNull(nameof(put));
+
             if (JsonMergePatch == null)
                 throw new InvalidOperationException($"To use the '{nameof(PatchAsync)}' methods the '{nameof(JsonMergePatch)}' object must be passed in the constructor. Where using dependency injection consider using '{nameof(Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.AddJsonMergePatch)}' to add and configure the supported options.");
 
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-
             if (!HttpMethods.IsPatch(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Patch}' to use {nameof(PatchAsync)}.", nameof(request));
-
-            if (get == null)
-                throw new ArgumentNullException(nameof(get));
-
-            if (put == null)
-                throw new ArgumentNullException(nameof(put));
 
             return await RunAsync(request, async (wap, ct) =>
             {

--- a/src/CoreEx.AspNetCore/WebApis/WebApiExceptionHandlerMiddleware.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiExceptionHandlerMiddleware.cs
@@ -15,25 +15,14 @@ namespace CoreEx.AspNetCore.WebApis
     /// <summary>
     /// Provides a <b>CoreEx</b> oriented <see cref="Exception"/> handling middleware that is <see cref="IExtendedException"/> result aware.
     /// </summary>
-    public class WebApiExceptionHandlerMiddleware
+    /// <param name="next">The next <see cref="RequestDelegate"/>.</param>
+    /// <param name="settings">The <see cref="SettingsBase"/>.</param>
+    /// <param name="logger">The <see cref="ILogger"/>.</param>
+    public class WebApiExceptionHandlerMiddleware(RequestDelegate next, SettingsBase settings, ILogger<WebApiExceptionHandlerMiddleware> logger)
     {
-        private readonly RequestDelegate _next;
-        private readonly SettingsBase _settings;
-        private readonly ILogger _logger;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WebApiExceptionHandlerMiddleware"/>.
-        /// </summary>
-        /// <param name="next">The next <see cref="RequestDelegate"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        /// <exception cref="ArgumentNullException"></exception>
-        public WebApiExceptionHandlerMiddleware(RequestDelegate next, SettingsBase settings, ILogger<WebApiExceptionHandlerMiddleware> logger)
-        {
-            _next = next ?? throw new ArgumentNullException(nameof(next));
-            _settings = settings ?? throw new ArgumentNullException(nameof(settings));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        }
+        private readonly RequestDelegate _next = next.ThrowIfNull(nameof(next));
+        private readonly SettingsBase _settings = settings.ThrowIfNull(nameof(settings));
+        private readonly ILogger _logger = logger.ThrowIfNull(nameof(logger));
 
         /// <summary>
         /// Invokes the <see cref="WebApiExceptionHandlerMiddleware"/>.

--- a/src/CoreEx.AspNetCore/WebApis/WebApiExecutionContextMiddleware.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiExecutionContextMiddleware.cs
@@ -11,10 +11,12 @@ namespace CoreEx.AspNetCore.WebApis
     /// Provides an <see cref="ExecutionContext"/> handling middleware that (using dependency injection) enables additional configuration where required.
     /// </summary>
     /// <remarks>A new <see cref="ExecutionContext"/> <see cref="ExecutionContext.Current"/> is instantiated through dependency injection using the <see cref="HttpContext.RequestServices"/>.</remarks>
-    public class WebApiExecutionContextMiddleware
+    /// <param name="next">The next <see cref="RequestDelegate"/>.</param>
+    /// <param name="executionContextUpdate">The optional function to update the <see cref="ExecutionContext"/>. Defaults to <see cref="DefaultExecutionContextUpdate(HttpContext, ExecutionContext)"/> where not specified.</param>
+    public class WebApiExecutionContextMiddleware(RequestDelegate next, Func<HttpContext, ExecutionContext, Task>? executionContextUpdate = null)
     {
-        private readonly RequestDelegate _next;
-        private readonly Func<HttpContext, ExecutionContext, Task> _updateFunc;
+        private readonly RequestDelegate _next = next.ThrowIfNull(nameof(next));
+        private readonly Func<HttpContext, ExecutionContext, Task> _updateFunc = executionContextUpdate ?? DefaultExecutionContextUpdate;
 
         /// <summary>
         /// Gets the default username where it is unable to be inferred (<see cref="System.Security.Principal.IIdentity.Name"/> from the <see cref="HttpContext"/> <see cref="HttpContext.User"/>).
@@ -30,26 +32,12 @@ namespace CoreEx.AspNetCore.WebApis
         /// <remarks>The <see cref="ExecutionContext.UserName"/> will be set to the <see cref="System.Security.Principal.IIdentity.Name"/> from the <see cref="HttpContext"/> <see cref="HttpContext.User"/>; otherwise, <see cref="DefaultUsername"/> where <c>null</c>.</remarks>
         public static Task DefaultExecutionContextUpdate(HttpContext context, ExecutionContext ec)
         {
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
-
-            if (ec == null)
-                throw new ArgumentNullException(nameof(ec));
+            context.ThrowIfNull(nameof(context));
+            ec.ThrowIfNull(nameof(ec));
 
             ec.UserName = context.User?.Identity?.Name ?? DefaultUsername;
             ec.Timestamp = context.RequestServices.GetService<ISystemTime>()?.UtcNow ?? SystemTime.Default.UtcNow;
             return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WebApiExecutionContextMiddleware"/>.
-        /// </summary>
-        /// <param name="next">The next <see cref="RequestDelegate"/>.</param>
-        /// <param name="executionContextUpdate">The optional function to update the <see cref="ExecutionContext"/>. Defaults to <see cref="DefaultExecutionContextUpdate(HttpContext, ExecutionContext)"/> where not specified.</param>
-        public WebApiExecutionContextMiddleware(RequestDelegate next, Func<HttpContext, ExecutionContext, Task>? executionContextUpdate = null)
-        {
-            _next = next ?? throw new ArgumentNullException(nameof(next));
-            _updateFunc = executionContextUpdate ?? DefaultExecutionContextUpdate;
         }
 
         /// <summary>
@@ -59,8 +47,7 @@ namespace CoreEx.AspNetCore.WebApis
         /// <returns>The <see cref="Task"/>.</returns>
         public async Task InvokeAsync(HttpContext context)
         {
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
+            context.ThrowIfNull(nameof(context));
 
             var ec = context.RequestServices.GetRequiredService<ExecutionContext>();
             ec.ServiceProvider ??= context.RequestServices;

--- a/src/CoreEx.AspNetCore/WebApis/WebApiParam.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiParam.cs
@@ -9,25 +9,15 @@ namespace CoreEx.AspNetCore.WebApis
     /// <summary>
     /// Represents a <see cref="WebApi"/> parameter.
     /// </summary>
-    public class WebApiParam
+    /// <param name="webApi">The parent <see cref="WebApiBase"/> instance.</param>
+    /// <param name="requestOptions">The <see cref="WebApiRequestOptions"/>.</param>
+    /// <param name="operationType">The <see cref="CoreEx.OperationType"/>.</param>
+    public class WebApiParam(WebApiBase webApi, WebApiRequestOptions requestOptions, OperationType operationType = OperationType.Unspecified)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WebApiParam"/> class.
-        /// </summary>
-        /// <param name="webApi">The parent <see cref="WebApiBase"/> instance.</param>
-        /// <param name="requestOptions">The <see cref="WebApiRequestOptions"/>.</param>
-        /// <param name="operationType">The <see cref="CoreEx.OperationType"/>.</param>
-        public WebApiParam(WebApiBase webApi, WebApiRequestOptions requestOptions, OperationType operationType = OperationType.Unspecified)
-        {
-            WebApi = webApi ?? throw new ArgumentNullException(nameof(webApi));
-            RequestOptions = requestOptions ?? throw new ArgumentNullException(nameof(requestOptions));
-            OperationType = operationType;
-        }
-
         /// <summary>
         /// Gets the parent (invoking) <see cref="WebApi"/>.
         /// </summary>
-        public WebApiBase WebApi { get; }
+        public WebApiBase WebApi { get; } = webApi.ThrowIfNull(nameof(webApi));
 
         /// <summary>
         /// Gets or sets the <see cref="HttpRequest"/>.
@@ -37,7 +27,7 @@ namespace CoreEx.AspNetCore.WebApis
         /// <summary>
         /// Gets or sets the <see cref="WebApiRequestOptions"/>.
         /// </summary>
-        public WebApiRequestOptions RequestOptions { get; }
+        public WebApiRequestOptions RequestOptions { get; } = requestOptions.ThrowIfNull(nameof(requestOptions));
 
         /// <summary>
         /// Gets the <see cref="Entities.PagingArgs"/>.
@@ -47,7 +37,7 @@ namespace CoreEx.AspNetCore.WebApis
         /// <summary>
         /// Gets the <see cref="CoreEx.OperationType"/>.
         /// </summary>
-        public OperationType OperationType { get; }
+        public OperationType OperationType { get; } = operationType;
 
         /// <summary>
         /// Inspects the <paramref name="value"/> to either update the <see cref="WebApiRequestOptions.ETag"/> or <paramref name="value"/> <see cref="IETag.ETag"/> where appropriate.

--- a/src/CoreEx.AspNetCore/WebApis/WebApiParamT.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiParamT.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
-using System;
-
 namespace CoreEx.AspNetCore.WebApis
 {
     /// <summary>
@@ -14,7 +12,7 @@ namespace CoreEx.AspNetCore.WebApis
         /// </summary>
         /// <param name="wap">The <see cref="WebApiParam"/> to copy from.</param>
         /// <param name="value">The deserialized request value.</param>
-        public WebApiParam(WebApiParam wap, T value) : base((wap ?? throw new ArgumentNullException(nameof(wap))).WebApi, wap.RequestOptions, wap.OperationType) => Value = InspectValue(value);
+        public WebApiParam(WebApiParam wap, T value) : base(wap.ThrowIfNull(nameof(wap)).WebApi, wap.RequestOptions, wap.OperationType) => Value = InspectValue(value);
 
         /// <summary>
         /// Gets the deserialized request value.

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisher.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisher.cs
@@ -5,14 +5,12 @@ using CoreEx.Events;
 using CoreEx.Json;
 using CoreEx.Mapping;
 using CoreEx.Results;
-using CoreEx.Validation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,26 +20,20 @@ namespace CoreEx.AspNetCore.WebApis
     /// Provides the core <see cref="IEventPublisher"/> Web API execution encapsulation.
     /// </summary>
     /// <remarks>Support to change/map request into a different published event type is also enabled where required (see also <seealso cref="Mapper"/>).</remarks>
-    public class WebApiPublisher : WebApiBase
+    /// <param name="eventPublisher">The <see cref="IEventPublisher"/>.</param>
+    /// <param name="executionContext">The <see cref="ExecutionContext"/>.</param>
+    /// <param name="settings">The <see cref="SettingsBase"/>.</param>
+    /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
+    /// <param name="invoker">The <see cref="WebApiInvoker"/>.</param>
+    /// <param name="logger">The <see cref="ILogger"/>.</param>
+    public class WebApiPublisher(IEventPublisher eventPublisher, ExecutionContext executionContext, SettingsBase settings, IJsonSerializer jsonSerializer, ILogger<WebApiPublisher> logger, WebApiInvoker? invoker = null) : WebApiBase(executionContext, settings, jsonSerializer, logger, invoker)
     {
         private IMapper? _mapper;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="WebApiPublisher"/> class.
-        /// </summary>
-        /// <param name="eventPublisher">The <see cref="IEventPublisher"/>.</param>
-        /// <param name="executionContext">The <see cref="ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
-        /// <param name="invoker">The <see cref="WebApiInvoker"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        public WebApiPublisher(IEventPublisher eventPublisher, ExecutionContext executionContext, SettingsBase settings, IJsonSerializer jsonSerializer, ILogger<WebApiPublisher> logger, WebApiInvoker? invoker = null)
-            : base(executionContext, settings, jsonSerializer, logger, invoker) => EventPublisher = eventPublisher ?? throw new ArgumentNullException(nameof(eventPublisher));
-
-        /// <summary>
         /// Gets the <see cref="IEventPublisher"/>.
         /// </summary>
-        public IEventPublisher EventPublisher { get; }
+        public IEventPublisher EventPublisher { get; } = eventPublisher.ThrowIfNull(nameof(eventPublisher));
 
         /// <summary>
         /// Gets or sets the <see cref="IMapper"/>.
@@ -62,163 +54,86 @@ namespace CoreEx.AspNetCore.WebApis
         /// </summary>
         /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
         /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
+        /// <param name="args">The <see cref="WebApiPublisherArgs{TValue}"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
         /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishAsync<TValue>(HttpRequest request, string? eventName, Func<WebApiParam<TValue>, CancellationToken, Task>? beforeEvent = null, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishAsync(request, eventName, (wapv, ct) => PublishBeforeEventAsync<TValue, TValue>(wapv, beforeEvent, ct), eventModifier, statusCode, operationType, validator, cancellationToken);
+        public Task<IActionResult> PublishAsync<TValue>(HttpRequest request, WebApiPublisherArgs<TValue>? args = null, CancellationToken cancellationToken = default)
+            => PublishOrchestrateAsync(request, false, default!, args ?? new WebApiPublisherArgs<TValue>(), cancellationToken);
 
         /// <summary>
         /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/>.
         /// </summary>
         /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
         /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
+        /// <param name="value">The value (already deserialized).</param>
+        /// <param name="args">The <see cref="WebApiPublisherArgs{TValue}"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
         /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishAsync<TValue>(HttpRequest request, TValue value, string? eventName = null, Func<WebApiParam<TValue>, CancellationToken, Task>? beforeEvent = null, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishAsync(request, value, eventName, (wapv, ct) => PublishBeforeEventAsync<TValue, TValue>(wapv, beforeEvent, ct), eventModifier, statusCode, operationType, validator, cancellationToken);
+        public Task<IActionResult> PublishValueAsync<TValue>(HttpRequest request, TValue value, WebApiPublisherArgs<TValue>? args = null, CancellationToken cancellationToken = default)
+            => PublishOrchestrateAsync(request, true, value, args ?? new WebApiPublisherArgs<TValue>(), cancellationToken);
 
         /// <summary>
-        /// Simulates a before event execution; where it in turn maps to itself.
+        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/>.
         /// </summary>
-        private static async Task<TEventValue> PublishBeforeEventAsync<TValue, TEventValue>(WebApiParam<TValue> wapv, Func<WebApiParam<TValue>, CancellationToken, Task>? beforeEvent, CancellationToken cancellationToken)
+        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <param name="args">The <see cref="WebApiPublisherArgs{TValue}"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
+        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
+        public Task<IActionResult> PublishAsync<TValue, TEventValue>(HttpRequest request, WebApiPublisherArgs<TValue, TEventValue>? args = null, CancellationToken cancellationToken = default)
+            => PublishOrchestrateAsync(request, false, default!, args ?? new WebApiPublisherArgs<TValue, TEventValue>(), cancellationToken);
+
+        /// <summary>
+        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <param name="value">The value (already deserialized).</param>
+        /// <param name="args">The <see cref="WebApiPublisherArgs{TValue}"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
+        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
+        public Task<IActionResult> PublishValueAsync<TValue, TEventValue>(HttpRequest request, TValue value, WebApiPublisherArgs<TValue, TEventValue>? args = null, CancellationToken cancellationToken = default)
+            => PublishOrchestrateAsync(request, true, value, args ?? new WebApiPublisherArgs<TValue, TEventValue>(), cancellationToken);
+
+        /// <summary>
+        /// Performs the publish orchestration.
+        /// </summary>
+        private async Task<IActionResult> PublishOrchestrateAsync<TValue, TEventValue>(HttpRequest request, bool useValue, TValue value, IWebApiPublisherArgs<TValue, TEventValue> args, CancellationToken cancellationToken = default)
         {
-            if (beforeEvent is not null)
-                await beforeEvent(wapv, cancellationToken).ConfigureAwait(false);
-
-            return wapv.Value is TEventValue tev ? tev : throw new InvalidCastException("The TValue and TEventValue must be the same Type.");
-        }
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.
-        /// <para>Where the <paramref name="beforeEvent"/> is <c>null</c> then the <see cref="Mapper"/> will be used to map between the <typeparamref name="TValue"/> and <typeparamref name="TEventValue"/> types.</para></remarks>
-        public Task<IActionResult> PublishAsync<TValue, TEventValue>(HttpRequest request, Func<WebApiParam<TValue>, CancellationToken, Task<TEventValue>>? beforeEvent = null, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishAsync(request, null, beforeEvent, eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.
-        /// <para>Where the <paramref name="beforeEvent"/> is <c>null</c> then the <see cref="Mapper"/> will be used to map between the <typeparamref name="TValue"/> and <typeparamref name="TEventValue"/> types.</para></remarks>
-        public Task<IActionResult> PublishAsync<TValue, TEventValue>(HttpRequest request, string? eventName, Func<WebApiParam<TValue>, CancellationToken, Task<TEventValue>>? beforeEvent = null, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishInternalAsync(request, false, default!, eventName, beforeEvent, eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.
-        /// <para>Where the <paramref name="beforeEvent"/> is <c>null</c> then the <see cref="Mapper"/> will be used to map between the <typeparamref name="TValue"/> and <typeparamref name="TEventValue"/> types.</para></remarks>
-        public Task<IActionResult> PublishAsync<TValue, TEventValue>(HttpRequest request, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task<TEventValue>>? beforeEvent = null, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishAsync(request, value, null, beforeEvent, eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.
-        /// <para>Where the <paramref name="beforeEvent"/> is <c>null</c> then the <see cref="Mapper"/> will be used to map between the <typeparamref name="TValue"/> and <typeparamref name="TEventValue"/> types.</para></remarks>
-        public Task<IActionResult> PublishAsync<TValue, TEventValue>(HttpRequest request, TValue value, string? eventName, Func<WebApiParam<TValue>, CancellationToken, Task<TEventValue>>? beforeEvent = null, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishInternalAsync(request, true, value, eventName, beforeEvent, eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        private async Task<IActionResult> PublishInternalAsync<TValue, TEventValue>(HttpRequest request, bool useValue, TValue value, string? eventName, Func<WebApiParam<TValue>, CancellationToken, Task<TEventValue>>? beforeEvent, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-        {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull();
+            args.ThrowIfNull();
 
             if (request.Method != HttpMethods.Post)
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PublishAsync)}.", nameof(request));
 
             return await RunAsync(request, async (wap, ct) =>
             {
-                var (wapv, vex) = await ValidateValueAsync(wap, useValue, value, true, validator, cancellationToken).ConfigureAwait(false);
-                if (vex != null)
+                // Use specified value or get from the request. 
+                var (wapv, vex) = await ValidateValueAsync(wap, useValue, value, true, null, cancellationToken).ConfigureAwait(false);
+                if (vex is not null)
                     return await CreateActionResultFromExceptionAsync(this, request.HttpContext, vex, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
 
-                var @event = new EventData
-                {
-                    Value = beforeEvent is null ? Mapper.Map<TValue, TEventValue>(wapv!.Value) : await beforeEvent(wapv!, ct).ConfigureAwait(false)
-                };
+                // Process the publishing as configured.
+                var r = await Result.Go()
+                    .WhenAsAsync(() => args.OnBeforeValidationAsync is not null, () => args.OnBeforeValidationAsync!(wapv!, ct))
+                    .WhenAsAsync(_ => args.Validator is not null, async _ => (await args.Validator!.ValidateAsync(wapv!.Value!, ct).ConfigureAwait(false)).ToResult<TValue>())
+                    .WhenAsync(_ => args.OnBeforeEventAsync is not null, _ => args.OnBeforeEventAsync!(wapv!, ct))
+                    .WhenAs(_ => args.AreSameType, _ => new EventData { Value = wapv!.Value }, _ => new EventData { Value = args.Mapper is not null ? args.Mapper.Map(wapv!.Value) : Mapper.Map<TValue, TEventValue>(wapv!.Value) })
+                    .Then(e => args.OnEvent?.Invoke(e))
+                    .ThenAs(e => args.EventName is null ? EventPublisher.Publish(e) : EventPublisher.PublishNamed(args.EventName, e))
+                    .ThenAsync(_ => EventPublisher.SendAsync(ct)).ConfigureAwait(false);
 
-                eventModifier?.Invoke(@event);
+                if (r.IsFailure)
+                    return await CreateActionResultFromExceptionAsync(this, request.HttpContext, r.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
 
-                if (eventName == null)
-                    EventPublisher.Publish(@event);
-                else
-                    EventPublisher.PublishNamed(eventName, @event);
-
-                await EventPublisher.SendAsync(cancellationToken).ConfigureAwait(false);
-
-                return new ExtendedStatusCodeResult(statusCode);
-            }, operationType, cancellationToken, nameof(PublishAsync)).ConfigureAwait(false);
+                return args.CreateSuccessResult?.Invoke() ?? new ExtendedStatusCodeResult(args.StatusCode);
+            }, args.OperationType, cancellationToken, nameof(PublishAsync)).ConfigureAwait(false);
         }
 
         #endregion
@@ -228,172 +143,82 @@ namespace CoreEx.AspNetCore.WebApis
         /// <summary>
         /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/>.
         /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
+        /// <typeparam name="TColl">The request JSON collection <see cref="Type"/>.</typeparam>
         /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
         /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
+        /// <param name="args">The <see cref="WebApiPublisherCollectionArgs{TColl, TItem}"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
         /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishCollectionAsync<TColl, TItem>(HttpRequest request, string? eventName = null, Func<WebApiParam<TColl>, CancellationToken, Task>? beforeEvents = null, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionAsync<TColl, TItem, TItem>(request, eventName, (wapc, ct) => PublishCollectionBeforeEventAsync<TColl, TItem, TItem>(wapc, beforeEvents, ct), eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
+        public Task<IActionResult> PublishCollectionAsync<TColl, TItem>(HttpRequest request, WebApiPublisherCollectionArgs<TColl, TItem>? args = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
+            => PublishCollectionOrchestrateAsync(request, false, default!, args ?? new WebApiPublisherCollectionArgs<TColl, TItem>(), cancellationToken);
 
         /// <summary>
         /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/>.
         /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
+        /// <typeparam name="TColl">The request JSON collection <see cref="Type"/>.</typeparam>
         /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
         /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
+        /// <param name="value">The value (already deserialized).</param>
+        /// <param name="args">The <see cref="WebApiPublisherCollectionArgs{TColl, TItem}"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
         /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishCollectionAsync<TColl, TItem>(HttpRequest request, TColl value, string? eventName = null, Func<WebApiParam<TColl>, CancellationToken, Task>? beforeEvents = null, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionAsync<TColl, TItem, TItem>(request, value, eventName, (wapc, ct) => PublishCollectionBeforeEventAsync<TColl, TItem, TItem>(wapc, beforeEvents, ct), eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
+        public Task<IActionResult> PublishCollectionValueAsync<TColl, TItem>(HttpRequest request, TColl value, WebApiPublisherCollectionArgs<TColl, TItem>? args = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
+            => PublishCollectionOrchestrateAsync(request, true, value, args ?? new WebApiPublisherCollectionArgs<TColl, TItem>(), cancellationToken);
 
         /// <summary>
-        /// Simulates a before event execution; where it in turn maps to itself.
+        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/>.
         /// </summary>
-        private static async Task<IEnumerable<TEventItem>> PublishCollectionBeforeEventAsync<TColl, TItem, TEventItem>(WebApiParam<TColl> wapc, Func<WebApiParam<TColl>, CancellationToken, Task>? beforeEvent, CancellationToken cancellationToken) where TColl : IEnumerable<TItem>
+        /// <typeparam name="TColl">The request JSON collection <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TEventItem">The <typeparamref name="TItem"/>-equivalent <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <param name="args">The <see cref="IWebApiPublisherCollectionArgs{TColl, TItem, TEventItem}"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
+        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
+        public Task<IActionResult> PublishCollectionAsync<TColl, TItem, TEventItem>(HttpRequest request, WebApiPublisherCollectionArgs<TColl, TItem, TEventItem>? args = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
+            => PublishCollectionOrchestrateAsync(request, false, default!, args ?? new WebApiPublisherCollectionArgs<TColl, TItem, TEventItem>(), cancellationToken);
+
+        /// <summary>
+        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/>.
+        /// </summary>
+        /// <typeparam name="TColl">The request JSON collection <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
+        /// <typeparam name="TEventItem">The <typeparamref name="TItem"/>-equivalent <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <param name="value">The value (already deserialized).</param>
+        /// <param name="args">The <see cref="IWebApiPublisherCollectionArgs{TColl, TItem, TEventItem}"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
+        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
+        public Task<IActionResult> PublishCollectionValueAsync<TColl, TItem, TEventItem>(HttpRequest request, TColl value, WebApiPublisherCollectionArgs<TColl, TItem, TEventItem>? args = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
+            => PublishCollectionOrchestrateAsync(request, true, value, args ?? new WebApiPublisherCollectionArgs<TColl, TItem, TEventItem>(), cancellationToken);
+
+        /// <summary>
+        /// Performs the publish orchestration.
+        /// </summary>
+        private async Task<IActionResult> PublishCollectionOrchestrateAsync<TColl, TItem, TEventValue>(HttpRequest request, bool useValue, TColl coll, IWebApiPublisherCollectionArgs<TColl, TItem, TEventValue> args, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
         {
-            if (beforeEvent is not null)
-                await beforeEvent(wapc, cancellationToken).ConfigureAwait(false);
-
-            var items = new List<TEventItem>();
-            foreach (var item in wapc.Value!)
-            {
-                if (item is TEventItem tei)
-                    items.Add(tei);
-                else
-                    throw new InvalidCastException("The TItem and TEventItem must be the same Type.");
-            }
-
-            return items;
-        }
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventItem">The <see cref="EventData.Value"/> item <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.
-        /// <para>Where the <paramref name="beforeEvents"/> is <c>null</c> then the <see cref="Mapper"/> will be used to map between the <typeparamref name="TItem"/> and <typeparamref name="TEventItem"/> types.</para></remarks>
-        public Task<IActionResult> PublishCollectionAsync<TColl, TItem, TEventItem>(HttpRequest request, Func<WebApiParam<TColl>, CancellationToken, Task<IEnumerable<TEventItem>>>? beforeEvents = null, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionAsync<TColl, TItem, TEventItem>(request, null, beforeEvents, eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventItem">The <see cref="EventData.Value"/> item <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.
-        /// <para>Where the <paramref name="beforeEvents"/> is <c>null</c> then the <see cref="Mapper"/> will be used to map between the <typeparamref name="TItem"/> and <typeparamref name="TEventItem"/> types.</para></remarks>
-        public Task<IActionResult> PublishCollectionAsync<TColl, TItem, TEventItem>(HttpRequest request, string? eventName, Func<WebApiParam<TColl>, CancellationToken, Task<IEnumerable<TEventItem>>>? beforeEvents = null, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionInternalAsync<TColl, TItem, TEventItem>(request, false, default!, eventName, beforeEvents, eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventItem">The <see cref="EventData.Value"/> item <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.
-        /// <para>Where the <paramref name="beforeEvents"/> is <c>null</c> then the <see cref="Mapper"/> will be used to map between the <typeparamref name="TItem"/> and <typeparamref name="TEventItem"/> types.</para></remarks>
-        public Task<IActionResult> PublishCollectionAsync<TColl, TItem, TEventItem>(HttpRequest request, TColl value, Func<WebApiParam<TColl>, CancellationToken, Task<IEnumerable<TEventItem>>>? beforeEvents = null, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionAsync<TColl, TItem, TEventItem>(request, value, null, beforeEvents, eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventItem">The <see cref="EventData.Value"/> item <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted (invoked after the <paramref name="validator"/>).</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.
-        /// <para>Where the <paramref name="beforeEvents"/> is <c>null</c> then the <see cref="Mapper"/> will be used to map between the <typeparamref name="TItem"/> and <typeparamref name="TEventItem"/> types.</para></remarks>
-        public Task<IActionResult> PublishCollectionAsync<TColl, TItem, TEventItem>(HttpRequest request, TColl value, string? eventName, Func<WebApiParam<TColl>, CancellationToken, Task<IEnumerable<TEventItem>>>? beforeEvents = null, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionInternalAsync<TColl, TItem, TEventItem>(request, true, value, eventName, beforeEvents, eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/>.
-        /// </summary>
-        private async Task<IActionResult> PublishCollectionInternalAsync<TColl, TItem, TEventItem>(HttpRequest request, bool useValue, TColl value, string? eventName, Func<WebApiParam<TColl>, CancellationToken, Task<IEnumerable<TEventItem>>>? beforeEvents, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-        {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull();
+            args.ThrowIfNull();
 
             if (request.Method != HttpMethods.Post)
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PublishAsync)}.", nameof(request));
 
-            // Fall back to a mapper where no explicit beforeEvents is specified.
             return await RunAsync(request, async (wap, ct) =>
             {
-                var (wapc, vex) = await ValidateValueAsync(wap, useValue, value, true, validator, cancellationToken).ConfigureAwait(false);
-                if (vex != null)
+                // Use specified value or get from the request. 
+                var (wapc, vex) = await ValidateValueAsync(wap, useValue, coll, true, null, cancellationToken).ConfigureAwait(false);
+                if (vex is not null)
                     return await CreateActionResultFromExceptionAsync(this, request.HttpContext, vex, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
 
-                var max = maxCollSize ?? Settings.MaxPublishCollSize;
+                // Check the collection size.
+                var max = args.MaxCollectionSize ?? Settings.MaxPublishCollSize;
+                if (max <= 0)
+                    throw new InvalidOperationException($"The maximum collection size must be greater than zero.");
+
                 var count = wapc!.Value?.Count() ?? 0;
                 if (count > max)
                 {
@@ -405,403 +230,31 @@ namespace CoreEx.AspNetCore.WebApis
                 if (count == 0)
                     return new AcceptedResult();
 
-                IEnumerable<TEventItem> items;
-                if (beforeEvents is null)
+                // Process the publishing as configured.
+                var r = await Result.Go()
+                    .WhenAsAsync(() => args.OnBeforeValidationAsync is not null, () => args.OnBeforeValidationAsync!(wapc!, ct))
+                    .WhenAsAsync(_ => args.Validator is not null, async _ => (await args.Validator!.ValidateAsync(wapc!.Value!, ct).ConfigureAwait(false)).ToResult<TColl>())
+                    .WhenAsync(_ => args.OnBeforeEventAsync is not null, _ => args.OnBeforeEventAsync!(wapc!, ct));
+
+                if (r.IsFailure)
+                    return await CreateActionResultFromExceptionAsync(this, request.HttpContext, r.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
+
+                // Create the events (also performing mapping where applicable).
+                foreach (var item in wapc!.Value!)
                 {
-                    var coll = new List<TEventItem>();
-                    {
-                        foreach (var item in wapc.Value!)
-                        {
-                            coll.Add(Mapper.Map<TItem, TEventItem>(item)!);
-                        }
-                    }
+                    var @event = new EventData { Value = args.AreSameType ? item : (args.Mapper is not null ? args.Mapper.Map(item) : Mapper.Map<TItem, TEventValue>(item)) };
+                    args.OnEvent?.Invoke(@event);
 
-                    items = coll.AsEnumerable();
-                }
-                else
-                    items = await beforeEvents(wapc!, ct).ConfigureAwait(false);
-
-                foreach (var item in items)
-                {
-                    var @event = new EventData { Value = item };
-
-                    eventModifier?.Invoke(@event);
-
-                    if (eventName == null)
+                    if (args.EventName is null)
                         EventPublisher.Publish(@event);
                     else
-                        EventPublisher.PublishNamed(eventName, @event);
+                        EventPublisher.PublishNamed(args.EventName, @event);
                 }
 
                 await EventPublisher.SendAsync(ct).ConfigureAwait(false);
 
-                return new ExtendedStatusCodeResult(statusCode);
-            }, operationType, cancellationToken, nameof(PublishAsync)).ConfigureAwait(false);
-        }
-
-        #endregion
-
-        #region PublishWithResultAsync
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishWithResultAsync<TValue>(HttpRequest request, string? eventName = null, Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? beforeEvent = null, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishWithResultAsync(request, eventName, (wapv, ct) => PublishBeforeEventWithResultAsync<TValue, TValue>(wapv, beforeEvent, ct), eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishWithResultAsync<TValue>(HttpRequest request, TValue value, string? eventName = null, Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? beforeEvent = null, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishWithResultAsync(request, value, eventName, (wapv, ct) => PublishBeforeEventWithResultAsync<TValue, TValue>(wapv, beforeEvent, ct), eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Simulates a before event execution; where it in turn maps to itself.
-        /// </summary>
-        private static async Task<Result<TEventValue>> PublishBeforeEventWithResultAsync<TValue, TEventValue>(WebApiParam<TValue> wapv, Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? beforeEvent, CancellationToken cancellationToken)
-        {
-            var result = beforeEvent is null ? Result.Success : await beforeEvent(wapv, cancellationToken).ConfigureAwait(false);
-            return result.ThenAs(() => wapv.Value is TEventValue tev ? tev : throw new InvalidCastException("The TValue and TEventValue must be the same Type."));
-        }
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishWithResultAsync<TValue, TEventValue>(HttpRequest request, Func<WebApiParam<TValue>, CancellationToken, Task<Result<TEventValue>>> beforeEvent, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishWithResultAsync(request, null, beforeEvent, eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishWithResultAsync<TValue, TEventValue>(HttpRequest request, string? eventName, Func<WebApiParam<TValue>, CancellationToken, Task<Result<TEventValue>>> beforeEvent, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishWithResultInternalAsync(request, false, default!, eventName, beforeEvent, eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishWithResultAsync<TValue, TEventValue>(HttpRequest request, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task<Result<TEventValue>>> beforeEvent, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishWithResultAsync(request, value, null, beforeEvent, eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventValue">The <see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvent">A function that enables the value to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable the <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishWithResultAsync<TValue, TEventValue>(HttpRequest request, TValue value, string? eventName, Func<WebApiParam<TValue>, CancellationToken, Task<Result<TEventValue>>> beforeEvent, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-            => PublishWithResultInternalAsync(request, true, value, eventName, beforeEvent, eventModifier, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TValue"/> that is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        private async Task<IActionResult> PublishWithResultInternalAsync<TValue, TEventValue>(HttpRequest request, bool useValue, TValue value, string? eventName, Func<WebApiParam<TValue>, CancellationToken, Task<Result<TEventValue>>>? beforeEvent = null, Action<EventData>? eventModifier = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
-        {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-
-            if (beforeEvent is null)
-                throw new ArgumentNullException(nameof(beforeEvent));
-
-            if (request.Method != HttpMethods.Post)
-                throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PublishWithResultAsync)}.", nameof(request));
-
-            return await RunAsync(request, async (wap, ct) =>
-            {
-                var (wapv, vex) = await ValidateValueAsync(wap, useValue, value, true, validator, cancellationToken).ConfigureAwait(false);
-                if (vex != null)
-                    return await CreateActionResultFromExceptionAsync(this, request.HttpContext, vex, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
-
-                var result = await beforeEvent(wapv!, ct).ConfigureAwait(false);
-                if (result.IsFailure)
-                    return await CreateActionResultFromExceptionAsync(this, request.HttpContext, result.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
-
-                var @event = new EventData { Value = result.Value };
-                eventModifier?.Invoke(@event);
-
-                if (eventName == null)
-                    EventPublisher.Publish(@event);
-                else
-                    EventPublisher.PublishNamed(eventName, @event);
-
-                await EventPublisher.SendAsync(cancellationToken).ConfigureAwait(false);
-
-                return new ExtendedStatusCodeResult(statusCode);
-            }, operationType, cancellationToken, nameof(PublishWithResultAsync)).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishCollectionWithResultAsync<TColl, TItem>(HttpRequest request, string? eventName = null, Func<WebApiParam<TColl>, CancellationToken, Task<Result>>? beforeEvents = null, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionWithResultAsync<TColl, TItem, TItem>(request, eventName, (wapc, ct) => PublishCollectionBeforeEventWithResultAsync<TColl, TItem, TItem>(wapc, beforeEvents, ct), eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishCollectionWithResultAsync<TColl, TItem>(HttpRequest request, TColl value, string? eventName = null, Func<WebApiParam<TColl>, CancellationToken, Task<Result>>? beforeEvents = null, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionWithResultAsync<TColl, TItem, TItem>(request, value, eventName, (wapc, ct) => PublishCollectionBeforeEventWithResultAsync<TColl, TItem, TItem>(wapc, beforeEvents, ct), eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Simulates a before event execution; where it in turn maps to itself.
-        /// </summary>
-        private static async Task<Result<IEnumerable<TEventItem>>> PublishCollectionBeforeEventWithResultAsync<TColl, TItem, TEventItem>(WebApiParam<TColl> wapc, Func<WebApiParam<TColl>, CancellationToken, Task<Result>>? beforeEvent, CancellationToken cancellationToken) where TColl : IEnumerable<TItem>
-        {
-            var result = beforeEvent is null ? Result.Success : await beforeEvent(wapc, cancellationToken).ConfigureAwait(false);
-            return result.ThenAs(() =>
-            {
-                var items = new List<TEventItem>();
-                foreach (var item in wapc.Value!)
-                {
-                    if (item is TEventItem tei)
-                        items.Add(tei);
-                    else
-                        throw new InvalidCastException("The TItem and TEventItem must be the same Type.");
-                }
-
-                return items.AsEnumerable();
-            });
-        }
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventItem">The <see cref="EventData.Value"/> item <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishCollectionWithResultAsync<TColl, TItem, TEventItem>(HttpRequest request, Func<WebApiParam<TColl>, CancellationToken, Task<Result<IEnumerable<TEventItem>>>> beforeEvents, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionWithResultAsync<TColl, TItem, TEventItem>(request, null, beforeEvents, eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventItem">The <see cref="EventData.Value"/> item <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishCollectionWithResultAsync<TColl, TItem, TEventItem>(HttpRequest request, string? eventName, Func<WebApiParam<TColl>, CancellationToken, Task<Result<IEnumerable<TEventItem>>>> beforeEvents, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionWithResultInternalAsync<TColl, TItem, TEventItem>(request, false, default!, eventName, beforeEvents, eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventItem">The <see cref="EventData.Value"/> item <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishCollectionWithResultAsync<TColl, TItem, TEventItem>(HttpRequest request, TColl value, Func<WebApiParam<TColl>, CancellationToken, Task<Result<IEnumerable<TEventItem>>>> beforeEvents, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionWithResultAsync<TColl, TItem, TEventItem>(request, value, null, beforeEvents, eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        /// <typeparam name="TColl">The collection <see cref="Type"/></typeparam>
-        /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TEventItem">The <see cref="EventData.Value"/> item <see cref="Type"/> (where different to the request).</typeparam>
-        /// <param name="request">The <see cref="HttpRequest"/>.</param>
-        /// <param name="value">The The value (already deserialized).</param>
-        /// <param name="eventName">The optional event destintion name (e.g. Queue or Topic name).</param>
-        /// <param name="beforeEvents">A function that enables the collection to be processed/validated before the underlying event publishing logic is enacted.</param>
-        /// <param name="eventModifier">An action to enable each item <see cref="EventData"/> instance to be modified prior to publish.</param>
-        /// <param name="maxCollSize">Overrides the default (see <see cref="SettingsBase.MaxPublishCollSize"/>) maximum publish collection size.</param>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> where successful.</param>
-        /// <param name="operationType">The <see cref="OperationType"/>.</param>
-        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
-        /// <remarks>The <paramref name="request"/> must have an <see cref="HttpRequest.Method"/> of <see cref="HttpMethods.Post"/>.</remarks>
-        public Task<IActionResult> PublishCollectionWithResultAsync<TColl, TItem, TEventItem>(HttpRequest request, TColl value, string? eventName, Func<WebApiParam<TColl>, CancellationToken, Task<Result<IEnumerable<TEventItem>>>> beforeEvents, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-            => PublishCollectionWithResultInternalAsync<TColl, TItem, TEventItem>(request, true, value, eventName, beforeEvents, eventModifier, maxCollSize, statusCode, operationType, validator, cancellationToken);
-
-        /// <summary>
-        /// Performs a <see cref="HttpMethods.Post"/> operation with a request JSON content value of <see cref="Type"/> <typeparamref name="TColl"/> where each item is to be published using the <see cref="EventPublisher"/> (with a <see cref="Result"/>).
-        /// </summary>
-        private async Task<IActionResult> PublishCollectionWithResultInternalAsync<TColl, TItem, TEventItem>(HttpRequest request, bool useValue, TColl value, string? eventName, Func<WebApiParam<TColl>, CancellationToken, Task<Result<IEnumerable<TEventItem>>>>? beforeEvents = null, Action<EventData>? eventModifier = null, int? maxCollSize = null,
-            HttpStatusCode statusCode = HttpStatusCode.Accepted, OperationType operationType = OperationType.Unspecified, IValidator<TColl>? validator = null, CancellationToken cancellationToken = default) where TColl : IEnumerable<TItem>
-        {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-
-            if (beforeEvents is null)
-                throw new ArgumentNullException(nameof(beforeEvents));
-
-            if (request.Method != HttpMethods.Post)
-                throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PublishWithResultAsync)}.", nameof(request));
-
-            return await RunAsync(request, async (wap, ct) =>
-            {
-                var (wapv, vex) = await ValidateValueAsync(wap, useValue, value, true, validator, cancellationToken).ConfigureAwait(false);
-                if (vex != null)
-                    return await CreateActionResultFromExceptionAsync(this, request.HttpContext, vex, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
-
-                var max = maxCollSize ?? Settings.MaxPublishCollSize;
-                var count = wapv!.Value?.Count() ?? 0;
-                if (count > max)
-                {
-                    Logger.LogWarning("The publish collection contains {EventsCount} items where only a maximum size of {MaxCollSize} is supported; request has been rejected.", count, max);
-                    var bex = new BusinessException($"The publish collection contains {count} items where only a maximum size of {max} is supported.");
-                    return await CreateActionResultFromExceptionAsync(this, request.HttpContext, bex, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
-                }
-
-                if (count == 0)
-                    return new AcceptedResult();
-
-                var result = await beforeEvents(wapv!, ct).ConfigureAwait(false);
-                if (result.IsFailure)
-                    return await CreateActionResultFromExceptionAsync(this, request.HttpContext, result.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
-
-                foreach (var item in result.Value)
-                {
-                    var @event = new EventData { Value = item };
-                    eventModifier?.Invoke(@event);
-
-                    if (eventName == null)
-                        EventPublisher.Publish(@event);
-                    else
-                        EventPublisher.PublishNamed(eventName, @event);
-                }
-
-                await EventPublisher.SendAsync(ct).ConfigureAwait(false);
-
-                return new ExtendedStatusCodeResult(statusCode);
-            }, operationType, cancellationToken, nameof(PublishWithResultAsync)).ConfigureAwait(false);
+                return args.CreateSuccessResult?.Invoke() ?? new ExtendedStatusCodeResult(args.StatusCode);
+            }, args.OperationType, cancellationToken, nameof(PublishAsync)).ConfigureAwait(false);
         }
 
         #endregion

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Events;
+using CoreEx.Mapping;
+using CoreEx.Results;
+using CoreEx.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Represents the <see cref="WebApiPublisher"/> arguments; being the opportunity to further configure the standard processing.
+    /// </summary>
+    /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
+    /// <param name="validator">The optional validator.</param>
+    public class WebApiPublisherArgs<TValue>(IValidator<TValue>? validator = null) : IWebApiPublisherArgs<TValue, TValue>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebApiPublisherArgs{TValue}"/> class.
+        /// </summary>
+        /// <param name="eventName">The event destination name (e.g. Queue or Topic name).</param>
+        /// <param name="validator">The optional validator.</param>
+        public WebApiPublisherArgs(string eventName, IValidator<TValue>? validator = null) : this(validator) => EventName = eventName;
+
+        /// <inheritdoc/>
+        public string? EventName { get; set; }
+
+        /// <inheritdoc/>
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
+
+        /// <inheritdoc/>
+        public IValidator<TValue>? Validator { get; set; } = validator;
+
+        /// <inheritdoc/>
+        public OperationType OperationType { get; set; } = OperationType.Unspecified;
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? OnBeforeValidationAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? OnBeforeEventAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Action<EventData>? OnEvent { get; set; }
+
+        /// <inheritdoc/>
+        IMapper<TValue, TValue>? IWebApiPublisherArgs<TValue, TValue>.Mapper => null;
+
+        /// <inheritdoc/>
+        public Func<IActionResult>? CreateSuccessResult { get; set; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT2.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT2.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Events;
+using CoreEx.Mapping;
+using CoreEx.Results;
+using CoreEx.Validation;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Represents the <see cref="WebApiPublisher"/> arguments; being the opportunity to further configure the standard processing.
+    /// </summary>
+    /// <typeparam name="TValue">The request JSON content value <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TEventValue"><see cref="EventData.Value"/> <see cref="Type"/> (where different to the request).</typeparam>
+    /// <param name="validator">The optional validator.</param>
+    public class WebApiPublisherArgs<TValue, TEventValue>(IValidator<TValue>? validator = null) : IWebApiPublisherArgs<TValue, TEventValue>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebApiPublisherArgs{TValue}"/> class.
+        /// </summary>
+        /// <param name="eventName">The event destination name (e.g. Queue or Topic name).</param>
+        /// <param name="validator">The optional validator.</param>
+        public WebApiPublisherArgs(string eventName, IValidator<TValue>? validator = null) : this(validator) => EventName = eventName;
+
+        /// <inheritdoc/>
+        public string? EventName { get; set; } = default!;
+
+        /// <inheritdoc/>
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
+
+        /// <inheritdoc/>
+        public IValidator<TValue>? Validator { get; set; } = validator;
+
+        /// <inheritdoc/>
+        public OperationType OperationType { get; set; } = OperationType.Unspecified;
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? OnBeforeValidationAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? OnBeforeEventAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Action<EventData>? OnEvent { get; set; }
+
+        /// <inheritdoc/>
+        public IMapper<TValue, TEventValue>? Mapper { get; set; }
+
+        /// <inheritdoc/>
+        public Func<IActionResult>? CreateSuccessResult { get; set; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCollectionArgsT.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCollectionArgsT.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Events;
+using CoreEx.Mapping;
+using CoreEx.Results;
+using CoreEx.Validation;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Represents the <see cref="WebApiPublisher"/> collection-based arguments; being the opportunity to further configure the standard processing.
+    /// </summary>
+    /// <typeparam name="TColl">The request JSON collection <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
+    /// <param name="validator">The optional validator.</param>
+    public class WebApiPublisherCollectionArgs<TColl, TItem>(IValidator<TColl>? validator = null) : IWebApiPublisherCollectionArgs<TColl, TItem, TItem> where TColl : IEnumerable<TItem>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebApiPublisherCollectionArgs{TColl, TItem}"/> class.
+        /// </summary>
+        /// <param name="eventName">The event destination name (e.g. Queue or Topic name).</param>
+        /// <param name="validator">The optional validator.</param>
+        public WebApiPublisherCollectionArgs(string eventName, IValidator<TColl>? validator = null) : this(validator) => EventName = eventName;
+
+        /// <inheritdoc/>
+        public string? EventName { get; set; }
+
+        /// <inheritdoc/>
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
+
+        /// <inheritdoc/>
+        public int? MaxCollectionSize { get; set; }
+
+        /// <inheritdoc/>
+        public IValidator<TColl>? Validator { get; set; } = validator;
+
+        /// <inheritdoc/>
+        public OperationType OperationType { get; set; } = OperationType.Unspecified;
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TColl>, CancellationToken, Task<Result>>? OnBeforeValidationAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TColl>, CancellationToken, Task<Result>>? OnBeforeEventAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Action<EventData>? OnEvent { get; set; }
+
+        /// <inheritdoc/>
+        IMapper<TItem, TItem>? IWebApiPublisherCollectionArgs<TColl, TItem, TItem>.Mapper => null;
+
+        /// <inheritdoc/>
+        public Func<IActionResult>? CreateSuccessResult { get; set; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCollectionArgsT2.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCollectionArgsT2.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Events;
+using CoreEx.Mapping;
+using CoreEx.Results;
+using CoreEx.Validation;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Represents the <see cref="WebApiPublisher"/> collection-based arguments; being the opportunity to further configure the standard processing.
+    /// </summary>
+    /// <typeparam name="TColl">The request JSON collection <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TItem">The collection item <see cref="Type"/>.</typeparam>
+    /// <typeparam name="TEventItem">The <typeparamref name="TItem"/>-equivalent <see cref="EventData.Value"/> <see cref="Type"/> (where different then a <see cref="Mapper"/> will be required).</typeparam>
+    /// <param name="validator">The optional validator.</param>
+    public class WebApiPublisherCollectionArgs<TColl, TItem, TEventItem>(IValidator<TColl>? validator = null) : IWebApiPublisherCollectionArgs<TColl, TItem, TEventItem> where TColl : IEnumerable<TItem>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebApiPublisherCollectionArgs{TColl, TItem}"/> class.
+        /// </summary>
+        /// <param name="eventName">The event destination name (e.g. Queue or Topic name).</param>
+        /// <param name="validator">The optional validator.</param>
+        public WebApiPublisherCollectionArgs(string eventName, IValidator<TColl>? validator = null) : this(validator) => EventName = eventName;
+
+        /// <inheritdoc/>
+        public string? EventName { get; set; }
+
+        /// <inheritdoc/>
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
+
+        /// <inheritdoc/>
+        public int? MaxCollectionSize { get; set; }
+
+        /// <inheritdoc/>
+        public IValidator<TColl>? Validator { get; set; } = validator;
+
+        /// <inheritdoc/>
+        public OperationType OperationType { get; set; } = OperationType.Unspecified;
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TColl>, CancellationToken, Task<Result>>? OnBeforeValidationAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TColl>, CancellationToken, Task<Result>>? OnBeforeEventAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Action<EventData>? OnEvent { get; set; }
+
+        /// <inheritdoc/>
+        public IMapper<TItem, TEventItem>? Mapper { get; set; }
+
+        /// <inheritdoc/>
+        public Func<IActionResult>? CreateSuccessResult { get; set; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/WebApiRequestOptions.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiRequestOptions.cs
@@ -24,7 +24,7 @@ namespace CoreEx.AspNetCore.WebApis
         /// <param name="httpRequest">The <see cref="HttpRequest"/>.</param>
         public WebApiRequestOptions(HttpRequest httpRequest)
         {
-            Request = httpRequest ?? throw new ArgumentNullException(nameof(httpRequest));
+            Request = httpRequest.ThrowIfNull(nameof(httpRequest));
             GetQueryStringOptions(Request.Query);
 
             if (httpRequest.Headers != null && httpRequest.Headers.Count > 0)

--- a/src/CoreEx.AspNetCore/WebApis/WebApiWithResult.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiWithResult.cs
@@ -46,14 +46,11 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> GetWithResultAsync<TResult>(HttpRequest request, Func<WebApiParam, CancellationToken, Task<Result<TResult>>> function, HttpStatusCode statusCode = HttpStatusCode.OK,
             HttpStatusCode alternateStatusCode = HttpStatusCode.NotFound, OperationType operationType = OperationType.Read, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsGet(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Get}' to use {nameof(GetAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -92,14 +89,11 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> PostWithResultAsync(HttpRequest request, Func<WebApiParam, CancellationToken, Task<Result>> function, HttpStatusCode statusCode = HttpStatusCode.OK, OperationType operationType = OperationType.Create,
             Func<Uri>? locationUri = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPost(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PostAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -184,14 +178,11 @@ namespace CoreEx.AspNetCore.WebApis
         private async Task<IActionResult> PostWithResultInternalAsync<TValue>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task<Result>> function, HttpStatusCode statusCode = HttpStatusCode.OK,
             OperationType operationType = OperationType.Create, bool valueIsRequired = true, IValidator<TValue>? validator = null, Func<Uri>? locationUri = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPost(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PostAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -236,14 +227,11 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> PostWithResultAsync<TResult>(HttpRequest request, Func<WebApiParam, CancellationToken, Task<Result<TResult>>> function, HttpStatusCode statusCode = HttpStatusCode.OK,
             HttpStatusCode alternateStatusCode = HttpStatusCode.NoContent, OperationType operationType = OperationType.Create, Func<TResult, Uri>? locationUri = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPost(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PostAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -336,14 +324,11 @@ namespace CoreEx.AspNetCore.WebApis
         private async Task<IActionResult> PostWithResultInternalAsync<TValue, TResult>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task<Result<TResult>>> function, HttpStatusCode statusCode = HttpStatusCode.OK, HttpStatusCode alternateStatusCode = HttpStatusCode.NoContent,
             OperationType operationType = OperationType.Create, bool valueIsRequired = true, IValidator<TValue>? validator = null, Func<TResult, Uri>? locationUri = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPost(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PostAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -432,14 +417,11 @@ namespace CoreEx.AspNetCore.WebApis
         private async Task<IActionResult> PutWithResultInternalAsync<TValue>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task<Result>> function, HttpStatusCode statusCode = HttpStatusCode.NoContent,
             OperationType operationType = OperationType.Update, bool valueIsRequired = true, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPut(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Put}' to use {nameof(PutWithResultAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -532,14 +514,11 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> PutWithResultInternalAsync<TValue, TResult>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam<TValue>, CancellationToken, Task<Result<TResult>>> function, HttpStatusCode statusCode = HttpStatusCode.OK,
             HttpStatusCode alternateStatusCode = HttpStatusCode.NoContent, OperationType operationType = OperationType.Update, bool valueIsRequired = true, IValidator<TValue>? validator = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsPut(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Put}' to use {nameof(PutWithResultAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -628,17 +607,12 @@ namespace CoreEx.AspNetCore.WebApis
         private async Task<IActionResult> PutWithResultInternalAsync<TValue>(HttpRequest request, bool useValue, TValue value, Func<WebApiParam, CancellationToken, Task<Result<TValue?>>> get, Func<WebApiParam<TValue>, CancellationToken, Task<Result<TValue>>> put, HttpStatusCode statusCode = HttpStatusCode.OK,
             OperationType operationType = OperationType.Update, IValidator<TValue>? validator = null, bool simulatedConcurrency = false, CancellationToken cancellationToken = default) where TValue : class
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            get.ThrowIfNull(nameof(get));
+            put.ThrowIfNull(nameof(put));
 
             if (!HttpMethods.IsPut(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Put}' to use {nameof(PutWithResultAsync)}.", nameof(request));
-
-            if (get == null)
-                throw new ArgumentNullException(nameof(get));
-
-            if (put == null)
-                throw new ArgumentNullException(nameof(put));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -687,14 +661,11 @@ namespace CoreEx.AspNetCore.WebApis
         /// <returns>The corresponding <see cref="ExtendedStatusCodeResult"/> <see cref="IActionResult"/> where successful.</returns>
         public async Task<IActionResult> DeleteWithResultAsync(HttpRequest request, Func<WebApiParam, CancellationToken, Task<Result>> function, HttpStatusCode statusCode = HttpStatusCode.NoContent, OperationType operationType = OperationType.Delete, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull(nameof(request));
+            function.ThrowIfNull(nameof(function));
 
             if (!HttpMethods.IsDelete(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Delete}' to use {nameof(DeleteWithResultAsync)}.", nameof(request));
-
-            if (function == null)
-                throw new ArgumentNullException(nameof(function));
 
             return await RunAsync(request, async (wap, ct) =>
             {
@@ -748,20 +719,15 @@ namespace CoreEx.AspNetCore.WebApis
         public async Task<IActionResult> PatchWithResultAsync<TValue>(HttpRequest request, Func<WebApiParam, CancellationToken, Task<Result<TValue?>>> get, Func<WebApiParam<TValue>, CancellationToken, Task<Result<TValue>>> put, HttpStatusCode statusCode = HttpStatusCode.OK,
             OperationType operationType = OperationType.Update, IValidator<TValue>? validator = null, bool simulatedConcurrency = false, CancellationToken cancellationToken = default) where TValue : class
         {
+            request.ThrowIfNull(nameof(request));
+            get.ThrowIfNull(nameof(get));
+            put.ThrowIfNull(nameof(put));
+
             if (JsonMergePatch == null)
                 throw new InvalidOperationException($"To use the '{nameof(PatchWithResultAsync)}' methods the '{nameof(JsonMergePatch)}' object must be passed in the constructor. Where using dependency injection consider using '{nameof(Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.AddJsonMergePatch)}' to add and configure the supported options.");
 
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-
             if (!HttpMethods.IsPatch(request.Method))
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Patch}' to use {nameof(PatchWithResultAsync)}.", nameof(request));
-
-            if (get == null)
-                throw new ArgumentNullException(nameof(get));
-
-            if (put == null)
-                throw new ArgumentNullException(nameof(put));
 
             return await RunAsync(request, async (wap, ct) =>
             {

--- a/src/CoreEx.Azure/ServiceBus/README.md
+++ b/src/CoreEx.Azure/ServiceBus/README.md
@@ -46,6 +46,8 @@ public class ServiceBusExecuteVerificationFunction
 }
 ```
 
+<br/>
+
 ### Instrumentation
 
 To get further insights into the processing of the messages an [`IEventSubscriberInstrumentation`](../../CoreEx/Events/IEventSubscriberInstrumentation.cs) can be implemented. The corresponding `EventSubscriberBase.Instrumentation` property should be set during construction; typically performed during dependency injection. Determine whether the instrumentation instance should also be registered as a _singleton_.

--- a/src/CoreEx.Validation/ValidationArgs.cs
+++ b/src/CoreEx.Validation/ValidationArgs.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Configuration;
 using CoreEx.Entities;
 using System.Collections.Generic;
 
@@ -10,6 +11,8 @@ namespace CoreEx.Validation
     /// </summary>
     public class ValidationArgs
     {
+        private static bool? _defaultUseJsonNames;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationArgs"/> class.
         /// </summary>
@@ -18,7 +21,12 @@ namespace CoreEx.Validation
         /// <summary>
         /// Indicates whether to use the JSON name for the <see cref="MessageItem"/> <see cref="MessageItem.Property"/>; by default (<c>false</c>) uses the .NET name.
         /// </summary>
-        public static bool DefaultUseJsonNames { get; set; } = false;
+        /// <remarks>Will attempt to use <see cref="SettingsBase.ValidationUseJsonNames"/> as a default where possible.</remarks>
+        public static bool DefaultUseJsonNames 
+        { 
+            get => _defaultUseJsonNames ?? ExecutionContext.GetService<SettingsBase>()?.ValidationUseJsonNames ?? false;
+            set => _defaultUseJsonNames = value;
+        } 
 
         /// <summary>
         /// Gets or sets the optional name of a selected (specific) property to validate for the entity (<c>null</c> indicates to validate all).

--- a/src/CoreEx.Validation/ValidationExtensions.cs
+++ b/src/CoreEx.Validation/ValidationExtensions.cs
@@ -15,9 +15,6 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using static System.Net.Mime.MediaTypeNames;
-using System.Xml.Linq;
-using System.Data;
 
 namespace CoreEx.Validation
 {

--- a/src/CoreEx/Configuration/SettingsBase.cs
+++ b/src/CoreEx/Configuration/SettingsBase.cs
@@ -21,6 +21,7 @@ namespace CoreEx.Configuration
         private readonly ThreadLocal<bool> _isReflectionCall = new();
         private readonly List<string> _prefixes = [];
         private readonly Dictionary<string, PropertyInfo> _allProperties;
+        private bool? _validationUseJsonNames;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SettingsBase"/> class.
@@ -205,5 +206,10 @@ namespace CoreEx.Configuration
         /// Gets the default <see cref="RefData.ReferenceDataOrchestrator"/> <see cref="ICacheEntry.SlidingExpiration"/>. Defaults to <c>30</c> minutes.
         /// </summary>
         public TimeSpan? RefDataCacheSlidingExpiration => GetValue($"RefDataCache__{nameof(ICacheEntry.SlidingExpiration)}", TimeSpan.FromMinutes(30));
+
+        /// <summary>
+        /// Gets the default validation use of JSON names. Defaults to <c>true</c>.
+        /// </summary>
+        public bool ValidationUseJsonNames => _validationUseJsonNames ??= GetValue(nameof(ValidationUseJsonNames), true);
     }
 }

--- a/src/CoreEx/Entities/PagingArgs.cs
+++ b/src/CoreEx/Entities/PagingArgs.cs
@@ -10,7 +10,7 @@ namespace CoreEx.Entities
     /// Represents position-based paging being a) <see cref="Page"/> and <see cref="Size"/>, b) <see cref="Skip"/> and <see cref="Take"/>, or c) <see cref="Token"/> and <see cref="Take"/>. The <see cref="DefaultTake"/> and <see cref="MaxTake"/> (and <see cref="DefaultIsGetCount"/>) 
     /// are static settings to encourage page-size consistency, as well as limit the maximum value possible. 
     /// </summary>
-    //[System.Diagnostics.DebuggerStepThrough]
+    [System.Diagnostics.DebuggerStepThrough]
     public class PagingArgs : IEquatable<PagingArgs>
     {
         private static long? _defaultTake;

--- a/src/CoreEx/Hosting/README.md
+++ b/src/CoreEx/Hosting/README.md
@@ -1,18 +1,54 @@
 ﻿# CoreEx.Hosting
 
-The `CoreEx.Hosting` namespace provides additional [hosted service (worker)](https://learn.microsoft.com/en-us/dotnet/core/extensions/workers) capabilities.
+The `CoreEx.Hosting` namespace provides additional [hosted service (worker)](https://learn.microsoft.com/en-us/dotnet/core/extensions/workers) runtime capabilities.
 
 <br/>
 
 ## Motivation
 
-To enable additional [`IHostedService`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostedservice) capabilities.
+To enable improved hosted service consistency and testability, plus additional [`IHostedService`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostedservice) runtime capabilities.
+
+<br/>
+
+## Host startup
+
+To improve consistency and testability the [`IHostStartup`](./IHostStartup.cs) and [`HostStartup`](./HostStartup) implementations are provided. By seperating out the key [Dependency Injection (DI)](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) configuration from the underlying host configuration enables the DI configuration to be tested in isolation against a _test-host_ where applicable.
+
+The following is an example of a `HostStartup` implementation.
+
+```csharp
+public class Startup : HostStartup
+{
+    public override void ConfigureAppConfiguration(HostBuilderContext context, IConfigurationBuilder config)
+    {
+        config.AddEnvironmentVariables("Prefix_");
+    }
+
+    /// <inheritdoc/>
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services
+            .AddSettings()
+            .AddExecutionContext()
+            .AddJsonSerializer();
+	}
+}
+```
+
+The following is an example of a `Program` implementation that initiates a host and uses the [`ConfigureHostStartup`](HostStartupExtensions.cs) extension method to integrate the `Startup` functionality. This has an added advantage of being able to add specific startup capabilities directly to a host that should not be available to the _test-host_ (as demonstrated by `ConfigureFunctionsWorkerDefaults`).
+
+```csharp
+new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureHostStartup<Startup>()
+    .Build().Run();
+```
 
 <br/>
 
 ## Hosted services
 
-The following additional `IHostedService` implementations are provided.
+The following additional [`IHostedService`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostedservice) implementations are provided.
 
 Class | Description
 -|-

--- a/tests/CoreEx.TestFunction/Functions/HttpTriggerPublishFunction.cs
+++ b/tests/CoreEx.TestFunction/Functions/HttpTriggerPublishFunction.cs
@@ -21,6 +21,6 @@ namespace CoreEx.TestFunction.Functions
 
         [FunctionName("HttpTriggerPublishFunction")]
         public Task<IActionResult> RunAsync([HttpTrigger(AuthorizationLevel.Function, "post", Route = "products/publish")] HttpRequest request)
-            => _webApiPublisher.PublishAsync<Product>(request, "test-queue", validator: new ProductValidator().Wrap());
+            => _webApiPublisher.PublishAsync(request, new WebApiPublisherArgs<Product>("test-queue", new ProductValidator().Wrap()));
     }
 }


### PR DESCRIPTION
- *Enhancement*: The `WebApiPublisher` publishing methods have been simplified (breaking change), primarily through the use of a new _argument_ that encapsulates the various related options. This will enable the addition of further options in the future without resulting in breaking changes or adding unneccessary complexities. The related [`README`](./src/CoreEx.AspNetCore/WebApis/README.md) has been updated to document.
- *Enhancement*: Added `ValidationUseJsonNames` to `SettingsBase` (defaults to `true`) to allow setting `ValidationArgs.DefaultUseJsonNames` to be configurable.