### PR TITLE
Fix README.md duplicate

### DIFF
--- a/src/CoreEx/README.md
+++ b/src/CoreEx/README.md
@@ -36,9 +36,6 @@ Namespace | Description
 [`Text.Json`](./Text/Json) | Provides [`System.Text.Json`](https://docs.microsoft.com/en-us/dotnet/api/system.text.json) implementation of the [`IJsonSerializer`](./Json/IJsonSerializer.cs).
 [`Validation`](./Validation) | Provides implementation agnostic validation capabilities.
 [`Wildcards`](./Wildcards) | Provides standardized approach to parsing and validating [`Wildcard`](./Wildcards/Wildcard.cs) text.`
-[`Text.Json`](./Text/Json) | Provides [`System.Text.Json`](https://docs.microsoft.com/en-us/dotnet/api/system.text.json) implementation of the [`IJsonSerializer`](./Json/IJsonSerializer.cs).
-[`Validation`](./Validation) | Provides implementation agnostic validation capabilities.
-[`Wildcards`](./Wildcards) | Provides standardized approach to parsing and validating [`Wildcard`](./Wildcards/Wildcard.cs) text. 
 
 <br/>
 


### PR DESCRIPTION
Just noticed duplicate namespaces mentioned in the docs