### PR TITLE
v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Represents the **NuGet** versions.
 
+## v3.11.0
+- *Enhancement*: The `ITypedToResult` correctly implements `IToResult` as the simple `ToResult` where required. 
+- *Enhancement*: Added `Result.AsTask()` and `Result<T>.AsTask` to simplify the conversion to a completed `Task<Result>` or `Task<Result<T>>` where applicable.
+- *Enhancement*: Added `IResult.IsFailureOfType<TException>` to indicate whether the result is in a failure state and the underlying error is of the specified `TException` type.
+- *Enhancement*: Added `EventTemplate` property to the `WebApiPublisherArgs` and `WebApiPublisherCollectionArgs` to define an `EventData` template.
+- *Enhancement:* Enum renames to improve understanding of intent for event subscribing logic: `ErrorHandling.None` is now `ErrorHandling.HandleByHost` and `ErrorHandling.Handle` is now `ErrorHandling.HandleBySubscriber`.
+- *Enhancement*: Added `CoreEx.Hosting.Work` namespace which includes light-weight/simple foundational capabilities to track and orchestrate work; intended for the likes of [_asynchronous request-response_](https://learn.microsoft.com/en-us/azure/architecture/patterns/async-request-reply) scenarios.
+  - Added `IWorkStatePersistence` to enable flexible/pluggable persistence of the `WorkState` and resulting data; includes `InMemoryWorkStatePersistence` for testing, `FileWorkStatePersistence` for file-based, and `TableWorkStatePersistence` leveraging Azure table storage.
+  - Added `WorkStateOrchestrator` support to `EventSubscriberBase`, including corresponding `ServiceBusSubscriber` and `ServiceBusOrchestratedSubscriber` using the `ServiceBusMessage.MessageId` as the corresponding `WorkState.Id`.
+
 ## v3.10.0
 - *Enhancement*: The `WebApiPublisher` publishing methods have been simplified (breaking change), primarily through the use of a new _argument_ that encapsulates the various related options. This will enable the addition of further options in the future without resulting in breaking changes or adding unneccessary complexities. The related [`README`](./src/CoreEx.AspNetCore/WebApis/README.md) has been updated to document.
 - *Enhancement*: Added `ValidationUseJsonNames` to `SettingsBase` (defaults to `true`) to allow setting `ValidationArgs.DefaultUseJsonNames` to be configurable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ Represents the **NuGet** versions.
 - *Enhancement*: Added `IResult.IsFailureOfType<TException>` to indicate whether the result is in a failure state and the underlying error is of the specified `TException` type.
 - *Enhancement*: Added `EventTemplate` property to the `WebApiPublisherArgs` and `WebApiPublisherCollectionArgs` to define an `EventData` template.
 - *Enhancement:* Enum renames to improve understanding of intent for event subscribing logic: `ErrorHandling.None` is now `ErrorHandling.HandleByHost` and `ErrorHandling.Handle` is now `ErrorHandling.HandleBySubscriber`.
+- *Enhancement:* Simplified the `ServiceBusSubscriber.Receive` methods by removing the `afterReceive` parameter which served no real purpose; also, reversed the `validator` and `valueIsRequired` parameters (order as stated) as the `validator` is more likely to be used than `valueIsRequired` which defaults to `true`.
 - *Enhancement*: Added `CoreEx.Hosting.Work` namespace which includes light-weight/simple foundational capabilities to track and orchestrate work; intended for the likes of [_asynchronous request-response_](https://learn.microsoft.com/en-us/azure/architecture/patterns/async-request-reply) scenarios.
   - Added `IWorkStatePersistence` to enable flexible/pluggable persistence of the `WorkState` and resulting data; includes `InMemoryWorkStatePersistence` for testing, `FileWorkStatePersistence` for file-based, and `TableWorkStatePersistence` leveraging Azure table storage.
   - Added `WorkStateOrchestrator` support to `EventSubscriberBase`, including corresponding `ServiceBusSubscriber` and `ServiceBusOrchestratedSubscriber` using the `ServiceBusMessage.MessageId` as the corresponding `WorkState.Id`.
+  - Extended `EventSubscriberArgs` to support a new `SetWorkStateDataAsync` operation to enable the setting of the underlying `WorkState` data is a consistent manner where using the event subscriber capabilities.
 
 ## v3.10.0
 - *Enhancement*: The `WebApiPublisher` publishing methods have been simplified (breaking change), primarily through the use of a new _argument_ that encapsulates the various related options. This will enable the addition of further options in the future without resulting in breaking changes or adding unneccessary complexities. The related [`README`](./src/CoreEx.AspNetCore/WebApis/README.md) has been updated to document.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Represents the **NuGet** versions.
 - *Enhancement*: Added `Result.AsTask()` and `Result<T>.AsTask` to simplify the conversion to a completed `Task<Result>` or `Task<Result<T>>` where applicable.
 - *Enhancement*: Added `IResult.IsFailureOfType<TException>` to indicate whether the result is in a failure state and the underlying error is of the specified `TException` type.
 - *Enhancement*: Added `EventTemplate` property to the `WebApiPublisherArgs` and `WebApiPublisherCollectionArgs` to define an `EventData` template.
+- *Enhancement*: Added `SubscriberBase<T>` constructor overload to enable specification of `valueValidator` and `ValueIsRequired` parameters versus setting properties directly simplifying usage.
 - *Enhancement:* Enum renames to improve understanding of intent for event subscribing logic: `ErrorHandling.None` is now `ErrorHandling.HandleByHost` and `ErrorHandling.Handle` is now `ErrorHandling.HandleBySubscriber`.
 - *Enhancement:* Simplified the `ServiceBusSubscriber.Receive` methods by removing the `afterReceive` parameter which served no real purpose; also, reversed the `validator` and `valueIsRequired` parameters (order as stated) as the `validator` is more likely to be used than `valueIsRequired` which defaults to `true`.
 - *Enhancement*: Added `CoreEx.Hosting.Work` namespace which includes light-weight/simple foundational capabilities to track and orchestrate work; intended for the likes of [_asynchronous request-response_](https://learn.microsoft.com/en-us/azure/architecture/patterns/async-request-reply) scenarios.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 Represents the **NuGet** versions.
 
 ## v3.11.0
-- *Enhancement*: The `ITypedToResult` correctly implements `IToResult` as the simple `ToResult` where required. 
+- *Enhancement*: The `ITypedToResult` updated to correctly implement `IToResult` as the simple `ToResult` where required. 
 - *Enhancement*: Added `Result.AsTask()` and `Result<T>.AsTask` to simplify the conversion to a completed `Task<Result>` or `Task<Result<T>>` where applicable.
 - *Enhancement*: Added `IResult.IsFailureOfType<TException>` to indicate whether the result is in a failure state and the underlying error is of the specified `TException` type.
 - *Enhancement*: Added `EventTemplate` property to the `WebApiPublisherArgs` and `WebApiPublisherCollectionArgs` to define an `EventData` template.
 - *Enhancement*: Added `SubscriberBase<T>` constructor overload to enable specification of `valueValidator` and `ValueIsRequired` parameters versus setting properties directly simplifying usage.
 - *Enhancement:* Enum renames to improve understanding of intent for event subscribing logic: `ErrorHandling.None` is now `ErrorHandling.HandleByHost` and `ErrorHandling.Handle` is now `ErrorHandling.HandleBySubscriber`.
-- *Enhancement:* Simplified the `ServiceBusSubscriber.Receive` methods by removing the `afterReceive` parameter which served no real purpose; also, reversed the `validator` and `valueIsRequired` parameters (order as stated) as the `validator` is more likely to be used than `valueIsRequired` which defaults to `true`.
+- *Enhancement:* Simplified the `ServiceBusSubscriber.Receive` methods by removing the `afterReceive` parameter which served no real purpose; also, reversed the `validator` and `valueIsRequired` parameters (order as stated) as the `validator` is more likely to be specified than `valueIsRequired` which defaults to `true`.
 - *Enhancement*: Added `CoreEx.Hosting.Work` namespace which includes light-weight/simple foundational capabilities to track and orchestrate work; intended for the likes of [_asynchronous request-response_](https://learn.microsoft.com/en-us/azure/architecture/patterns/async-request-reply) scenarios.
   - Added `IWorkStatePersistence` to enable flexible/pluggable persistence of the `WorkState` and resulting data; includes `InMemoryWorkStatePersistence` for testing, `FileWorkStatePersistence` for file-based, and `TableWorkStatePersistence` leveraging Azure table storage.
   - Added `WorkStateOrchestrator` support to `EventSubscriberBase`, including corresponding `ServiceBusSubscriber` and `ServiceBusOrchestratedSubscriber` using the `ServiceBusMessage.MessageId` as the corresponding `WorkState.Id`.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.10.0</Version>
+		<Version>3.11.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.0.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/My.Hr/My.Hr.Api/Startup.cs
+++ b/samples/My.Hr/My.Hr.Api/Startup.cs
@@ -32,7 +32,7 @@ public class Startup
             .AddAzureServiceBusPurger()
             .AddAzureServiceBusClient(connectionName: nameof(HrSettings.ServiceBusConnection), configure: (o, sp) => o.RetryOptions.MaxRetries = 3)
             .AddJsonMergePatch()
-            .AddWebApi(c => c.UnhandledExceptionAsync = (ex, _, _) => Task.FromResult(ex is DbUpdateConcurrencyException efex ? WebApiBase.CreateActionResultFromExtendedException(new ConcurrencyException()) : null))
+            .AddWebApi((_, c) => c.UnhandledExceptionAsync = (ex, _, _) => Task.FromResult(ex is DbUpdateConcurrencyException efex ? WebApiBase.CreateActionResultFromExtendedException(new ConcurrencyException()) : null))
             .AddReferenceDataContentWebApi()
             .AddRequestCache();
 

--- a/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
+++ b/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.3.15" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/My.Hr/My.Hr.Functions/My.Hr.Functions.csproj
+++ b/samples/My.Hr/My.Hr.Functions/My.Hr.Functions.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.5.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/My.Hr/My.Hr.Functions/Startup.cs
+++ b/samples/My.Hr/My.Hr.Functions/Startup.cs
@@ -41,7 +41,7 @@ public class Startup : FunctionsStartup
                 .AddEventDataFormatter()
                 .AddEventPublisher()
                 .AddAzureServiceBusSender()
-                .AddWebApi(c => c.UnhandledExceptionAsync = (ex, _, _) => Task.FromResult(ex is DbUpdateConcurrencyException efex ? WebApiBase.CreateActionResultFromExtendedException(new ConcurrencyException()) : null))
+                .AddWebApi((_, c) => c.UnhandledExceptionAsync = (ex, _, _) => Task.FromResult(ex is DbUpdateConcurrencyException efex ? WebApiBase.CreateActionResultFromExtendedException(new ConcurrencyException()) : null))
                 .AddJsonMergePatch()
                 .AddWebApiPublisher()
                 .AddAzureServiceBusSubscriber()

--- a/samples/My.Hr/My.Hr.UnitTest/EmployeeControllerTest.cs
+++ b/samples/My.Hr/My.Hr.UnitTest/EmployeeControllerTest.cs
@@ -184,6 +184,7 @@ namespace My.Hr.UnitTest
                 .AssertCreated()
                 .AssertValue(e, "Id", "ETag")
                 .AssertLocationHeader<Employee>(v => new Uri($"api/employees/{v!.Id}", UriKind.Relative))
+                .AssertLocationHeaderContains("api/employees") // Just for kicks testing both types work
                 .GetValue<Employee>();
 
             // Do a GET to make sure it is in the database and all fields equal.

--- a/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
+++ b/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CoreEx.AspNetCore/Abstractions/AspNetCoreServiceCollectionExtensions.cs
+++ b/src/CoreEx.AspNetCore/Abstractions/AspNetCoreServiceCollectionExtensions.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="configure">The action to enable the <see cref="WebApi"/> to be further configured.</param>
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
-        public static IServiceCollection AddWebApi(this IServiceCollection services, Action<WebApi>? configure = null) => CheckServices(services).AddScoped(sp =>
+        public static IServiceCollection AddWebApi(this IServiceCollection services, Action<IServiceProvider, WebApi>? configure = null) => CheckServices(services).AddScoped(sp =>
         {
             var wa = new WebApi(sp.GetRequiredService<ExecutionContext>(), sp.GetRequiredService<SettingsBase>(), sp.GetRequiredService<IJsonSerializer>(), sp.GetRequiredService<ILogger<WebApi>>(), sp.GetService<WebApiInvoker>(), sp.GetService<IJsonMergePatch>());
-            configure?.Invoke(wa);
+            configure?.Invoke(sp, wa);
             return wa;
         });
 
@@ -40,10 +40,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="configure">The action to enable the <see cref="WebApi"/> to be further configured.</param>
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
-        public static IServiceCollection AddReferenceDataContentWebApi(this IServiceCollection services, Action<ReferenceDataContentWebApi>? configure = null) => CheckServices(services).AddScoped(sp =>
+        public static IServiceCollection AddReferenceDataContentWebApi(this IServiceCollection services, Action<IServiceProvider, ReferenceDataContentWebApi>? configure = null) => CheckServices(services).AddScoped(sp =>
         {
             var wa = new ReferenceDataContentWebApi(sp.GetRequiredService<ExecutionContext>(), sp.GetRequiredService<SettingsBase>(), sp.GetRequiredService<IReferenceDataContentJsonSerializer>(), sp.GetRequiredService<ILogger<WebApi>>(), sp.GetService<WebApiInvoker>(), sp.GetService<IJsonMergePatch>());
-            configure?.Invoke(wa);
+            configure?.Invoke(sp, wa);
             return wa;
         });
 
@@ -53,10 +53,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="configure">The action to enable the <see cref="WebApi"/> to be further configured.</param>
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
-        public static IServiceCollection AddWebApiPublisher(this IServiceCollection services, Action<WebApiPublisher>? configure = null) => CheckServices(services).AddScoped(sp =>
+        public static IServiceCollection AddWebApiPublisher(this IServiceCollection services, Action<IServiceProvider, WebApiPublisher>? configure = null) => CheckServices(services).AddScoped(sp =>
         {
             var wap = new WebApiPublisher(sp.GetRequiredService<IEventPublisher>(), sp.GetRequiredService<ExecutionContext>(), sp.GetRequiredService<SettingsBase>(), sp.GetRequiredService<IJsonSerializer>(), sp.GetRequiredService<ILogger<WebApiPublisher>>(), sp.GetService<WebApiInvoker>());
-            configure?.Invoke(wap);
+            configure?.Invoke(sp,wap);
             return wap;
         });
     }

--- a/src/CoreEx.AspNetCore/README.md
+++ b/src/CoreEx.AspNetCore/README.md
@@ -203,24 +203,25 @@ Depending on the overload used (as defined above), an optional _argument_ can be
 
 The following argurment types are supported:
 - [`WebApiPublisherArgs<TValue>`](./WebApis/WebApiPublisherArgsT.cs) - single message with no mapping.
-- [`WebApiPublisherArgs<TValue, TEventValue>`](./WebApis/WebApiPublisherArgsT2.cs) - single message _with_ mapping.
+- [`WebApiPublisherArgs<TValue, TEventValue>`](./WebApis/WebApiPublisherArgsT2.cs) - single message _with_ [mapping](https://github.com/Avanade/CoreEx/tree/main/src/CoreEx/Mapping).
 - [`WebApiPublisherCollectionArgs<TColl, TItem>`](./WebApis/WebApiPublisherCollectionArgsT.cs) - collection of messages with no mapping.
-- [`WebApiPublisherCollectionArgs<TColl, TItem, TEventItem>`](./WebApis/WebApiPublisherCollectionArgsT2.cs) - collection of messages _with_ mapping.
+- [`WebApiPublisherCollectionArgs<TColl, TItem, TEventItem>`](./WebApis/WebApiPublisherCollectionArgsT2.cs) - collection of messages _with_ [mapping](https://github.com/Avanade/CoreEx/tree/main/src/CoreEx/Mapping).
 
 The arguments will have the following properties depending on the supported functionality. The sequence defines the order in which each of the properties is enacted (orchestrated) internally. Where a failure or exception occurs then the execution will be aborted and the corresponding `IActionResult` returned (including the likes of logging etc. where applicable).
 
 Property | Description | Sequence
 -|-
 `EventName` | The event destintion name (e.g. Queue or Topic name) where applicable. | N/A
+`EventTemplate` | The [`EventData`](../CoreEx/Events/EventData.cs) template to be used to create the message/event. | N/A
 `StatusCode` | The resulting status code where successful. Defaults to `204-Accepted`. | N/A
 `OperationType` | The [`OperationType`](../CoreEx/OperationType.cs). Defaults to `OperationType.Unspecified`. | N/A
-`MaxCollectionSize` | The maximum collection size allowed/supported. | 1
+`MaxCollectionSize` | The maximum collection size allowed/supported (where applicable). | 1
 `OnBeforeValidateAsync` | The function to be invoked before the request value is validated; opportunity to modify contents. | 2
 `Validator` | The `IValidator<T>` to validate the request value. | 3
 `OnBeforeEventAsync` | The function to be invoked after validation / before event; opportunity to modify contents. | 4
-`Mapper` | The `IMapper<TSource, TDestination>` override. | 5
+`Mapper` | The `IMapper<TSource, TDestination>` override (where applicable). | 5
 `OnEvent` | The action to be invoked once converted to an [`EventData`](../CoreEx/Events/EventData.cs); opportunity to modify contents. | 6
-`CreateSuccessResult` | The function to be invoked to create/override the success `IActionResult`. | 7
+`CreateSuccessResult` | The function to be invoked to create/override the success `IActionResult`. Defaults to returning specified `StatusCode`. | 7
 
 <br/>
 

--- a/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherArgs.cs
@@ -44,7 +44,12 @@ namespace CoreEx.AspNetCore.WebApis
         HttpStatusCode StatusCode { get; }
 
         /// <summary>
-        /// Gets or sets the optional validator.
+        /// Indicates whether the <typeparamref name="TValue"/> is required.
+        /// </summary>
+        bool ValueIsRequired { get; }
+
+        /// <summary>
+        /// Gets or sets the optional <typeparamref name="TValue"/> validator.
         /// </summary>
         IValidator<TValue>? Validator { get; }
 
@@ -95,7 +100,8 @@ namespace CoreEx.AspNetCore.WebApis
         /// <summary>
         /// Gets or sets the function to create the <see cref="WorkStateArgs"/>.
         /// </summary>
-        /// <remarks><para>The <see cref="WorkStateArgs.Id"/> and <see cref="WorkStateArgs.CorrelationId"/> will be overridden by the <see cref="EventData"/> equivalents after creation to ensure consistencey; therefore, these properties need not be set during create.</para>
+        /// <remarks><para>The <see cref="WorkStateArgs.Id"/> and <see cref="WorkStateArgs.CorrelationId"/> will be overridden by the <see cref="EventData"/> equivalents after creation to ensure consistencey; therefore, these properties need
+        /// not be set during create. The <see cref="WorkStateArgs.Key"/> will be set to the <see cref="EventDataBase.Key"/> where <c>null</c>, so also does not need to be explicitly set.</para>
         /// An <see cref="InvalidOperationException"/> will occur where this is set and the corresponding <see cref="WebApiPublisher.WorkStateOrchestrator"/> is <c>null</c>. The combination of the two enables
         /// the automatic create (<see cref="WorkStateOrchestrator.CreateAsync(WorkStateArgs, CancellationToken)"/>) of <see cref="WorkState"/> tracking to enable the likes of the <i>asynchronous request-response</i> pattern.</remarks>
         Func<WorkStateArgs>? CreateWorkStateArgs { get; }

--- a/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherArgs.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using CoreEx.Events;
+using CoreEx.Hosting.Work;
 using CoreEx.Mapping;
 using CoreEx.Results;
 using CoreEx.Validation;
@@ -31,6 +32,12 @@ namespace CoreEx.AspNetCore.WebApis
         string? EventName { get; }
 
         /// <summary>
+        /// Gets or sets the optional <see cref="EventData"/> to use as a template when instantiating the <see cref="EventData"/> for publishing.
+        /// </summary>
+        /// <remarks>Will use the <see cref="EventData(EventDataBase)"/> constructor to copy from the template.</remarks>
+        EventData? EventTemplate { get; }
+
+        /// <summary>
         /// Gets or sets the <see cref="HttpStatusCode"/> where successful.
         /// </summary>
         /// <remarks>Defaults to <see cref="HttpStatusCode.Accepted"/>.</remarks>
@@ -48,21 +55,21 @@ namespace CoreEx.AspNetCore.WebApis
         OperationType OperationType { get; }
 
         /// <summary>
-        /// Gets or sets the on before validation <typeparamref name="TValue"/> modifier function.
+        /// Gets or sets the on before validation <typeparamref name="TValue"/> function.
         /// </summary>
-        /// <remarks>Enables the value to be modified before validation. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        /// <remarks>Enables the likes of security, value modification, etc., before validation. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
         Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? OnBeforeValidationAsync { get; }
 
         /// <summary>
-        /// Gets or sets the after validation / on before event <typeparamref name="TValue"/> modifier function.
+        /// Gets or sets the after validation / on before event <typeparamref name="TValue"/> function.
         /// </summary>
-        /// <remarks>Enables the value to be modified after validation. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        /// <remarks>Enables the likes of security, value modification, etc., after validation. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
         Func<WebApiParam<TValue>, CancellationToken, Task<Result>>? OnBeforeEventAsync { get; }
 
         /// <summary>
         /// Gets or sets the <see cref="EventData"/> modifier function.
         /// </summary>
-        /// <remarks>Enables the corresponding <see cref="EventData"/> to be modified prior to publish.</remarks>
+        /// <remarks>Enables the corresponding <see cref="EventData"/> to be modified prior to publish beyond the <see cref="EventTemplate"/> application.</remarks>
         Action<EventData>? OnEvent { get; }
 
         /// <summary>
@@ -75,6 +82,22 @@ namespace CoreEx.AspNetCore.WebApis
         /// Gets or sets the function to override the creation of the success <see cref="IActionResult"/>.
         /// </summary>
         /// <remarks>Defaults to a <see cref="ExtendedStatusCodeResult"/> using the defined <see cref="StatusCode"/>.</remarks>
-        Func<IActionResult>? CreateSuccessResult { get; }
+        Func<Task<IActionResult>>? CreateSuccessResultAsync { get; }
+
+        /// <summary>
+        /// Gets or sets the function to create the <see cref="Uri"/> for the <see cref="Microsoft.AspNetCore.Http.Headers.ResponseHeaders.Location"/>.
+        /// </summary>
+        /// <remarks>
+        /// Where enabling the likes of the <i>asynchronous request-response</i> pattern then the <see cref="EventDataBase.Id"/> represents the <see cref="WorkState.Id"/> which is the unique identifier for the work instance and is therefore required.
+        /// <para>This will not be invoked automatically where the <see cref="CreateSuccessResultAsync"/> is overridden.</para></remarks>
+        Func<WebApiParam<TValue>, EventData, Uri>? CreateLocation { get; }
+
+        /// <summary>
+        /// Gets or sets the function to create the <see cref="WorkStateArgs"/>.
+        /// </summary>
+        /// <remarks><para>The <see cref="WorkStateArgs.Id"/> and <see cref="WorkStateArgs.CorrelationId"/> will be overridden by the <see cref="EventData"/> equivalents after creation to ensure consistencey; therefore, these properties need not be set during create.</para>
+        /// An <see cref="InvalidOperationException"/> will occur where this is set and the corresponding <see cref="WebApiPublisher.WorkStateOrchestrator"/> is <c>null</c>. The combination of the two enables
+        /// the automatic create (<see cref="WorkStateOrchestrator.CreateAsync(WorkStateArgs, CancellationToken)"/>) of <see cref="WorkState"/> tracking to enable the likes of the <i>asynchronous request-response</i> pattern.</remarks>
+        Func<WorkStateArgs>? CreateWorkStateArgs { get; }
     }
 }

--- a/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherCollectionArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/IWebApiPublisherCollectionArgs.cs
@@ -34,6 +34,12 @@ namespace CoreEx.AspNetCore.WebApis
         string? EventName { get; }
 
         /// <summary>
+        /// Gets or sets the optional <see cref="EventData"/> to use as a template when instantiating the <see cref="EventData"/> for publishing.
+        /// </summary>
+        /// <remarks>Will use the <see cref="EventData(EventDataBase)"/> constructor to copy from the template.</remarks>
+        EventData? EventTemplate { get; }
+
+        /// <summary>
         /// Gets or sets the <see cref="HttpStatusCode"/> where successful.
         /// </summary>
         /// <remarks>Defaults to <see cref="HttpStatusCode.Accepted"/>.</remarks>
@@ -84,6 +90,6 @@ namespace CoreEx.AspNetCore.WebApis
         /// Gets or sets the function to override the creation of the success <see cref="IActionResult"/>.
         /// </summary>
         /// <remarks>Defaults to a <see cref="ExtendedStatusCodeResult"/> using the defined <see cref="StatusCode"/>.</remarks>
-        Func<IActionResult>? CreateSuccessResult { get; }
+        Func<Task<IActionResult>>? CreateSuccessResultAsync { get; }
     }
 }

--- a/src/CoreEx.AspNetCore/WebApis/ValueContentResult.cs
+++ b/src/CoreEx.AspNetCore/WebApis/ValueContentResult.cs
@@ -59,6 +59,11 @@ namespace CoreEx.AspNetCore.WebApis
         /// </summary>
         public Uri? Location { get; set; }
 
+        /// <summary>
+        /// Gets or sets the <see cref="TimeSpan"/> for the <see cref="System.Net.Http.Headers.RetryConditionHeaderValue"/>.
+        /// </summary>
+        public TimeSpan? RetryAfter { get; set; }
+
         /// <inheritdoc/>
         public override Task ExecuteResultAsync(ActionContext context)
         {
@@ -70,6 +75,9 @@ namespace CoreEx.AspNetCore.WebApis
 
             if (Location != null)
                 headers.Location = Location;
+
+            if (RetryAfter is not null)
+                context.HttpContext.Response.Headers.Append(HeaderNames.RetryAfter, new System.Net.Http.Headers.RetryConditionHeaderValue(RetryAfter.Value).ToString());
 
             return base.ExecuteResultAsync(context);
         }

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisher.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisher.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.AspNetCore.Http;
 using CoreEx.Configuration;
 using CoreEx.Events;
+using CoreEx.Hosting.Work;
 using CoreEx.Json;
 using CoreEx.Mapping;
 using CoreEx.Results;
@@ -11,15 +13,19 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Timers;
+using YamlDotNet.Core.Tokens;
 
 namespace CoreEx.AspNetCore.WebApis
 {
     /// <summary>
     /// Provides the core <see cref="IEventPublisher"/> Web API execution encapsulation.
     /// </summary>
-    /// <remarks>Support to change/map request into a different published event type is also enabled where required (see also <seealso cref="Mapper"/>).</remarks>
+    /// <remarks>Support to change/map request into a different published event type is also enabled where required (see also <seealso cref="Mapper"/>).
+    /// <para>By adding a <see cref="WorkStateOrchestrator"/> then the beginnings of the <i>asynchronous request-response</i> pattern implementation can be achieved.</para></remarks>
     /// <param name="eventPublisher">The <see cref="IEventPublisher"/>.</param>
     /// <param name="executionContext">The <see cref="ExecutionContext"/>.</param>
     /// <param name="settings">The <see cref="SettingsBase"/>.</param>
@@ -46,6 +52,12 @@ namespace CoreEx.AspNetCore.WebApis
             get => _mapper ??= ExecutionContext.GetRequiredService<IMapper>();
             set => _mapper = value;
         }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Hosting.Work.WorkStateOrchestrator"/>.
+        /// </summary>
+        /// <remarks>See <see cref="IWebApiPublisherArgs{TValue, TEventValue}.CreateWorkStateArgs"/> for corresponding <i>asynchronous request-response</i> pattern implementation.</remarks>
+        public WorkStateOrchestrator? WorkStateOrchestrator { get; set; }
 
         #region PublishAsync
 
@@ -112,6 +124,9 @@ namespace CoreEx.AspNetCore.WebApis
             if (request.Method != HttpMethods.Post)
                 throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Post}' to use {nameof(PublishAsync)}.", nameof(request));
 
+            if (args.CreateWorkStateArgs is not null && WorkStateOrchestrator is null)
+                throw new InvalidOperationException($"The {nameof(WorkStateOrchestrator)} must be set to use {nameof(IWebApiPublisherArgs<TValue, TEventValue>)}.{nameof(IWebApiPublisherArgs<TValue, TEventValue>.CreateWorkStateArgs)}.");    
+
             return await RunAsync(request, async (wap, ct) =>
             {
                 // Use specified value or get from the request. 
@@ -124,15 +139,35 @@ namespace CoreEx.AspNetCore.WebApis
                     .WhenAsAsync(() => args.OnBeforeValidationAsync is not null, () => args.OnBeforeValidationAsync!(wapv!, ct))
                     .WhenAsAsync(_ => args.Validator is not null, async _ => (await args.Validator!.ValidateAsync(wapv!.Value!, ct).ConfigureAwait(false)).ToResult<TValue>())
                     .WhenAsync(_ => args.OnBeforeEventAsync is not null, _ => args.OnBeforeEventAsync!(wapv!, ct))
-                    .WhenAs(_ => args.AreSameType, _ => new EventData { Value = wapv!.Value }, _ => new EventData { Value = args.Mapper is not null ? args.Mapper.Map(wapv!.Value) : Mapper.Map<TValue, TEventValue>(wapv!.Value) })
+                    .ThenAs(_ => args.EventTemplate is null ? new EventData() : new EventData(args.EventTemplate))
+                    .WhenAs(e => args.AreSameType, e => e.Adjust(x => x.Value = wapv!.Value), e => e.Adjust(x => x.Value = args.Mapper is not null ? args.Mapper.Map(wapv!.Value) : Mapper.Map<TValue, TEventValue>(wapv!.Value)))
                     .Then(e => args.OnEvent?.Invoke(e))
-                    .ThenAs(e => args.EventName is null ? EventPublisher.Publish(e) : EventPublisher.PublishNamed(args.EventName, e))
-                    .ThenAsync(_ => EventPublisher.SendAsync(ct)).ConfigureAwait(false);
+                    .Then(e =>
+                    {
+                        if (args.EventName is null)
+                            EventPublisher.Publish(e);
+                        else
+                            EventPublisher.PublishNamed(args.EventName, e);
+                    })
+                    .ThenAsync(async e =>
+                    {
+                        await EventPublisher.SendAsync(ct).ConfigureAwait(false);
+                    })
+                    .WhenAsync(e => WorkStateOrchestrator is not null && args.CreateWorkStateArgs is not null, async e =>
+                    {
+                        var wsa = args.CreateWorkStateArgs!();
+                        wsa.Id = e.Id;
+                        wsa.CorrelationId = e.CorrelationId;
+                        await WorkStateOrchestrator!.CreateAsync(wsa).ConfigureAwait(false);
+                    });
 
                 if (r.IsFailure)
                     return await CreateActionResultFromExceptionAsync(this, request.HttpContext, r.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
 
-                return args.CreateSuccessResult?.Invoke() ?? new ExtendedStatusCodeResult(args.StatusCode);
+                if (args.CreateSuccessResultAsync is not null)
+                    return await args.CreateSuccessResultAsync().ConfigureAwait(false) ?? throw new InvalidOperationException($"The {nameof(IWebApiPublisherArgs<TValue, TEventValue>.CreateSuccessResultAsync)} must return a result.");
+
+                return new ExtendedStatusCodeResult(args.StatusCode) { Location = args.CreateLocation?.Invoke(wapv!, r.Value) };
             }, args.OperationType, cancellationToken, nameof(PublishAsync)).ConfigureAwait(false);
         }
 
@@ -242,7 +277,8 @@ namespace CoreEx.AspNetCore.WebApis
                 // Create the events (also performing mapping where applicable).
                 foreach (var item in wapc!.Value!)
                 {
-                    var @event = new EventData { Value = args.AreSameType ? item : (args.Mapper is not null ? args.Mapper.Map(item) : Mapper.Map<TItem, TEventValue>(item)) };
+                    var @event = args.EventTemplate is null ? new EventData() : new EventData(args.EventTemplate);
+                    @event.Value = args.AreSameType ? item : (args.Mapper is not null ? args.Mapper.Map(item) : Mapper.Map<TItem, TEventValue>(item));
                     args.OnEvent?.Invoke(@event);
 
                     if (args.EventName is null)
@@ -253,8 +289,175 @@ namespace CoreEx.AspNetCore.WebApis
 
                 await EventPublisher.SendAsync(ct).ConfigureAwait(false);
 
-                return args.CreateSuccessResult?.Invoke() ?? new ExtendedStatusCodeResult(args.StatusCode);
+                if (args.CreateSuccessResultAsync is not null)
+                    return await args.CreateSuccessResultAsync().ConfigureAwait(false) ?? throw new InvalidOperationException($"The {nameof(IWebApiPublisherCollectionArgs<TColl, TItem, TEventValue>.CreateSuccessResultAsync)} must return a result.");
+
+                return new ExtendedStatusCodeResult(args.StatusCode);
             }, args.OperationType, cancellationToken, nameof(PublishAsync)).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region Async Request-Response
+
+        /// <summary>
+        /// Performs a <see cref="HttpMethods.Get"/> operation to get the <see cref="WorkState"/> <see cref="WorkState.Status"/> to enable the likes of the <i>asynchronous request-response</i> pattern.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <param name="args">The <see cref="WebApiPublisherStatusArgs"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The corresponding <see cref="IActionResult"/>.</returns>
+        public Task<IActionResult> GetWorkStatusAsync(HttpRequest request, WebApiPublisherStatusArgs args, CancellationToken cancellationToken = default)
+        {
+            if (WorkStateOrchestrator is null)
+                throw new InvalidOperationException($"The {nameof(GetWorkStatusAsync)} operation requires that the {nameof(WorkStateOrchestrator)} is not null.");
+
+            request.ThrowIfNull(nameof(request));
+            args.ThrowIfNull(nameof(args));
+
+            if (request.Method != HttpMethods.Get)
+                throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Get}' to use {nameof(GetWorkStatusAsync)}.", nameof(request));
+
+            return RunAsync(request, async (wap, ct) =>
+            {
+                var ws = string.IsNullOrEmpty(args.Id) ? null : await WorkStateOrchestrator!.GetAsync(args.TypeName, args.Id, ct).ConfigureAwait(false);
+                if (ws is null)
+                    return new ExtendedStatusCodeResult(HttpStatusCode.NotFound);
+
+                if (args.OnBeforeResponseAsync is not null)
+                {
+                    var r = await args.OnBeforeResponseAsync(ws).ConfigureAwait(false);
+                    if (r.IsFailure)
+                        return await CreateActionResultFromExceptionAsync(this, request.HttpContext, r.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Check for the completed status and redirect to the result location where applicable.
+                if (ws.Status == WorkStatus.Completed && args.CreateResultLocation is not null)
+                    return new RedirectResult(args.CreateResultLocation(ws).ToString());
+
+                // Return the work status as either a BadRequest or OK.
+                var res = ValueContentResult.CreateResult(ws, WorkStatus.Terminated.HasFlag(ws.Status) ? HttpStatusCode.BadRequest : HttpStatusCode.OK, null, JsonSerializer, request.GetRequestOptions(), true, null);
+                if (res is ValueContentResult vcr && WorkStatus.Executing.HasFlag(ws.Status))
+                    vcr.RetryAfter = args.ExecutingRetryAfter;
+
+                return res;
+
+            }, OperationType.Unspecified, cancellationToken, nameof(GetWorkStatusAsync));
+        }
+
+        /// <summary>
+        /// Performs a <see cref="HttpMethods.Get"/> operation to get the <see cref="WorkState"/> result with no resulting value by default.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <param name="args">The <see cref="WebApiPublisherResultArgs"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The corresponding <see cref="IActionResult"/>.</returns>
+        public Task<IActionResult> GetWorkResultAsync(HttpRequest request, WebApiPublisherResultArgs args, CancellationToken cancellationToken = default)
+        {
+            if (WorkStateOrchestrator is null)
+                throw new InvalidOperationException($"The {nameof(GetWorkResultAsync)} operation requires that the {nameof(WorkStateOrchestrator)} is not null.");
+
+            request.ThrowIfNull(nameof(request));
+            args.ThrowIfNull(nameof(args));
+
+            if (request.Method != HttpMethods.Get)
+                throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Get}' to use {nameof(GetWorkResultAsync)}.", nameof(request));
+
+            return RunAsync(request, async (wap, ct) =>
+            {
+                var ws = string.IsNullOrEmpty(args.Id) ? null : await WorkStateOrchestrator!.GetAsync(args.TypeName, args.Id, ct).ConfigureAwait(false);
+                if (ws is null || ws.Status != WorkStatus.Completed)
+                    return new ExtendedStatusCodeResult(HttpStatusCode.NotFound);
+
+                if (args.OnBeforeResponseAsync is not null)
+                {
+                    var r = await args.OnBeforeResponseAsync(ws).ConfigureAwait(false);
+                    if (r.IsFailure)
+                        return await CreateActionResultFromExceptionAsync(this, request.HttpContext, r.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (args.CreateSuccessResultAsync is not null)
+                    return await args.CreateSuccessResultAsync(ws).ConfigureAwait(false) ?? throw new InvalidOperationException($"The {nameof(WebApiPublisherResultArgs.CreateSuccessResultAsync)} must return a result.");
+
+                return new ExtendedStatusCodeResult(HttpStatusCode.NoContent); 
+
+            }, OperationType.Unspecified, cancellationToken, nameof(GetWorkResultAsync));
+        }
+
+        /// <summary>
+        /// Performs a <see cref="HttpMethods.Get"/> operation to get the <see cref="WorkState"/> result with a result of <see cref="Type"/> <typeparamref name="TValue"/>.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <param name="args">The <see cref="WebApiPublisherResultArgs{TValue}"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The corresponding <see cref="IActionResult"/>.</returns>
+        public Task<IActionResult> GetWorkResultAsync<TValue>(HttpRequest request, WebApiPublisherResultArgs<TValue> args, CancellationToken cancellationToken = default)
+        {
+            if (WorkStateOrchestrator is null)
+                throw new InvalidOperationException($"The {nameof(GetWorkResultAsync)} operation requires that the {nameof(WorkStateOrchestrator)} is not null.");
+
+            request.ThrowIfNull(nameof(request));
+            args.ThrowIfNull(nameof(args));
+
+            if (request.Method != HttpMethods.Get)
+                throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Get}' to use {nameof(GetWorkResultAsync)}.", nameof(request));
+
+            return RunAsync(request, async (wap, ct) =>
+            {
+                var ws = string.IsNullOrEmpty(args.Id) ? null : await WorkStateOrchestrator!.GetAsync(args.TypeName, args.Id, ct).ConfigureAwait(false);
+                if (ws is null || ws.Status != WorkStatus.Completed)
+                    return new ExtendedStatusCodeResult(HttpStatusCode.NotFound);
+
+                if (args.OnBeforeResponseAsync is not null)
+                {
+                    var r = await args.OnBeforeResponseAsync(ws).ConfigureAwait(false);
+                    if (r.IsFailure)
+                        return await CreateActionResultFromExceptionAsync(this, request.HttpContext, r.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
+                }
+
+                var value = await WorkStateOrchestrator.GetDataAsync<TValue>(args.Id!, ct).ConfigureAwait(false);
+                return ValueContentResult.CreateResult(value, HttpStatusCode.OK, HttpStatusCode.NoContent, JsonSerializer, request.GetRequestOptions(), true, null);
+            }, OperationType.Unspecified, cancellationToken, nameof(GetWorkResultAsync));
+        }
+
+        /// <summary>
+        /// Performs a <see cref="HttpMethods.Post"/> operation to cancel the <see cref="WorkState"/> <see cref="WorkState.Status"/> to enable the likes of the <i>asynchronous request-response</i> pattern.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequest"/>.</param>
+        /// <param name="args">The <see cref="WebApiPublisherCancelArgs"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The corresponding <see cref="IActionResult"/>.</returns>
+        public Task<IActionResult> CancelWorkStatusAsync(HttpRequest request, WebApiPublisherCancelArgs args, CancellationToken cancellationToken = default)
+        {
+            if (WorkStateOrchestrator is null)
+                throw new InvalidOperationException($"The {nameof(CancelWorkStatusAsync)} operation requires that the {nameof(WorkStateOrchestrator)} is not null.");
+
+            request.ThrowIfNull(nameof(request));
+            args.ThrowIfNull(nameof(args));
+
+            if (request.Method != HttpMethods.Get)
+                throw new ArgumentException($"HttpRequest.Method is '{request.Method}'; must be '{HttpMethods.Get}' to use {nameof(CancelWorkStatusAsync)}.", nameof(request));
+
+            return RunAsync(request, async (wap, ct) =>
+            {
+                var ws = string.IsNullOrEmpty(args.Id) ? null : await WorkStateOrchestrator!.GetAsync(args.TypeName, args.Id, ct).ConfigureAwait(false);
+                if (ws is null)
+                    return new ExtendedStatusCodeResult(HttpStatusCode.NotFound);
+
+                if (args.OnBeforeResponseAsync is not null)
+                {
+                    var r = await args.OnBeforeResponseAsync(ws).ConfigureAwait(false);
+                    if (r.IsFailure)
+                        return await CreateActionResultFromExceptionAsync(this, request.HttpContext, r.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Check for the completed status and redirect to the result location where applicable.
+                var cr = await WorkStateOrchestrator!.CancelAsync(args.Id!, args.Reason ?? WebApiPublisherCancelArgs.NotSpecifiedReason, ct).ConfigureAwait(false);
+                if (cr.IsFailure)
+                    return await CreateActionResultFromExceptionAsync(this, request.HttpContext, cr.Error, Settings, Logger, OnUnhandledExceptionAsync, cancellationToken).ConfigureAwait(false);
+
+                return ValueContentResult.CreateResult(cr.Value, HttpStatusCode.OK, null, JsonSerializer, request.GetRequestOptions(), true, null);
+            }, OperationType.Unspecified, cancellationToken, nameof(CancelWorkStatusAsync));
         }
 
         #endregion

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgs.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Events;
+using CoreEx.Hosting.Work;
+using CoreEx.Mapping;
+using CoreEx.Results;
+using CoreEx.Validation;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Represents the <see cref="WebApiPublisher"/> arguments; being the opportunity to further configure the standard processing.
+    /// </summary>
+    /// <remarks>
+    /// Initializes a new instance of the <see cref="WebApiPublisherArgs{TValue}"/> class.
+    /// </remarks>
+    /// <param name="eventName">The event destination name (e.g. Queue or Topic name).</param>
+    public class WebApiPublisherArgs(string eventName) : IWebApiPublisherArgs<object, object>
+    {
+        /// <inheritdoc/>
+        public string? EventName { get; set; } = eventName.ThrowIfNull(nameof(eventName));
+
+        /// <inheritdoc/>
+        public EventData? EventTemplate { get; set; }
+
+        /// <inheritdoc/>
+        public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
+
+        /// <inheritdoc/>
+        bool IWebApiPublisherArgs<object, object>.ValueIsRequired => false;
+
+        /// <inheritdoc/>
+        IValidator<object>? IWebApiPublisherArgs<object, object>.Validator => null;
+
+        /// <inheritdoc/>
+        public OperationType OperationType { get; set; } = OperationType.Unspecified;
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<object>, CancellationToken, Task<Result>>? OnBeforeValidationAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<object>, CancellationToken, Task<Result>>? OnBeforeEventAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Action<EventData>? OnEvent { get; set; }
+
+        /// <inheritdoc/>
+        IMapper<object, object>? IWebApiPublisherArgs<object, object>.Mapper => null;
+
+        /// <inheritdoc/>
+        public Func<Task<IActionResult>>? CreateSuccessResultAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<object>, EventData, Uri>? CreateLocation { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WorkStateArgs>? CreateWorkStateArgs { get; set; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT.cs
@@ -37,6 +37,9 @@ namespace CoreEx.AspNetCore.WebApis
         public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
 
         /// <inheritdoc/>
+        public bool ValueIsRequired { get; set; } = true;
+
+        /// <inheritdoc/>
         public IValidator<TValue>? Validator { get; set; } = validator;
 
         /// <inheritdoc/>

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using CoreEx.Events;
+using CoreEx.Hosting.Work;
 using CoreEx.Mapping;
 using CoreEx.Results;
 using CoreEx.Validation;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Net;
@@ -31,6 +31,9 @@ namespace CoreEx.AspNetCore.WebApis
         public string? EventName { get; set; }
 
         /// <inheritdoc/>
+        public EventData? EventTemplate { get; set; }
+
+        /// <inheritdoc/>
         public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
 
         /// <inheritdoc/>
@@ -52,6 +55,37 @@ namespace CoreEx.AspNetCore.WebApis
         IMapper<TValue, TValue>? IWebApiPublisherArgs<TValue, TValue>.Mapper => null;
 
         /// <inheritdoc/>
-        public Func<IActionResult>? CreateSuccessResult { get; set; }
+        public Func<Task<IActionResult>>? CreateSuccessResultAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TValue>, EventData, Uri>? CreateLocation { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WorkStateArgs>? CreateWorkStateArgs { get; set; }
+
+        /// <summary>
+        /// Sets the <see cref="CreateWorkStateArgs"/> to use the <see cref="WorkStateArgs.Create{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to infer the <see cref="WorkState.TypeName"/> enabling state separation.</typeparam>
+        /// <returns>The <see cref="WebApiPublisherArgs{TValue}"/> to support fluent-style method-chaining.</returns>
+        public WebApiPublisherArgs<TValue> WithWorkState<T>()
+        {
+            CreateWorkStateArgs = () => WorkStateArgs.Create<T>();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="CreateWorkStateArgs"/> to use the specified <paramref name="typeName"/> or where <c>null</c> automatically set using the <typeparamref name="TValue"/> <see cref="Type"/>.
+        /// </summary>
+        /// <param name="typeName">The type name.</param>
+        /// <returns>The <see cref="WebApiPublisherArgs{TValue}"/> to support fluent-style method-chaining.</returns>
+        public WebApiPublisherArgs<TValue> WithWorkState(string? typeName = null)
+        {
+            if (typeName is null)
+                return WithWorkState<TValue>();
+
+            CreateWorkStateArgs = () => new WorkStateArgs(typeName);
+            return this;
+        }
     }
 }

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT2.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT2.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using CoreEx.Events;
+using CoreEx.Hosting.Work;
 using CoreEx.Mapping;
 using CoreEx.Results;
 using CoreEx.Validation;
@@ -31,6 +32,9 @@ namespace CoreEx.AspNetCore.WebApis
         public string? EventName { get; set; } = default!;
 
         /// <inheritdoc/>
+        public EventData? EventTemplate { get; set; }
+
+        /// <inheritdoc/>
         public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
 
         /// <inheritdoc/>
@@ -52,6 +56,37 @@ namespace CoreEx.AspNetCore.WebApis
         public IMapper<TValue, TEventValue>? Mapper { get; set; }
 
         /// <inheritdoc/>
-        public Func<IActionResult>? CreateSuccessResult { get; set; }
+        public Func<Task<IActionResult>>? CreateSuccessResultAsync { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WebApiParam<TValue>, EventData, Uri>? CreateLocation { get; set; }
+
+        /// <inheritdoc/>
+        public Func<WorkStateArgs>? CreateWorkStateArgs { get; set; }
+
+        /// <summary>
+        /// Sets the <see cref="CreateWorkStateArgs"/> to use the <see cref="WorkStateArgs.Create{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to infer the <see cref="WorkState.TypeName"/> enabling state separation.</typeparam>
+        /// <returns>The <see cref="WebApiPublisherArgs{TValue}"/> to support fluent-style method-chaining.</returns>
+        public WebApiPublisherArgs<TValue, TEventValue> WithWorkState<T>()
+        {
+            CreateWorkStateArgs = () => WorkStateArgs.Create<T>();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="CreateWorkStateArgs"/> to use the specified <paramref name="typeName"/> or where <c>null</c> automatically set using the <typeparamref name="TEventValue"/> <see cref="Type"/>.
+        /// </summary>
+        /// <param name="typeName">The type name.</param>
+        /// <returns>The <see cref="WebApiPublisherArgs{TValue}"/> to support fluent-style method-chaining.</returns>
+        public WebApiPublisherArgs<TValue, TEventValue> WithWorkState(string? typeName = null)
+        {
+            if (typeName is null)
+                return WithWorkState<TEventValue>();
+
+            CreateWorkStateArgs = () => new WorkStateArgs(typeName);
+            return this;
+        }
     }
 }

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT2.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherArgsT2.cs
@@ -38,6 +38,9 @@ namespace CoreEx.AspNetCore.WebApis
         public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
 
         /// <inheritdoc/>
+        public bool ValueIsRequired { get; set; } = true;
+
+        /// <inheritdoc/>
         public IValidator<TValue>? Validator { get; set; } = validator;
 
         /// <inheritdoc/>

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCancelArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCancelArgs.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Hosting.Work;
+using CoreEx.Localization;
+using CoreEx.Results;
+using System;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Represents the <see cref="WebApiPublisher.CancelWorkStatusAsync"/> arguments; being the opportunity to further configure the standard processing.
+    /// </summary>
+    /// <param name="typeName">The <see cref="WorkState.TypeName"/> enabling state separation.</param>
+    /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+    /// <param name="reason">The cancellation reason.</param>
+    public class WebApiPublisherCancelArgs(string typeName, string? id, string? reason = null)
+    {
+        /// <summary>
+        /// Gets the default <see cref="WorkState.Reason"/>.
+        /// </summary>
+        public static LText NotSpecifiedReason { get; } = "No reason was specified.";
+
+        /// <summary>
+        /// Gets the <see cref="WorkStateOrchestrator"/> type name.
+        /// </summary>
+        /// <remarks>Enables separation between one or more <see cref="WorkState"/> types.</remarks>
+        public string TypeName => typeName.ThrowIfNullOrEmpty(nameof(typeName));
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkState.Id"/>.
+        /// </summary>
+        public string? Id { get; set; } = id;
+
+        /// <summary>
+        /// Gets or sets the cancellation reason; defaults to <see cref="NotSpecifiedReason"/>.
+        /// </summary>
+        public string? Reason { get; set; } = reason;
+
+        /// <summary>
+        /// Gets or sets the function to execute prior to returning the response.
+        /// </summary>
+        /// <remarks>Enables the likes of security, etc., before returning the response. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        public Func<WorkState, Task<Result>>? OnBeforeResponseAsync { get; set; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCollectionArgsT.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCollectionArgsT.cs
@@ -32,6 +32,9 @@ namespace CoreEx.AspNetCore.WebApis
         public string? EventName { get; set; }
 
         /// <inheritdoc/>
+        public EventData? EventTemplate { get; set;  }
+
+        /// <inheritdoc/>
         public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
 
         /// <inheritdoc/>
@@ -56,6 +59,6 @@ namespace CoreEx.AspNetCore.WebApis
         IMapper<TItem, TItem>? IWebApiPublisherCollectionArgs<TColl, TItem, TItem>.Mapper => null;
 
         /// <inheritdoc/>
-        public Func<IActionResult>? CreateSuccessResult { get; set; }
+        public Func<Task<IActionResult>>? CreateSuccessResultAsync { get; set; }
     }
 }

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCollectionArgsT2.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherCollectionArgsT2.cs
@@ -33,6 +33,9 @@ namespace CoreEx.AspNetCore.WebApis
         public string? EventName { get; set; }
 
         /// <inheritdoc/>
+        public EventData? EventTemplate { get; set; }
+
+        /// <inheritdoc/>
         public HttpStatusCode StatusCode { get; set; } = HttpStatusCode.Accepted;
 
         /// <inheritdoc/>
@@ -57,6 +60,6 @@ namespace CoreEx.AspNetCore.WebApis
         public IMapper<TItem, TEventItem>? Mapper { get; set; }
 
         /// <inheritdoc/>
-        public Func<IActionResult>? CreateSuccessResult { get; set; }
+        public Func<Task<IActionResult>>? CreateSuccessResultAsync { get; set; }
     }
 }

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherResultArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherResultArgs.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Hosting.Work;
+using CoreEx.Results;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Represents the <see cref="WebApiPublisher.GetWorkResultAsync"/> arguments with no result value; being the opportunity to further configure the standard processing.
+    /// </summary>
+    /// <param name="typeName">The <see cref="WorkState.TypeName"/> enabling state separation.</param>
+    /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+    public class WebApiPublisherResultArgs(string typeName, string? id)
+    {
+        /// <summary>
+        /// Gets the <see cref="WorkStateOrchestrator"/> type name.
+        /// </summary>
+        /// <remarks>Enables separation between one or more <see cref="WorkState"/> types.</remarks>
+        public string TypeName => typeName.ThrowIfNullOrEmpty(nameof(typeName));
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkState.Id"/>.
+        /// </summary>
+        public string? Id { get; set; } = id;
+
+        /// <summary>
+        /// Gets or sets the function to execute prior to returning the response.
+        /// </summary>
+        /// <remarks>Enables the likes of security, etc., before returning the response. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        public Func<WorkState, Task<Result>>? OnBeforeResponseAsync { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function to override the creation of the success <see cref="IActionResult"/>.
+        /// </summary>
+        /// <remarks>Defaults to a <see cref="ExtendedStatusCodeResult"/> with <see cref="HttpStatusCode.NoContent"/>.</remarks>
+        public Func<WorkState, Task<IActionResult>>? CreateSuccessResultAsync { get; set; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherResultArgsT.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherResultArgsT.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Hosting.Work;
+using CoreEx.Results;
+using System;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Represents the <see cref="WebApiPublisher.GetWorkResultAsync"/> arguments with a result value; being the opportunity to further configure the standard processing.
+    /// </summary>
+    /// <typeparam name="TValue">The resulting value <see cref="Type"/>.</typeparam>
+    /// <param name="typeName">The <see cref="WorkState.TypeName"/> enabling state separation.</param>
+    /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+    public class WebApiPublisherResultArgs<TValue>(string typeName, string? id)
+    {
+        /// <summary>
+        /// Gets the resulting <typeparamref name="TValue"/> <see cref="Type"/>.
+        /// </summary>
+        public Type ValueType => typeof(TValue);
+
+        /// <summary>
+        /// Gets the <see cref="WorkStateOrchestrator"/> type name.
+        /// </summary>
+        /// <remarks>Enables separation between one or more <see cref="WorkState"/> types.</remarks>
+        public string TypeName => typeName.ThrowIfNullOrEmpty(nameof(typeName));
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkState.Id"/>.
+        /// </summary>
+        public string? Id { get; set; } = id;
+
+        /// <summary>
+        /// Gets or sets the function to execute prior to returning the response.
+        /// </summary>
+        /// <remarks>Enables the likes of security, etc., before returning the response. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        public Func<WorkState, Task<Result>>? OnBeforeResponseAsync { get; set; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherStatusArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherStatusArgs.cs
@@ -35,7 +35,7 @@ namespace CoreEx.AspNetCore.WebApis
         /// <summary>
         /// Gets or sets the function to create the <see cref="Uri"/> for the result <see cref="Microsoft.AspNetCore.Http.Headers.ResponseHeaders.Location"/>.
         /// </summary>
-        /// <remarks>This will only be invoked when the <see cref="WorkState.Status"/> is <see cref="WorkStatus.Completed"/>. Will result in a <see cref="RedirectResult"/> with an <see cref="System.Net.HttpStatusCode.Redirect"/>.</remarks>
+        /// <remarks>This will only be invoked when the <see cref="WorkState.Status"/> is <see cref="WorkStatus.Completed"/> and enables the <see cref="System.Net.HttpStatusCode.Redirect"/> <see cref="ExtendedStatusCodeResult"/> behavior.</remarks>
         public Func<WorkState, Uri>? CreateResultLocation { get; set; }
 
         /// <summary>

--- a/src/CoreEx.AspNetCore/WebApis/WebApiPublisherStatusArgs.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiPublisherStatusArgs.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Hosting.Work;
+using CoreEx.Results;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Represents the <see cref="WebApiPublisher.GetWorkStatusAsync"/> arguments; being the opportunity to further configure the standard processing.
+    /// </summary>
+    /// <param name="typeName">The <see cref="WorkState.TypeName"/> enabling state separation.</param>
+    /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+    public class WebApiPublisherStatusArgs(string typeName, string? id)
+    {
+        /// <summary>
+        /// Gets the <see cref="WorkStateOrchestrator"/> type name.
+        /// </summary>
+        /// <remarks>Enables separation between one or more <see cref="WorkState"/> types.</remarks>
+        public string TypeName => typeName.ThrowIfNullOrEmpty(nameof(typeName));
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkState.Id"/>.
+        /// </summary>
+        public string? Id { get; set; } = id;
+
+        /// <summary>
+        /// Gets or sets the function to execute prior to returning the response.
+        /// </summary>
+        /// <remarks>Enables the likes of security, etc., before returning the response. The <see cref="Result"/> will allow failures and alike to be returned where applicable.</remarks>
+        public Func<WorkState, Task<Result>>? OnBeforeResponseAsync { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function to create the <see cref="Uri"/> for the result <see cref="Microsoft.AspNetCore.Http.Headers.ResponseHeaders.Location"/>.
+        /// </summary>
+        /// <remarks>This will only be invoked when the <see cref="WorkState.Status"/> is <see cref="WorkStatus.Completed"/>. Will result in a <see cref="RedirectResult"/> with an <see cref="System.Net.HttpStatusCode.Redirect"/>.</remarks>
+        public Func<WorkState, Uri>? CreateResultLocation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="TimeSpan"/> for the <see cref="WorkStatus.Executing"/> <see cref="System.Net.Http.Headers.RetryConditionHeaderValue"/>.
+        /// </summary>
+        /// <remarks>This will only be invoked when the <see cref="WorkState.Status"/> is <see cref="WorkStatus.Executing"/>. Defaults to 30 seconds.</remarks>
+        public TimeSpan? ExecutingRetryAfter { get; set; } = TimeSpan.FromSeconds(30);
+    }
+}

--- a/src/CoreEx.Azure/CoreEx.Azure.csproj
+++ b/src/CoreEx.Azure/CoreEx.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>CoreEx.Azure</RootNamespace>
     <Product>CoreEx</Product>
     <Title>CoreEx .NET Standard Azure Extensions.</Title>
@@ -14,9 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.1" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.2" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.15.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.16.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusOrchestratedSubscriber.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusOrchestratedSubscriber.cs
@@ -81,35 +81,45 @@ namespace CoreEx.Azure.ServiceBus
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         public Task ReceiveAsync(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, EventSubscriberArgs? args = null, CancellationToken cancellationToken = default)
         {
-            if (message == null)
-                throw new ArgumentNullException(nameof(message));
-
-            if (messageActions == null)
-                throw new ArgumentNullException(nameof(messageActions));
+            message.ThrowIfNull(nameof(message));
+            messageActions.ThrowIfNull(nameof(messageActions));
 
             return ServiceBusSubscriberInvoker.InvokeAsync(this, async (_, ct) =>
             {
+                // Perform any pre-processing.
+                var canProceed = await OnBeforeProcessingAsync(message.MessageId, message, cancellationToken).ConfigureAwait(false);
+                if (!canProceed)
+                    return;
+
                 // Get the event (without value as type unknown).
-                var @event = await DeserializeEventAsync(message, cancellationToken);
+                var @event = await DeserializeEventAsync(message.MessageId, message, cancellationToken);
                 if (@event is null)
                     return;
 
                 ServiceBusSubscriber.UpdateEventSubscriberArgsWithServiceBusMessage(args ??= [], message, messageActions);
 
                 // Match subscriber to metadata.
-                if (!Orchestrator.TryMatchSubscriber(this, @event, args, out var subscriber, out var valueType))
+                var match = Orchestrator.TryMatchSubscriber(this, @event, args);
+                if (!match.Matched)
+                {
+                    var txt = $"Subject: {(string.IsNullOrEmpty(@event.Subject) ? "<none>" : @event.Subject)}, Action: {(string.IsNullOrEmpty(@event.Action) ? "<none>" : @event.Action)}, Type: {(string.IsNullOrEmpty(@event.Type) ? "<none>" : @event.Type)}";
+                    var esex = new EventSubscriberException(match.Subscriber == null ? $"No corresponding Subscriber could be matched; {txt}" : $"More than one Subscriber was matched (ambiguous); {txt}")
+                        { ExceptionSource = match.Subscriber == null ? EventSubscriberExceptionSource.OrchestratorNotSubscribed : EventSubscriberExceptionSource.OrchestratorAmbiquousSubscriber };
+
+                    await ErrorHandler.HandleErrorAsync(new ErrorHandlerArgs(@event.Id, esex, match.Subscriber == null ? Orchestrator.NotSubscribedHandling : Orchestrator.AmbiquousSubscriberHandling, Logger) { Instrumentation = Instrumentation, WorkOrchestrator = WorkStateOrchestrator }, cancellationToken);
                     return;
+                }
 
                 // Deserialize the event (again) where there is a value as value not deserialized previously.
-                if (valueType is not null)
+                if (match.ValueType is not null)
                 {
-                    @event = await DeserializeEventAsync(message, valueType, cancellationToken).ConfigureAwait(false);
+                    @event = await DeserializeEventAsync(message.MessageId, message, match.ValueType, cancellationToken).ConfigureAwait(false);
                     if (@event is null)
                         return;
                 }
 
                 // Execute subscriber receive with the event.
-                await Orchestrator.ReceiveAsync(this, subscriber!, @event, args, cancellationToken).ConfigureAwait(false);
+                await Orchestrator.ReceiveAsync(this, match.Subscriber!, @event, args, cancellationToken).ConfigureAwait(false);
             }, (message, messageActions), cancellationToken);
         }
     }

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusOrchestratedSubscriber.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusOrchestratedSubscriber.cs
@@ -87,7 +87,8 @@ namespace CoreEx.Azure.ServiceBus
             return ServiceBusSubscriberInvoker.InvokeAsync(this, async (_, ct) =>
             {
                 // Perform any pre-processing.
-                var canProceed = await OnBeforeProcessingAsync(message.MessageId, message, cancellationToken).ConfigureAwait(false);
+                args ??= [];
+                var canProceed = await OnBeforeProcessingAsync(message.MessageId, message, args, cancellationToken).ConfigureAwait(false);
                 if (!canProceed)
                     return;
 
@@ -96,7 +97,7 @@ namespace CoreEx.Azure.ServiceBus
                 if (@event is null)
                     return;
 
-                ServiceBusSubscriber.UpdateEventSubscriberArgsWithServiceBusMessage(args ??= [], message, messageActions);
+                ServiceBusSubscriber.UpdateEventSubscriberArgsWithServiceBusMessage(args, message, messageActions);
 
                 // Match subscriber to metadata.
                 var match = Orchestrator.TryMatchSubscriber(this, @event, args);

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriber.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriber.cs
@@ -26,14 +26,14 @@ namespace CoreEx.Azure.ServiceBus
     public class ServiceBusSubscriber : EventSubscriberBase, IServiceBusSubscriber
     {
         /// <summary>
-        /// Gets the <see cref="EventSubscriberArgs"/> name to access the <see cref="ServiceBusMessage"/>.
+        /// Gets the <see cref="EventSubscriberArgs"/> name to access the <see cref="ServiceBusReceivedMessage"/>.
         /// </summary>
-        public const string ServiceBusReceivedMessageName = "_ServiceBusReceivedMessage";
+        public const string ServiceBusReceivedMessageName = nameof(ServiceBusReceivedMessage);
 
         /// <summary>
         /// Gets the <see cref="EventSubscriberArgs"/> name to access the <see cref="ServiceBusMessageActions"/>.
         /// </summary>
-        public const string ServiceBusMessageActionsName = "ServiceBusMessageActions";
+        public const string ServiceBusMessageActionsName = nameof(ServiceBusMessageActions);
 
         internal static ServiceBusSubscriberInvoker? _invoker;
 
@@ -86,11 +86,9 @@ namespace CoreEx.Azure.ServiceBus
         /// <param name="messageActions">The <see cref="ServiceBusMessageActions"/>.</param>
         /// <param name="function">The function logic to invoke.</param>
         /// <param name="args">The <see cref="EventSubscriberArgs"/>.</param>
-        /// <param name="afterReceive">A function that enables the <paramref name="message"/> <see cref="EventData"/> to be processed directly after the message is received and deserialized.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public Task ReceiveAsync(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData, EventSubscriberArgs, Task> function,
-            EventSubscriberArgs? args = null, Func<EventData, EventSubscriberArgs, Task>? afterReceive = null, CancellationToken cancellationToken = default)
-            => ReceiveAsync(message, messageActions, (ed, ea) => Result.Success.ThenAsync(() => function(ed, ea)), args, afterReceive, cancellationToken);
+        public Task ReceiveAsync(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData, EventSubscriberArgs, Task> function, EventSubscriberArgs? args = null, CancellationToken cancellationToken = default)
+            => ReceiveAsync(message, messageActions, (ed, ea, _) => Result.Success.ThenAsync(() => function(ed, ea)), args, cancellationToken);
 
         /// <summary>
         /// Encapsulates the execution of an <see cref="ServiceBusReceivedMessage"/> <paramref name="function"/> converting the <paramref name="message"/> into a corresponding <see cref="EventData"/> (with no value) for processing.
@@ -99,10 +97,30 @@ namespace CoreEx.Azure.ServiceBus
         /// <param name="messageActions">The <see cref="ServiceBusMessageActions"/>.</param>
         /// <param name="function">The function logic to invoke.</param>
         /// <param name="args">The <see cref="EventSubscriberArgs"/>.</param>
-        /// <param name="afterReceive">A function that enables the <paramref name="message"/> <see cref="EventData"/> to be processed directly after the message is received and deserialized.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public Task ReceiveAsync(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData, EventSubscriberArgs, Task<Result>> function, 
-            EventSubscriberArgs? args = null, Func<EventData, EventSubscriberArgs, Task>? afterReceive = null, CancellationToken cancellationToken = default)
+        public Task ReceiveAsync(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData, EventSubscriberArgs, CancellationToken, Task> function, EventSubscriberArgs? args = null, CancellationToken cancellationToken = default)
+            => ReceiveAsync(message, messageActions, (ed, ea, ct) => Result.Success.ThenAsync(() => function(ed, ea, ct)), args, cancellationToken);
+
+        /// <summary>
+        /// Encapsulates the execution of an <see cref="ServiceBusReceivedMessage"/> <paramref name="function"/> converting the <paramref name="message"/> into a corresponding <see cref="EventData"/> (with no value) for processing.
+        /// </summary>
+        /// <param name="message">The <see cref="ServiceBusReceivedMessage"/>.</param>
+        /// <param name="messageActions">The <see cref="ServiceBusMessageActions"/>.</param>
+        /// <param name="function">The function logic to invoke.</param>
+        /// <param name="args">The <see cref="EventSubscriberArgs"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public Task ReceiveAsync(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData, EventSubscriberArgs, Task<Result>> function, EventSubscriberArgs? args = null, CancellationToken cancellationToken = default)
+            => ReceiveAsync(message, messageActions, (ed, ea, _) => function(ed, ea), args, cancellationToken);
+
+        /// <summary>
+        /// Encapsulates the execution of an <see cref="ServiceBusReceivedMessage"/> <paramref name="function"/> converting the <paramref name="message"/> into a corresponding <see cref="EventData"/> (with no value) for processing.
+        /// </summary>
+        /// <param name="message">The <see cref="ServiceBusReceivedMessage"/>.</param>
+        /// <param name="messageActions">The <see cref="ServiceBusMessageActions"/>.</param>
+        /// <param name="function">The function logic to invoke.</param>
+        /// <param name="args">The <see cref="EventSubscriberArgs"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public Task ReceiveAsync(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData, EventSubscriberArgs, CancellationToken, Task<Result>> function, EventSubscriberArgs? args = null, CancellationToken cancellationToken = default)
         {
             message.ThrowIfNull(nameof(message));
             messageActions.ThrowIfNull(nameof(messageActions));
@@ -111,7 +129,8 @@ namespace CoreEx.Azure.ServiceBus
             return ServiceBusSubscriberInvoker.InvokeAsync(this, async (_, ct) =>
             {
                 // Perform any pre-processing.
-                var canProceed = await OnBeforeProcessingAsync(message.MessageId, message, cancellationToken).ConfigureAwait(false);
+                args ??= [];
+                var canProceed = await OnBeforeProcessingAsync(message.MessageId, message, args, cancellationToken).ConfigureAwait(false);
                 if (!canProceed)
                     return;
 
@@ -120,12 +139,10 @@ namespace CoreEx.Azure.ServiceBus
                 if (@event is null)
                     return;
 
-                UpdateEventSubscriberArgsWithServiceBusMessage(args ??= [], message, messageActions);
-                if (afterReceive != null)
-                    await afterReceive(@event!, args).ConfigureAwait(false);
+                UpdateEventSubscriberArgsWithServiceBusMessage(args, message, messageActions);
 
                 // Invoke the actual function logic.
-                Result.Go(await function(@event!, args).ConfigureAwait(false))
+                Result.Go(await function(@event!, args, ct).ConfigureAwait(false))
                       .Then(() => Logger.LogInformation("{Type} executed successfully - Service Bus message '{Message}'.", GetType().Name, message.MessageId))
                       .ThrowOnError();
 
@@ -144,14 +161,13 @@ namespace CoreEx.Azure.ServiceBus
         /// <param name="message">The <see cref="ServiceBusReceivedMessage"/>.</param>
         /// <param name="messageActions">The <see cref="ServiceBusMessageActions"/>.</param>
         /// <param name="function">The function logic to invoke.</param>
-        /// <param name="valueIsRequired">Indicates whether the value is required; will consider invalid where null.</param>
         /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
+        /// <param name="valueIsRequired">Indicates whether the value is required; will consider invalid where null.</param>
         /// <param name="args">The <see cref="EventSubscriberArgs"/>.</param>
-        /// <param name="afterReceive">A function that enables the <paramref name="message"/> <see cref="EventData"/> to be processed directly after the message is received and deserialized.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public Task ReceiveAsync<TValue>(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData<TValue>, EventSubscriberArgs, Task> function, bool valueIsRequired = true, IValidator<TValue>? validator = null,
-            EventSubscriberArgs? args = null, Func<EventData<TValue>, EventSubscriberArgs, Task>? afterReceive = null, CancellationToken cancellationToken = default)
-            => ReceiveAsync(message, messageActions, (ed, ea) => Result.Success.ThenAsync(() => function(ed, ea)), valueIsRequired, validator, args, afterReceive, cancellationToken);
+        public Task ReceiveAsync<TValue>(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData<TValue>, EventSubscriberArgs, Task> function, IValidator<TValue>? validator = null, bool valueIsRequired = true,
+            EventSubscriberArgs? args = null, CancellationToken cancellationToken = default)
+            => ReceiveAsync(message, messageActions, (ed, ea, _) => Result.Success.ThenAsync(() => function(ed, ea)), validator, valueIsRequired, args, cancellationToken);
 
         /// <summary>
         /// Encapsulates the execution of an <see cref="ServiceBusReceivedMessage"/> <paramref name="function"/> converting the <paramref name="message"/> into a corresponding <see cref="EventData{T}"/> for processing.
@@ -160,13 +176,42 @@ namespace CoreEx.Azure.ServiceBus
         /// <param name="message">The <see cref="ServiceBusReceivedMessage"/>.</param>
         /// <param name="messageActions">The <see cref="ServiceBusMessageActions"/>.</param>
         /// <param name="function">The function logic to invoke.</param>
-        /// <param name="valueIsRequired">Indicates whether the value is required; will consider invalid where null.</param>
         /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
+        /// <param name="valueIsRequired">Indicates whether the value is required; will consider invalid where null.</param>
         /// <param name="args">The <see cref="EventSubscriberArgs"/>.</param>
-        /// <param name="afterReceive">A function that enables the <paramref name="message"/> <see cref="EventData"/> to be processed directly after the message is received and deserialized.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public Task ReceiveAsync<TValue>(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData<TValue>, EventSubscriberArgs, Task<Result>> function, bool valueIsRequired = true, IValidator<TValue>? validator = null,
-            EventSubscriberArgs? args = null, Func<EventData<TValue>, EventSubscriberArgs, Task>? afterReceive = null, CancellationToken cancellationToken = default)
+        public Task ReceiveAsync<TValue>(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData<TValue>, EventSubscriberArgs, CancellationToken, Task> function, IValidator<TValue>? validator = null, bool valueIsRequired = true,
+            EventSubscriberArgs? args = null, CancellationToken cancellationToken = default)
+            => ReceiveAsync(message, messageActions, (ed, ea, ct) => Result.Success.ThenAsync(() => function(ed, ea, ct)), validator, valueIsRequired, args, cancellationToken);
+
+        /// <summary>
+        /// Encapsulates the execution of an <see cref="ServiceBusReceivedMessage"/> <paramref name="function"/> converting the <paramref name="message"/> into a corresponding <see cref="EventData{T}"/> for processing.
+        /// </summary>
+        /// <typeparam name="TValue">The event value <see cref="Type"/>.</typeparam>
+        /// <param name="message">The <see cref="ServiceBusReceivedMessage"/>.</param>
+        /// <param name="messageActions">The <see cref="ServiceBusMessageActions"/>.</param>
+        /// <param name="function">The function logic to invoke.</param>
+        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
+        /// <param name="valueIsRequired">Indicates whether the value is required; will consider invalid where null.</param>
+        /// <param name="args">The <see cref="EventSubscriberArgs"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public Task ReceiveAsync<TValue>(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData<TValue>, EventSubscriberArgs, Task<Result>> function, IValidator<TValue>? validator = null, bool valueIsRequired = true,
+            EventSubscriberArgs? args = null, CancellationToken cancellationToken = default)
+            => ReceiveAsync(message, messageActions, (ed, ea, _) => function(ed, ea), validator, valueIsRequired, args, cancellationToken);
+
+        /// <summary>
+        /// Encapsulates the execution of an <see cref="ServiceBusReceivedMessage"/> <paramref name="function"/> converting the <paramref name="message"/> into a corresponding <see cref="EventData{T}"/> for processing.
+        /// </summary>
+        /// <typeparam name="TValue">The event value <see cref="Type"/>.</typeparam>
+        /// <param name="message">The <see cref="ServiceBusReceivedMessage"/>.</param>
+        /// <param name="messageActions">The <see cref="ServiceBusMessageActions"/>.</param>
+        /// <param name="function">The function logic to invoke.</param>
+        /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
+        /// <param name="valueIsRequired">Indicates whether the value is required; will consider invalid where null.</param>
+        /// <param name="args">The <see cref="EventSubscriberArgs"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public Task ReceiveAsync<TValue>(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, Func<EventData<TValue>, EventSubscriberArgs, CancellationToken, Task<Result>> function, IValidator<TValue>? validator = null, bool valueIsRequired = true,
+            EventSubscriberArgs? args = null, CancellationToken cancellationToken = default)
         {
             message.ThrowIfNull(nameof(message));
             messageActions.ThrowIfNull(nameof(messageActions));
@@ -175,7 +220,8 @@ namespace CoreEx.Azure.ServiceBus
             return ServiceBusSubscriberInvoker.InvokeAsync(this, async (_, ct) =>
             {
                 // Perform any pre-processing.
-                var canProceed = await OnBeforeProcessingAsync(message.MessageId, message, cancellationToken).ConfigureAwait(false);
+                args ??= [];
+                var canProceed = await OnBeforeProcessingAsync(message.MessageId, message, args, cancellationToken).ConfigureAwait(false);
                 if (!canProceed)
                     return;
 
@@ -184,12 +230,10 @@ namespace CoreEx.Azure.ServiceBus
                 if (@event is null)
                     return;
 
-                UpdateEventSubscriberArgsWithServiceBusMessage(args ??= [], message, messageActions);
-                if (afterReceive != null)
-                    await afterReceive(@event!, args).ConfigureAwait(false);
+                UpdateEventSubscriberArgsWithServiceBusMessage(args, message, messageActions);
 
                 // Invoke the actual function logic.
-                Result.Go(await function(@event!, args).ConfigureAwait(false))
+                Result.Go(await function(@event!, args, ct).ConfigureAwait(false))
                       .Then(() => Logger.LogInformation("{Type} executed successfully - Service Bus message '{Message}'.", GetType().Name, message.MessageId))
                       .ThrowOnError();
 
@@ -209,11 +253,10 @@ namespace CoreEx.Azure.ServiceBus
         /// <param name="messageActions">The <see cref="ServiceBusMessageActions"/>.</param>
         /// <remarks>This will allow access to these values from within the event processing logic and is intended for advanced scenarios only; care should be taken to not perform an action that would result in the underlying host to fail
         /// unexpectantly.</remarks>
-        public static void UpdateEventSubscriberArgsWithServiceBusMessage(EventSubscriberArgs args, ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions)
+        internal static void UpdateEventSubscriberArgsWithServiceBusMessage(EventSubscriberArgs args, ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions)
         {
-            args.ThrowIfNull(nameof(args));
-            args.TryAdd(ServiceBusReceivedMessageName, message ?? throw new ArgumentNullException(nameof(message)));
-            args.TryAdd(ServiceBusMessageActionsName, messageActions ?? throw new ArgumentNullException(nameof(messageActions)));
+            args.TryAdd(ServiceBusReceivedMessageName, message);
+            args.TryAdd(ServiceBusMessageActionsName, messageActions);
         }
     }
 }

--- a/src/CoreEx.Azure/Storage/TableWorkStatePersistence.cs
+++ b/src/CoreEx.Azure/Storage/TableWorkStatePersistence.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using Azure;
+using Azure.Data.Tables;
+using CoreEx.Hosting.Work;
+using CoreEx.Json;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.Azure.Storage
+{
+    /// <summary>
+    /// An <see cref="IWorkStatePersistence"/> that persists the <see cref="WorkState"/> using an Azure <see cref="TableClient"/> and the related <see cref="BinaryData"/> to a separate <see cref="TableClient"/>.
+    /// </summary>
+    /// <remarks>The maximum <see cref="BinaryData"/> size currently supported is 960,000 bytes.</remarks>
+    public class TableWorkStatePersistence : IWorkStatePersistence
+    {
+        private static readonly string[] _columns = [nameof(WorkState.TypeName), nameof(WorkState.CorrelationId), nameof(WorkState.Status), nameof(WorkState.Created), nameof(WorkState.Expiry), nameof(WorkState.Started), nameof(WorkState.Indeterminate), nameof(WorkState.Finished), nameof(WorkState.Reason)];
+
+        private readonly TableClient _workStateTableClient;
+        private readonly TableClient _workDataTableClient;
+        private readonly IJsonSerializer _jsonSerializer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableWorkStatePersistence"/> class.
+        /// </summary>
+        /// <param name="tableServiceClient">The <see cref="TableServiceClient"/>.</param>
+        /// <param name="workStateTableName">The work state table name.</param>
+        /// <param name="workDataTableName">The work data table name.</param>
+        /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>. Defaults to <see cref="JsonSerializer.Default"/>.</param>
+        public TableWorkStatePersistence(TableServiceClient tableServiceClient, string workStateTableName = "workstate", string workDataTableName = "workdata", IJsonSerializer? jsonSerializer = null)
+            : this(tableServiceClient.ThrowIfNull(nameof(tableServiceClient)).GetTableClient(workStateTableName), tableServiceClient.GetTableClient(workDataTableName), jsonSerializer) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TableWorkStatePersistence"/> class.
+        /// </summary>
+        /// <param name="workStateTableClient">The work state <see cref="TableClient"/>.</param>
+        /// <param name="workDataTableClient">The work data <see cref="TableClient"/>.</param>
+        /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>. Defaults to <see cref="JsonSerializer.Default"/>.</param>
+        public TableWorkStatePersistence(TableClient workStateTableClient, TableClient workDataTableClient, IJsonSerializer? jsonSerializer = null)
+        {
+            if (workStateTableClient.ThrowIfNull(nameof(workStateTableClient)).Name == workDataTableClient.ThrowIfNull(nameof(workDataTableClient)).Name)
+                throw new ArgumentException("The work state and data table names must be different.", nameof(workDataTableClient));
+
+            _workDataTableClient = workDataTableClient;
+            _workStateTableClient = workStateTableClient;
+
+            _workDataTableClient.CreateIfNotExists();
+            _workStateTableClient.CreateIfNotExists();
+
+            _jsonSerializer = jsonSerializer ?? JsonSerializer.Default;
+        }
+
+        private class WorkStateEntity() : WorkState, ITableEntity
+        {
+            public WorkStateEntity(WorkState state) : this()
+            {
+                RowKey = state.Id!;
+                TypeName = state.TypeName;
+                Key = state.Key;
+                CorrelationId = state.CorrelationId;
+                Status = state.Status;
+                Created = state.Created;
+                Expiry = state.Expiry;
+                Started = state.Started;
+                Indeterminate = state.Indeterminate;
+                Finished = state.Finished;
+                Reason = state.Reason;
+            }
+
+            public string PartitionKey { get; set; } = GetPartitionKey();
+            public string RowKey { get; set; } = null!;
+            public DateTimeOffset? Timestamp { get; set; }
+            public ETag ETag { get; set; }
+        }
+
+        private class WorkDataEntity() : ITableEntity
+        {
+            private const int _chunkSize = 64000;
+            private const int _maxChunks = 15;
+            private const int _maxSize = _chunkSize * _maxChunks;
+            private readonly BinaryData?[] _data = new BinaryData?[_maxChunks];
+            public WorkDataEntity(BinaryData data) : this()
+            {
+                var arr = data.ToArray();
+                if (arr.Length <= _chunkSize)
+                {
+                    Data00 = data;
+                    return;
+                }
+                else if (arr.Length > _maxSize)
+                    throw new ArgumentException($"Data too large ({arr.Length}B versus {_maxSize}B) to store in Azure table storage.", nameof(data));
+
+                var i = 0;
+                foreach (var chunk in data.ToArray().Chunk(_chunkSize))
+                {
+                    _data[i++] = BinaryData.FromBytes(chunk);
+                }
+            }
+            public string PartitionKey { get; set; } = GetPartitionKey();
+            public string RowKey { get; set; } = null!;
+            public DateTimeOffset? Timestamp { get; set; }
+            public ETag ETag { get; set; }
+            public BinaryData? Data00 { get => _data[0]; set => _data[0] = value; }
+            public BinaryData? Data01 { get => _data[1]; set => _data[1] = value; }
+            public BinaryData? Data02 { get => _data[2]; set => _data[2] = value; }
+            public BinaryData? Data03 { get => _data[3]; set => _data[3] = value; }
+            public BinaryData? Data04 { get => _data[4]; set => _data[4] = value; }
+            public BinaryData? Data05 { get => _data[5]; set => _data[5] = value; }
+            public BinaryData? Data06 { get => _data[6]; set => _data[6] = value; }
+            public BinaryData? Data07 { get => _data[7]; set => _data[7] = value; }
+            public BinaryData? Data08 { get => _data[8]; set => _data[8] = value; }
+            public BinaryData? Data09 { get => _data[9]; set => _data[9] = value; }
+            public BinaryData? Data10 { get => _data[10]; set => _data[10] = value; }
+            public BinaryData? Data11 { get => _data[11]; set => _data[11] = value; }
+            public BinaryData? Data12 { get => _data[12]; set => _data[12] = value; }
+            public BinaryData? Data13 { get => _data[13]; set => _data[13] = value; }
+            public BinaryData? Data14 { get => _data[14]; set => _data[14] = value; }
+
+            /// <summary>
+            /// Unchunks the data properties into a single <see cref="BinaryData"/>.
+            /// </summary>
+            /// <returns>The <see cref="BinaryData"/>.</returns>
+            public BinaryData? ToSingleData()
+            {
+                if (Data00 is null || Data01 is null)
+                    return Data00;
+
+                using var ms = new MemoryStream();
+                for (int i = 0; i < _maxChunks; i++)
+                {
+                    if (_data[i] is null)
+                        break;
+
+                    ms.Write(_data[i]!.ToArray());
+                }
+
+                ms.Position = 0;
+                return BinaryData.FromStream(ms);
+            }
+        }
+
+        /// <summary>
+        /// Gets the partition key.
+        /// </summary>
+        private static string GetPartitionKey() => (ExecutionContext.HasCurrent ? ExecutionContext.Current.TenantId : null) ?? "default";
+
+        /// <inheritdoc/>
+        public async Task<WorkState?> GetAsync(string id, CancellationToken cancellationToken)
+        {
+            var er = await _workStateTableClient.GetEntityIfExistsAsync<WorkStateEntity>(GetPartitionKey(), id, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (!er.HasValue)
+                return null;
+
+            return new WorkState
+            {
+                Id = er.Value!.RowKey,
+                TypeName = er.Value.TypeName,
+                Key = er.Value.Key,
+                CorrelationId = er.Value.CorrelationId,
+                Status = er.Value.Status,
+                Created = er.Value.Created,
+                Expiry = er.Value.Expiry,
+                Started = er.Value.Started,
+                Indeterminate = er.Value.Indeterminate,
+                Finished = er.Value.Finished,
+                Reason = er.Value.Reason
+            };
+        }
+
+        /// <inheritdoc/>
+        public Task CreateAsync(WorkState state, CancellationToken cancellationToken) => UpsertAsync(state, cancellationToken);
+
+        /// <inheritdoc/>
+        public Task UpdateAsync(WorkState state, CancellationToken cancellationToken) => UpsertAsync(state, cancellationToken);
+
+        /// <summary>
+        /// Performs an upsert (create/update).
+        /// </summary>
+        private async Task UpsertAsync(WorkState state, CancellationToken cancellationToken)  
+            => await _workStateTableClient.UpsertEntityAsync(new WorkStateEntity(state), TableUpdateMode.Replace, cancellationToken).ConfigureAwait(false);
+
+        /// <inheritdoc/>
+        public async Task DeleteAsync(string id, CancellationToken cancellationToken)
+        {
+            await _workDataTableClient.DeleteEntityAsync(GetPartitionKey(), id, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await _workStateTableClient.DeleteEntityAsync(GetPartitionKey(), id, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task<BinaryData?> GetDataAsync(string id, CancellationToken cancellationToken)
+        {
+            var er = await _workDataTableClient.GetEntityIfExistsAsync<WorkDataEntity>(GetPartitionKey(), id, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return er.HasValue ? er.Value!.ToSingleData() : null;
+        }
+
+        /// <inheritdoc/>
+        public Task SetDataAsync(string id, BinaryData data, CancellationToken cancellationToken)
+            => _workDataTableClient.UpsertEntityAsync(new WorkDataEntity(data) { PartitionKey = GetPartitionKey(), RowKey = id }, TableUpdateMode.Replace, cancellationToken: cancellationToken);
+    }
+}

--- a/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
+++ b/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
@@ -12,8 +12,8 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.7" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.38.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Database.MySql/CoreEx.Database.MySql.csproj
+++ b/src/CoreEx.Database.MySql/CoreEx.Database.MySql.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="8.2.0" />
+    <PackageReference Include="MySql.Data" Version="8.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Database.SqlServer/CoreEx.Database.SqlServer.csproj
+++ b/src/CoreEx.Database.SqlServer/CoreEx.Database.SqlServer.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.FluentValidation/ValidationResultWrapper.cs
+++ b/src/CoreEx.FluentValidation/ValidationResultWrapper.cs
@@ -70,5 +70,8 @@ namespace CoreEx.FluentValidation
 
         /// <inheritdoc/>
         public Result<R> ToResult<R>() => HasErrors ? Result<R>.ValidationError(Messages!) : Validation.Validation.ConvertValueToResult<T, R>(Value!);
+
+        /// <inheritdoc/>
+        public Result ToResult() => HasErrors ? Results.Result.ValidationError(Messages!) : Results.Result.Success;
     }
 }

--- a/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
+++ b/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
+++ b/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.1" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.UnitTesting/Abstractions/CoreExOneOffTestSetUp.cs
+++ b/src/CoreEx.UnitTesting/Abstractions/CoreExOneOffTestSetUp.cs
@@ -42,5 +42,10 @@ namespace UnitTestEx.Abstractions
                 return false;
             });
         }
+
+        /// <summary>
+        /// Forces the one-off test set-up to occur.
+        /// </summary>
+        public static void ForceSetUp() => new CoreExOneOffTestSetUp().SetUp();
     }
 }

--- a/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
+++ b/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="UnitTestEx" Version="4.1.1" />
+    <PackageReference Include="UnitTestEx" Version="4.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
+++ b/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="UnitTestEx" Version="4.1.0" />
+    <PackageReference Include="UnitTestEx" Version="4.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreEx.UnitTesting/UnitTestExExtensions.cs
+++ b/src/CoreEx.UnitTesting/UnitTestExExtensions.cs
@@ -186,7 +186,7 @@ namespace UnitTestEx
         public static ActionResultAssertor AssertETagHeader(this ActionResultAssertor assertor, string expectedETag)
         {
             if (assertor.Result != null && assertor.Result is ValueContentResult vcr)
-                assertor.Owner.Implementor.AssertAreEqual(expectedETag, vcr.ETag, $"Expected and Actual {nameof(ValueContentResult)}.{nameof(ValueContentResult.ETag)} values are not equal.");
+                assertor.Owner.Implementor.AssertAreEqual(expectedETag, vcr.ETag, $"Expected and Actual {nameof(ValueContentResult.ETag)} values are not equal.");
             else
                 assertor.Owner.Implementor.AssertFail($"The Result must be of Type {typeof(ValueContentResult).FullName} to use {nameof(AssertETagHeader)}.");
 
@@ -202,9 +202,11 @@ namespace UnitTestEx
         public static ActionResultAssertor AssertLocationHeader(this ActionResultAssertor assertor, Uri expectedUri)
         {
             if (assertor.Result != null && assertor.Result is ValueContentResult vcr)
-                assertor.Owner.Implementor.AssertAreEqual(expectedUri, vcr.Location, $"Expected and Actual {nameof(ValueContentResult)}.{nameof(ValueContentResult.Location)} values are not equal.");
+                assertor.Owner.Implementor.AssertAreEqual(expectedUri, vcr.Location, $"Expected and Actual {nameof(ValueContentResult.Location)} values are not equal.");
+            else if (assertor.Result != null && assertor.Result is ExtendedStatusCodeResult escr)
+                assertor.Owner.Implementor.AssertAreEqual(expectedUri, escr.Location, $"Expected and Actual {nameof(ExtendedStatusCodeResult.Location)} values are not equal.");
             else
-                assertor.Owner.Implementor.AssertFail($"The Result must be of Type {typeof(ValueContentResult).FullName} to use {nameof(AssertETagHeader)}.");
+                assertor.Owner.Implementor.AssertFail($"The Result must be of Type {typeof(ValueContentResult).FullName} or {typeof(ExtendedStatusCodeResult).FullName} to use {nameof(AssertLocationHeader)}.");
 
             return assertor;
         }
@@ -217,14 +219,42 @@ namespace UnitTestEx
         /// <param name="expectedUri">The expected <see cref="Uri"/> function.</param>
         /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
         public static ActionResultAssertor AssertLocationHeader<TValue>(this ActionResultAssertor assertor, Func<TValue, Uri> expectedUri)
+            => assertor.AssertLocationHeader(expectedUri.Invoke(assertor.GetValue<TValue>()!));
+
+        /// <summary>
+        /// Asserts that the <see cref="ValueContentResult.Location"/> contains the <paramref name="expected"/> string.
+        /// </summary>
+        /// <param name="assertor">The assertor.</param>
+        /// <param name="expected">The expected string.</param>
+        /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
+        public static ActionResultAssertor AssertLocationHeaderContains(this ActionResultAssertor assertor, string expected)
         {
+            Uri? actual = null;
             if (assertor.Result != null && assertor.Result is ValueContentResult vcr)
-                assertor.Owner.Implementor.AssertAreEqual(expectedUri?.Invoke(assertor.GetValue<TValue>()!), vcr.Location, $"Expected and Actual {nameof(ValueContentResult)}.{nameof(ValueContentResult.Location)} values are not equal.");
+                actual = vcr.Location;
+            else if (assertor.Result != null && assertor.Result is ExtendedStatusCodeResult escr)
+                actual = escr.Location;
             else
-                assertor.Owner.Implementor.AssertFail($"The Result must be of Type {typeof(ValueContentResult).FullName} to use {nameof(AssertETagHeader)}.");
+                assertor.Owner.Implementor.AssertFail($"The Result must be of Type {typeof(ValueContentResult).FullName} or {typeof(ExtendedStatusCodeResult).FullName} to use {nameof(AssertLocationHeader)}.");
+
+            if (actual == null)
+                assertor.Owner.Implementor.AssertFail($"The actual {nameof(ValueContentResult.Location)} must not be null.");
+
+            if (!actual!.ToString().Contains(expected))
+                assertor.Owner.Implementor.AssertFail($"The {nameof(ValueContentResult.Location)} '{actual}' must contain {expected}.");
 
             return assertor;
         }
+
+        /// <summary>
+        /// Asserts that the <see cref="ValueContentResult.Location"/> contains the <paramref name="expected"/> string function.
+        /// </summary>
+        /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
+        /// <param name="assertor">The assertor.</param>
+        /// <param name="expected">The expected string function.</param>
+        /// <returns>The <see cref="ActionResultAssertor"/> to support fluent-style method-chaining.</returns>
+        public static ActionResultAssertor AssertLocationHeader<TValue>(this ActionResultAssertor assertor, Func<TValue, string> expected)
+            => assertor.AssertLocationHeaderContains(expected.Invoke(assertor.GetValue<TValue>()!));
 
         #endregion
 

--- a/src/CoreEx.Validation/ValidationContext.cs
+++ b/src/CoreEx.Validation/ValidationContext.cs
@@ -179,6 +179,9 @@ namespace CoreEx.Validation
         /// <inheritdoc/>
         public Result<R> ToResult<R>() => FailureResult.HasValue ? FailureResult.Value.Bind<R>() : (HasErrors ? Result<R>.ValidationError(Messages!) : Validation.ConvertValueToResult<TEntity, R>(Value!));
 
+        /// <inheritdoc/>
+        public Result ToResult() => FailureResult ?? (HasErrors ? Result.ValidationError(Messages!) : Result.Success);
+
         /// <summary>
         /// Merges a validation result into this.
         /// </summary>

--- a/src/CoreEx.Validation/ValidationExtensions.cs
+++ b/src/CoreEx.Validation/ValidationExtensions.cs
@@ -1219,7 +1219,8 @@ namespace CoreEx.Validation
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>> validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #else
         /// <summary>
         /// Executes the <paramref name="validator"/> for the specified <paramref name="value"/> where the <paramref name="result"/> is <see cref="Result.IsSuccess"/>.
@@ -1233,11 +1234,11 @@ namespace CoreEx.Validation
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>> validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #endif
         {
-            if (validator == null) throw new ArgumentNullException(nameof(validator));
-            if (result.IsFailure)
+            if (validator is null || result.IsFailure)
                 return result;
 
             var vi = validator(value.Validate(name, text)) ?? throw new InvalidOperationException($"The {nameof(validator)} function must return a non-null instance to perform the requested validation.");
@@ -1258,7 +1259,8 @@ namespace CoreEx.Validation
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>> validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #else
         /// <summary>
         /// Executes the <paramref name="validator"/> for the specified <paramref name="value"/> where the <paramref name="result"/> is <see cref="Result.IsSuccess"/>.
@@ -1272,12 +1274,12 @@ namespace CoreEx.Validation
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>> validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #endif
         {
-            if (validator == null) throw new ArgumentNullException(nameof(validator));
             var r = await result.ConfigureAwait(false);
-            if (r.IsFailure)
+            if (validator is null || r.IsFailure)
                 return r;
 
             var vi = validator(value.Validate(name, text)) ?? throw new InvalidOperationException($"The {nameof(validator)} function must return a non-null instance to perform the requested validation.");

--- a/src/CoreEx.Validation/ValueValidatorResult.cs
+++ b/src/CoreEx.Validation/ValueValidatorResult.cs
@@ -49,6 +49,9 @@ namespace CoreEx.Validation
         /// <inheritdoc/>
         public Result<R> ToResult<R>() => FailureResult.HasValue ? FailureResult.Value.Bind<R>() : (HasErrors ? Result<R>.ValidationError(Messages!) : Validation.ConvertValueToResult<TProperty, R>(Value!));
 
+        /// <inheritdoc/>
+        public Result ToResult() => FailureResult ?? (HasErrors ? Result.ValidationError(Messages!) : Result.Success);
+
         /// <summary>
         /// Throws a <see cref="ValidationException"/> where an error was found (and optionally if warnings).
         /// </summary>

--- a/src/CoreEx/Abstractions/IServiceCollectionExtensions.cs
+++ b/src/CoreEx/Abstractions/IServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using CoreEx.Entities;
 using CoreEx.Events;
 using CoreEx.Events.Subscribing;
 using CoreEx.Hosting;
+using CoreEx.Hosting.Work;
 using CoreEx.Http;
 using CoreEx.Json;
 using CoreEx.Json.Merge;
@@ -231,9 +232,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
         public static IServiceCollection AddJsonMergePatch(this IServiceCollection services, Action<CoreEx.Json.Merge.JsonMergePatchOptions>? configure = null) => CheckServices(services).AddSingleton<IJsonMergePatch>(sp =>
         {
-            var jmpo = new CoreEx.Json.Merge.JsonMergePatchOptions(sp.GetService<IJsonSerializer>());
+            var jmpo = new JsonMergePatchOptions(sp.GetService<IJsonSerializer>());
             configure?.Invoke(jmpo);
-            return new CoreEx.Json.Merge.JsonMergePatch(jmpo);
+            return new JsonMergePatch(jmpo);
         });
 
         /// <summary>
@@ -331,5 +332,18 @@ namespace Microsoft.Extensions.DependencyInjection
             mapper.Register(assemblies);
             return services.AddSingleton<IMapper>(mapper);
         }
+
+        /// <summary>
+        /// Adds the <see cref="WorkStateOrchestrator"/> as a singleton service.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configure">The action to enable the <see cref="WorkStateOrchestrator"/> to be further configured.</param>
+        /// <returns>The <see cref="IServiceCollection"/> for fluent-style method-chaining.</returns>
+        public static IServiceCollection AddWorkStateOrchestrator(this IServiceCollection services, Action<IServiceProvider, WorkStateOrchestrator>? configure = null) => CheckServices(services).AddSingleton(sp =>
+        {
+            var wso = new WorkStateOrchestrator(sp.GetRequiredService<IWorkStatePersistence>(), sp.GetService<SettingsBase>(), sp.GetService<IJsonSerializer>(), sp.GetService<IIdentifierGenerator>());
+            configure?.Invoke(sp, wso);
+            return wso;
+        });
     }
 }

--- a/src/CoreEx/Configuration/SettingsBase.cs
+++ b/src/CoreEx/Configuration/SettingsBase.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using CoreEx.Hosting.Work;
 using CoreEx.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
@@ -211,5 +212,10 @@ namespace CoreEx.Configuration
         /// Gets the default validation use of JSON names. Defaults to <c>true</c>.
         /// </summary>
         public bool ValidationUseJsonNames => _validationUseJsonNames ??= GetValue(nameof(ValidationUseJsonNames), true);
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStateOrchestrator"/> <see cref="WorkStateOrchestrator.ExpiryTimeSpan"/>. Defaults to <c>1</c> hour.
+        /// </summary>
+        public TimeSpan WorkerExpiryTimeSpan => GetValue(nameof(WorkerExpiryTimeSpan), TimeSpan.FromHours(1));
     }
 }

--- a/src/CoreEx/CoreEx.csproj
+++ b/src/CoreEx/CoreEx.csproj
@@ -69,7 +69,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="YamlDotNet" Version="15.1.0" />
+    <PackageReference Include="YamlDotNet" Version="15.1.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/CoreEx/CoreEx.csproj
+++ b/src/CoreEx/CoreEx.csproj
@@ -69,7 +69,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="YamlDotNet" Version="13.7.1" />
+    <PackageReference Include="YamlDotNet" Version="15.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/CoreEx/Events/EventPublisher.cs
+++ b/src/CoreEx/Events/EventPublisher.cs
@@ -61,9 +61,8 @@ namespace CoreEx.Events
         {
             foreach (var @event in events)
             {
-                var e = @event.Copy();
-                EventDataFormatter.Format(e);
-                _queue.Enqueue((name, e));
+                EventDataFormatter.Format(@event);
+                _queue.Enqueue((name, @event));
             }
 
             return this;

--- a/src/CoreEx/Events/EventSubscriberBase.cs
+++ b/src/CoreEx/Events/EventSubscriberBase.cs
@@ -2,6 +2,7 @@
 
 using CoreEx.Configuration;
 using CoreEx.Events.Subscribing;
+using CoreEx.Hosting.Work;
 using CoreEx.Localization;
 using CoreEx.Validation;
 using Microsoft.Extensions.Logging;
@@ -79,36 +80,40 @@ namespace CoreEx.Events
         /// <summary>
         /// Gets or sets the <see cref="ErrorHandling"/> where an <see cref="Exception"/> occurs during <see cref="EventData"/>/<see cref="EventData{T}"/> <see cref="IEventSerializer.DeserializeAsync(BinaryData, CancellationToken)"/>/<see cref="IEventSerializer.DeserializeAsync{T}(BinaryData, CancellationToken)"/>.
         /// </summary>
-        /// <remarks>Defaults to <see cref="ErrorHandling.Handle"/>.</remarks>
-        public ErrorHandling EventDataDeserializationErrorHandling { get; set; } = ErrorHandling.Handle;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleBySubscriber"/>.</remarks>
+        public ErrorHandling EventDataDeserializationErrorHandling { get; set; } = ErrorHandling.HandleBySubscriber;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.Handle"/>.</remarks>
-        public ErrorHandling UnhandledHandling { get; set; } = ErrorHandling.Handle;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleBySubscriber"/>.</remarks>
+        public ErrorHandling UnhandledHandling { get; set; } = ErrorHandling.HandleBySubscriber;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.Handle"/>.</remarks>
-        public ErrorHandling SecurityHandling { get; set; } = ErrorHandling.Handle;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleBySubscriber"/>.</remarks>
+        public ErrorHandling SecurityHandling { get; set; } = ErrorHandling.HandleBySubscriber;
 
         /// <inheritdoc/>
         /// <remarks>Defaults to <see cref="ErrorHandling.Retry"/>.</remarks>
         public ErrorHandling TransientHandling { get; set; } = ErrorHandling.Retry;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.Handle"/>.</remarks>
-        public ErrorHandling NotFoundHandling { get; set; } = ErrorHandling.Handle;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleBySubscriber"/>.</remarks>
+        public ErrorHandling NotFoundHandling { get; set; } = ErrorHandling.HandleBySubscriber;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.Handle"/>.</remarks>
-        public ErrorHandling ConcurrencyHandling { get; set; } = ErrorHandling.Handle;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleBySubscriber"/>.</remarks>
+        public ErrorHandling ConcurrencyHandling { get; set; } = ErrorHandling.HandleBySubscriber;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.Handle"/>.</remarks>
-        public ErrorHandling DataConsistencyHandling { get; set; } = ErrorHandling.Handle;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleBySubscriber"/>.</remarks>
+        public ErrorHandling DataConsistencyHandling { get; set; } = ErrorHandling.HandleBySubscriber;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.Handle"/>.</remarks>
-        public ErrorHandling InvalidDataHandling { get; set; } = ErrorHandling.Handle;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleBySubscriber"/>.</remarks>
+        public ErrorHandling InvalidDataHandling { get; set; } = ErrorHandling.HandleBySubscriber;
+
+        /// <inheritdoc/>
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleBySubscriber"/>.</remarks>
+        public ErrorHandling? WorkStateAlreadyFinishedHandling { get; set; } = ErrorHandling.HandleBySubscriber;
 
         /// <summary>
         /// Gets or sets the optional <see cref="IEventSubscriberInstrumentation"/>.
@@ -116,9 +121,47 @@ namespace CoreEx.Events
         public IEventSubscriberInstrumentation? Instrumentation { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional <see cref="Hosting.Work.WorkStateOrchestrator"/> to orchestrate and track <see cref="WorkState"/>; this enables the likes of the <i>async request-response</i> pattern.
+        /// </summary>
+        /// <remarks>The <see cref="WorkState.Id"/> is set from the <see cref="EventDataBase.Id"/> and the <see cref="WorkState.TypeName"/> is set from the <see cref="EventDataBase.Type"/> to enable the underlying operations. Where an
+        /// <see cref="EventSubscriberException"/> is thrown the <see cref="WorkState.Status"/> will be set to <see cref="WorkStatus.Indeterminate"/> as it is unknown as to whether the message will be reprocessed.</remarks>
+        public WorkStateOrchestrator? WorkStateOrchestrator { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="ErrorHandler"/>.
         /// </summary>
         public ErrorHandler ErrorHandler { get => _errorHandler ??= new ErrorHandler(); set => _errorHandler = value; }
+
+        /// <summary>
+        /// Performs any checks prior to the processing of the <paramref name="originatingMessage"/>.
+        /// </summary>
+        /// <param name="identifier">The unique identifier from the originiating message.</param>
+        /// <param name="originatingMessage">The originating message.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns><c>true</c> indicates that processing can continue; otherwise, <c>false</c>.</returns>
+        /// <remarks>Where there is a corresponding <see cref="WorkState"/> for the <paramref name="originatingMessage"/> and it is not in a state that is considered valid for processing then processing will not occur.</remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Future proofing.")]
+        protected async Task<bool> OnBeforeProcessingAsync(string identifier, object originatingMessage, CancellationToken cancellationToken = default)
+        {
+            if (WorkStateOrchestrator is null)
+                return true;
+
+            var wr = await WorkStateOrchestrator.GetAsync(identifier, cancellationToken).ConfigureAwait(false);
+            if (wr is null || WorkStatus.InProgress.HasFlag(wr.Status))
+                return true;
+
+            if (wr.Status == WorkStatus.Created)
+            {
+                await WorkStateOrchestrator.StartAsync(identifier, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+
+            if (WorkStateAlreadyFinishedHandling is null)
+                return true;
+
+            await ErrorHandler.HandleErrorAsync(new ErrorHandlerArgs(identifier, new EventSubscriberException($"Unable to process message as corresponding work state status is {wr.Status}: {wr.Reason ?? "Unexpected state."}") { ExceptionSource = EventSubscriberExceptionSource.WorkStateAlreadyFinished }, WorkStateAlreadyFinishedHandling.Value, Logger) { Instrumentation = Instrumentation, WorkOrchestrator = null }, cancellationToken).ConfigureAwait(false);
+            return false;
+        }
 
         /// <summary>
         /// Deserializes (<see cref="EventDataConverter"/>) the <paramref name="originatingMessage"/> into the specified <see cref="EventData"/> value containg metadata only. 
@@ -131,10 +174,11 @@ namespace CoreEx.Events
         /// <summary>
         /// Deserializes (<see cref="EventDataConverter"/>) the <paramref name="originatingMessage"/> into the specified <see cref="EventData"/> value. 
         /// </summary>
+        /// <param name="identifier">The unique identifier from the originiating message.</param>
         /// <param name="originatingMessage">The originating message.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The <see cref="EventData"/> where deserialized successfully; otherwise, <c>null</c>.</returns>
-        protected async Task<EventData?> DeserializeEventAsync(object originatingMessage, CancellationToken cancellationToken = default)
+        protected async Task<EventData?> DeserializeEventAsync(string identifier, object originatingMessage, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -144,25 +188,26 @@ namespace CoreEx.Events
             }
             catch (Exception ex)
             {
-                ErrorHandler.HandleError(new EventSubscriberException($"{MessageErrorText} {ex.Message}", ex) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger, Instrumentation);
+                await ErrorHandler.HandleErrorAsync(new ErrorHandlerArgs(identifier, new EventSubscriberException($"{MessageErrorText} {ex.Message}", ex) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger) { Instrumentation = Instrumentation, WorkOrchestrator = WorkStateOrchestrator }, cancellationToken).ConfigureAwait(false);
                 return null;
             }
 
-            ErrorHandler.HandleError(new EventSubscriberException(NullEventErrorText) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger, Instrumentation);
+            await ErrorHandler.HandleErrorAsync(new ErrorHandlerArgs(identifier, new EventSubscriberException(NullEventErrorText) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger) { Instrumentation = Instrumentation, WorkOrchestrator = WorkStateOrchestrator }, cancellationToken).ConfigureAwait(false);
             return null;
         }
 
         /// <summary>
         /// Deserializes (<see cref="EventDataConverter"/>) the <paramref name="originatingMessage"/> into the specified <see cref="EventData"/>.
         /// </summary>
+        /// <param name="identifier">The unique identifier from the originiating message.</param>
         /// <param name="originatingMessage">The originating message.</param>
         /// <param name="valueType">The optional <see cref="EventData{T}.Value"/> <see cref="Type"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The <see cref="EventData"/> or <see cref="EventData{T}"/> (<paramref name="valueType"/>) where deserialized successfully; otherwise, the corresponding <see cref="EventSubscriberException"/>.</returns>
-        protected async Task<EventData?> DeserializeEventAsync(object originatingMessage, Type? valueType, CancellationToken cancellationToken = default)
+        protected async Task<EventData?> DeserializeEventAsync(string identifier, object originatingMessage, Type? valueType, CancellationToken cancellationToken = default)
         {
             if (valueType is null)
-                return await DeserializeEventAsync(originatingMessage, cancellationToken).ConfigureAwait(false);
+                return await DeserializeEventAsync(identifier, originatingMessage, cancellationToken).ConfigureAwait(false);
 
             try
             {
@@ -172,11 +217,11 @@ namespace CoreEx.Events
             }
             catch (Exception ex)
             {
-                ErrorHandler.HandleError(new EventSubscriberException($"{MessageErrorText} {ex.Message}", ex) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger, Instrumentation);
+                await ErrorHandler.HandleErrorAsync(new ErrorHandlerArgs(identifier, new EventSubscriberException($"{MessageErrorText} {ex.Message}", ex) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger) { Instrumentation = Instrumentation, WorkOrchestrator = WorkStateOrchestrator }, cancellationToken).ConfigureAwait(false);
                 return null;
             }
 
-            ErrorHandler.HandleError(new EventSubscriberException(NullEventErrorText) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger, Instrumentation);
+            await ErrorHandler.HandleErrorAsync(new ErrorHandlerArgs(identifier, new EventSubscriberException(NullEventErrorText) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger) { Instrumentation = Instrumentation, WorkOrchestrator = WorkStateOrchestrator }, cancellationToken).ConfigureAwait(false);
             return null;
         }
 
@@ -184,13 +229,14 @@ namespace CoreEx.Events
         /// Deserializes (<see cref="EventDataConverter"/>) the <paramref name="originatingMessage"/> into the specified <see cref="EventData{T}"/>.
         /// </summary>
         /// <typeparam name="T">The <see cref="EventData{T}.Value"/> <see cref="Type"/>.</typeparam>
+        /// <param name="identifier">The unique identifier from the originiating message.</param>
         /// <param name="originatingMessage">The originating message.</param>
         /// <param name="valueIsRequired">Indicates whether the value is required; will consider invalid where null.</param>
         /// <param name="validator">The <see cref="IValidator{T}"/> to validate the deserialized value.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The <see cref="EventData{T}"/> where deserialized successfully; otherwise, the corresponding <see cref="Exception"/>.</returns>
         /// <remarks>Will result in an <see cref="EventSubscriberException"/> where a deserialization error occurs, or <see cref="ValidationException"/> where <paramref name="valueIsRequired"/> or <paramref name="validator"/> error occurs.</remarks>
-        protected async Task<EventData<T>?> DeserializeEventAsync<T>(object originatingMessage, bool valueIsRequired = true, IValidator<T>? validator = null, CancellationToken cancellationToken = default)
+        protected async Task<EventData<T>?> DeserializeEventAsync<T>(string identifier, object originatingMessage, bool valueIsRequired = true, IValidator<T>? validator = null, CancellationToken cancellationToken = default)
         {
             // Deserialize the event.
             EventData<T>? @event;
@@ -200,13 +246,13 @@ namespace CoreEx.Events
             }
             catch (Exception ex)
             {
-                ErrorHandler.HandleError(new EventSubscriberException($"{MessageErrorText} {ex.Message}", ex) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger, Instrumentation);
+                await ErrorHandler.HandleErrorAsync(new ErrorHandlerArgs(identifier, new EventSubscriberException($"{MessageErrorText} {ex.Message}", ex) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger) { Instrumentation = Instrumentation, WorkOrchestrator = WorkStateOrchestrator }, cancellationToken).ConfigureAwait(false);
                 return null;
             }
 
             if (@event is null)
             {
-                ErrorHandler.HandleError(new EventSubscriberException(NullEventErrorText) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger, Instrumentation);
+                await ErrorHandler.HandleErrorAsync(new ErrorHandlerArgs(identifier, new EventSubscriberException(NullEventErrorText) { ExceptionSource = EventSubscriberExceptionSource.EventDataDeserialization }, EventDataDeserializationErrorHandling, Logger) { Instrumentation = Instrumentation, WorkOrchestrator = WorkStateOrchestrator }, cancellationToken).ConfigureAwait(false);
                 return null;
             }
 
@@ -226,7 +272,7 @@ namespace CoreEx.Events
                 return @event;
 
             // Handle the validation exception.
-            ErrorHandler.HandleError(new EventSubscriberException(vex.Message, vex), ErrorHandler.DetermineErrorHandling(this, vex), Logger, Instrumentation);
+            await ErrorHandler.HandleErrorAsync(new ErrorHandlerArgs(identifier, new EventSubscriberException(vex.Message, vex), ErrorHandler.DetermineErrorHandling(this, vex), Logger) { Instrumentation = Instrumentation, WorkOrchestrator = WorkStateOrchestrator }, cancellationToken).ConfigureAwait(false);
             return null;
         }
     }

--- a/src/CoreEx/Events/EventSubscriberBase.cs
+++ b/src/CoreEx/Events/EventSubscriberBase.cs
@@ -137,16 +137,22 @@ namespace CoreEx.Events
         /// </summary>
         /// <param name="identifier">The unique identifier from the originiating message.</param>
         /// <param name="originatingMessage">The originating message.</param>
+        /// <param name="args">The <see cref="EventSubscriberArgs"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns><c>true</c> indicates that processing can continue; otherwise, <c>false</c>.</returns>
         /// <remarks>Where there is a corresponding <see cref="WorkState"/> for the <paramref name="originatingMessage"/> and it is not in a state that is considered valid for processing then processing will not occur.</remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Future proofing.")]
-        protected async Task<bool> OnBeforeProcessingAsync(string identifier, object originatingMessage, CancellationToken cancellationToken = default)
+        protected async Task<bool> OnBeforeProcessingAsync(string identifier, object originatingMessage, EventSubscriberArgs args, CancellationToken cancellationToken = default)
         {
+            args.ThrowIfNull(nameof(args));
             if (WorkStateOrchestrator is null)
+            {
+                args.SetState(this, identifier, null);
                 return true;
+            }
 
             var wr = await WorkStateOrchestrator.GetAsync(identifier, cancellationToken).ConfigureAwait(false);
+            args.SetState(this, identifier, wr);
             if (wr is null || WorkStatus.InProgress.HasFlag(wr.Status))
                 return true;
 

--- a/src/CoreEx/Events/EventSubscriberException.cs
+++ b/src/CoreEx/Events/EventSubscriberException.cs
@@ -45,8 +45,8 @@ namespace CoreEx.Events
         /// <summary>
         /// Gets or sets the <see cref="ErrorHandling"/> used when handling the error.
         /// </summary>
-        /// <remarks>See <see cref="ErrorHandler.HandleError(EventSubscriberException, ErrorHandling, Microsoft.Extensions.Logging.ILogger, IEventSubscriberInstrumentation?)"/></remarks>
-        public ErrorHandling ErrorHandling { get; set; } = ErrorHandling.None;
+        /// <remarks>See <see cref="ErrorHandler.HandleErrorAsync"/>.</remarks>
+        public ErrorHandling ErrorHandling { get; set; } = ErrorHandling.HandleByHost;
 
         /// <summary>
         /// Gets the error type/reason.

--- a/src/CoreEx/Events/Subscribing/ErrorHandlerArgs.cs
+++ b/src/CoreEx/Events/Subscribing/ErrorHandlerArgs.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Hosting.Work;
+using Microsoft.Extensions.Logging;
+
+namespace CoreEx.Events.Subscribing
+{
+    /// <summary>
+    /// Provides the <see cref="ErrorHandler.HandleErrorAsync"/> arguments.
+    /// </summary>
+    /// <param name="identifier">The corresponding unique identifier.</param>
+    /// <param name="eventSubscriberException">The <see cref="EventSubscriberException"/>.</param>
+    /// <param name="errorHandling">The <see cref="Subscribing.ErrorHandling"/> option.</param>
+    /// <param name="logger">The <see cref="ILogger"/>.</param>
+    public sealed class ErrorHandlerArgs(string? identifier, EventSubscriberException eventSubscriberException, ErrorHandling errorHandling, ILogger logger)
+    {
+        /// <summary>
+        /// Gets the corresponding unique identifier.
+        /// </summary>
+        public string? Identifier { get; } = identifier;
+
+        /// <summary>
+        /// Gets the <see cref="EventSubscriberException"/>.
+        /// </summary>
+        public EventSubscriberException Exception { get; } = eventSubscriberException.ThrowIfNull(nameof(eventSubscriberException));
+
+        /// <summary>
+        /// Gets the <see cref="Subscribing.ErrorHandling"/> option.
+        /// </summary>
+        public ErrorHandling ErrorHandling { get; } = errorHandling;
+        
+        /// <summary>
+        /// Gets the <see cref="ILogger"/>.
+        /// </summary>
+        public ILogger Logger { get; } = logger.ThrowIfNull(nameof(logger));
+        
+        /// <summary>
+        /// Gets or sets the optional <see cref="IEventSubscriberInstrumentation"/>.
+        /// </summary>
+        public IEventSubscriberInstrumentation? Instrumentation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional <see cref="WorkOrchestrator"/>.
+        /// </summary>
+        public WorkStateOrchestrator? WorkOrchestrator { get; set; }
+    }
+}

--- a/src/CoreEx/Events/Subscribing/ErrorHandling.cs
+++ b/src/CoreEx/Events/Subscribing/ErrorHandling.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace CoreEx.Events.Subscribing
 {
@@ -10,16 +11,19 @@ namespace CoreEx.Events.Subscribing
     public enum ErrorHandling
     {
         /// <summary>
-        /// Indicates that when the corresponding <i>error</i> occurs the underlying <see cref="System.Exception"/> will continue to bubble up the stack as unhandled.
+        /// Indicates that when the corresponding <i>error</i> occurs the underlying <see cref="System.Exception"/> will continue to bubble up the stack as unhandled to the executing host.
         /// </summary>
-        None,
+        /// <remarks>The host is the process that initiated the underlying <see cref="EventSubscriberBase"/>.</remarks>
+        HandleByHost,
 
         /// <summary>
         /// Indicates that when the corresponding <i>error</i> occurs that it should be handled by the subscriber.
         /// </summary>
-        /// <remarks>Results in a <see cref="EventSubscriberException"/> where the <see cref="Abstractions.IExtendedException.IsTransient"/> property is set (overridden) to <c>false</c>.
-        /// <para>Depending on the underlying messaging subsystem this may result in the likes of the message being deadlettered (or equivalent) where supported.</para></remarks>
-        Handle,
+        /// <remarks>Depending on the underlying messaging subsystem this may result in the likes of the message being deadlettered (or equivalent) where supported. May result in <see cref="HandleByHost"/> (bubble up the stack as unhandled to the executing host)
+        /// where subscriber is unable to handle appropriately.
+        /// <para>Where the underlying <see cref="Exception"/> implements <see cref="Abstractions.IExtendedException"/> and the <see cref="Abstractions.IExtendedException.IsTransient"/> property is set to <c>true</c> any configured retries
+        /// will be performed until exhausted; then will bubble up the stack as unhandled to the executing host.</para></remarks>
+        HandleBySubscriber,
 
         /// <summary>
         /// Indicates that when the corresponding <i>error</i> occurs that it may be transient and should be retried (where possible).

--- a/src/CoreEx/Events/Subscribing/EventSubscriberArgs.cs
+++ b/src/CoreEx/Events/Subscribing/EventSubscriberArgs.cs
@@ -1,11 +1,84 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Hosting.Work;
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace CoreEx.Events.Subscribing
 {
     /// <summary>
-    /// Provides the <see cref="IEventSubscriber"/> arguments; is obstensibly a <see cref="Dictionary{TKey, TValue}"/> with a <see cref="string"/> key and <see cref="object"/> value.
+    /// Provides the <see cref="EventSubscriberBase"/> arguments; is obstensibly a <see cref="Dictionary{TKey, TValue}"/> with a <see cref="string"/> key and <see cref="object"/> value.
     /// </summary>
-    public class EventSubscriberArgs : Dictionary<string, object?> { }
+    /// <remarks>This enables runtime state to passed through to the underlying subscriber receive logic where applicable.</remarks>
+    public class EventSubscriberArgs : Dictionary<string, object?> 
+    {
+        private EventSubscriberBase? _owner;
+        private string? _id;
+        private WorkState? _workState;
+
+        /// <summary>
+        /// Sets the initial subscriber state.
+        /// </summary>
+        /// <param name="owner">The owning <see cref="EventSubscriberBase"/>.</param>
+        /// <param name="id">The event/messagage identifier.</param>
+        /// <param name="workState">The corresponding <see cref="WorkState"/> (where applicable).</param>
+        internal void SetState(EventSubscriberBase owner, string id, WorkState? workState)
+        {
+            if (_owner is not null)
+                throw new InvalidOperationException($"An existing {nameof(EventSubscriberArgs)} instance may not be reused across subscriber executions; a new instance is required per event/message.");
+
+            _owner = owner.ThrowIfNull(nameof(owner));
+            _id = id.ThrowIfNullOrEmpty(nameof(id));
+            _workState = workState;
+        }
+
+        /// <summary>
+        /// Gets the owning <see cref="EventSubscriberBase"/>.
+        /// </summary>
+        /// <remarks>This is set automatically by the <see cref="EventSubscriberBase"/>.</remarks>
+        public EventSubscriberBase Owner => _owner ?? throw new InvalidOperationException($"The {nameof(Owner)} property has not yet been configured by the {nameof(EventSubscriberBase)} infrastructure.");
+
+        /// <summary>
+        /// Gets the event/messagage identifier.
+        /// </summary>
+        public string Id => _id ?? throw new InvalidOperationException($"The {nameof(Id)} property has not yet been configured by the {nameof(EventSubscriberBase)} infrastructure.");
+
+        /// <summary>
+        /// Gets the <see cref="WorkState"/> (where applicable).
+        /// </summary>
+        public WorkState? WorkState => _workState ?? throw new InvalidOperationException($"The {nameof(WorkState)} property has not yet been configured by the {nameof(EventSubscriberBase)} infrastructure.");
+
+        /// <summary>
+        /// Indicates whether the subscribing event/message has corresponding <see cref="WorkState"/>.
+        /// </summary>
+        public bool HasWorkState => _workState != null;
+
+        /// <summary>
+        /// Sets the corresponding <see cref="WorkState"/> result data with the specified <paramref name="data"/> (where <see cref="HasWorkState"/>).
+        /// </summary>
+        /// <param name="data">The <see cref="BinaryData"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public Task SetWorkStateDataAsync(BinaryData data, CancellationToken cancellationToken = default)
+        {
+            if (!HasWorkState)
+                throw new InvalidOperationException($"This event/message is not being {nameof(WorkState)} tracked/orchestrated therefore tracking data is unable to be set.");
+
+            return Owner.WorkStateOrchestrator!.SetDataAsync(Id, data, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the corresponding <see cref="WorkState"/> result data with the specified <paramref name="value"/> serialized as JSON (where <see cref="HasWorkState"/>).
+        /// </summary>
+        /// <param name="value">The value to JSON serialize as the result data.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public Task SetWorkStateDataAsync<TValue>(TValue value, CancellationToken cancellationToken = default)
+        {
+            if (!HasWorkState)
+                throw new InvalidOperationException($"This event/message is not being {nameof(WorkState)} tracked/orchestrated therefore tracking data is unable to be set.");
+
+            return Owner.WorkStateOrchestrator!.SetDataAsync(Id, value, cancellationToken);
+        }
+    }
 }

--- a/src/CoreEx/Events/Subscribing/EventSubscriberExceptionSource.cs
+++ b/src/CoreEx/Events/Subscribing/EventSubscriberExceptionSource.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Hosting.Work;
+
 namespace CoreEx.Events.Subscribing
 {
     /// <summary>
@@ -25,6 +27,11 @@ namespace CoreEx.Events.Subscribing
         /// <summary>
         /// Indicates that the <see cref="EventSubscriberException"/> relates to the <see cref="EventSubscriberOrchestrator.AmbiquousSubscriberHandling"/>. 
         /// </summary>
-        OrchestratorAmbiquousSubscriber = 2204
+        OrchestratorAmbiquousSubscriber = 2204,
+
+        /// <summary>
+        /// Indicates that the <see cref="EventSubscriberException"/> relates to the <see cref="WorkStateOrchestrator"/> having a <see cref="WorkState.Status"/> of <see cref="WorkStatus.Finished"/>.
+        /// </summary>
+        WorkStateAlreadyFinished = 2205
     }
 }

--- a/src/CoreEx/Events/Subscribing/EventSubscriberInstrumentationBase.cs
+++ b/src/CoreEx/Events/Subscribing/EventSubscriberInstrumentationBase.cs
@@ -51,7 +51,7 @@ namespace CoreEx.Events.Subscribing
         public string SuccessSuffix { get; set; } = "Success";
 
         /// <summary>
-        /// Gets or sets the instrumentation suffix for an see <see cref="ErrorHandling.None"/> or <see cref="ErrorType.UnhandledError"/>.
+        /// Gets or sets the instrumentation suffix for an see <see cref="ErrorHandling.HandleByHost"/> or <see cref="ErrorType.UnhandledError"/>.
         /// </summary>
         public string UnhandledErrorSuffix { get; set; } = nameof(ErrorType.UnhandledError);
 

--- a/src/CoreEx/Events/Subscribing/IErrorHandling.cs
+++ b/src/CoreEx/Events/Subscribing/IErrorHandling.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Hosting.Work;
 using System;
 
 namespace CoreEx.Events.Subscribing
@@ -44,5 +45,11 @@ namespace CoreEx.Events.Subscribing
         /// Gets the <see cref="ErrorHandling"/> for when a <see cref="ValidationException"/>, <see cref="BusinessException"/>, <see cref="DuplicateException"/> or <see cref="ConflictException"/> is encountered.
         /// </summary>
         ErrorHandling InvalidDataHandling { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ErrorHandling"/> for when the corresponding <see cref="WorkState"/> has a <see cref="WorkState.Status"/> already of <see cref="WorkStatus.Finished"/>.
+        /// </summary>
+        /// <remarks>A <c>null</c> indicates that the <see cref="WorkState"/> should not be verified before processing and work should occur regardless.</remarks>
+        ErrorHandling? WorkStateAlreadyFinishedHandling { get; }
     }
 }

--- a/src/CoreEx/Events/Subscribing/IEventSubscriberInstrumentation.cs
+++ b/src/CoreEx/Events/Subscribing/IEventSubscriberInstrumentation.cs
@@ -14,7 +14,7 @@ namespace CoreEx.Events.Subscribing
         /// Records instrumentation based on the <paramref name="errorHandling"/> and <paramref name="exception"/> values.
         /// </summary>
         /// <param name="errorHandling">The corresponding <see cref="ErrorHandling"/> value where an error ocurred; otherwise, <c>null</c> for success.</param>
-        /// <param name="exception">The corresponding <see cref="Exception"/> where there is an error (will be of Type <see cref="EventSubscriberException"/> where <paramref name="errorHandling"/> is not <see cref="ErrorHandling.None"/>).</param>
+        /// <param name="exception">The corresponding <see cref="Exception"/> where there is an error (will be of Type <see cref="EventSubscriberException"/> where <paramref name="errorHandling"/> is not <see cref="ErrorHandling.HandleByHost"/>).</param>
         void Instrument(ErrorHandling? errorHandling = null, Exception? exception = null);
     }
 }

--- a/src/CoreEx/Events/Subscribing/SubscriberBase.cs
+++ b/src/CoreEx/Events/Subscribing/SubscriberBase.cs
@@ -20,37 +20,36 @@ namespace CoreEx.Events.Subscribing
         public virtual Type? ValueType => null;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.None"/> indicating that the <see cref="EventSubscriberBase.UnhandledHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
-        public virtual ErrorHandling UnhandledHandling => ErrorHandling.None;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleByHost"/> indicating that the <see cref="EventSubscriberBase.UnhandledHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
+        public virtual ErrorHandling UnhandledHandling => ErrorHandling.HandleByHost;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.None"/> indicating that the <see cref="EventSubscriberBase.SecurityHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
-        public virtual ErrorHandling SecurityHandling => ErrorHandling.None;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleByHost"/> indicating that the <see cref="EventSubscriberBase.SecurityHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
+        public virtual ErrorHandling SecurityHandling => ErrorHandling.HandleByHost;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.None"/> indicating that the <see cref="EventSubscriberBase.TransientHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
-        public virtual ErrorHandling TransientHandling => ErrorHandling.None;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleByHost"/> indicating that the <see cref="EventSubscriberBase.TransientHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
+        public virtual ErrorHandling TransientHandling => ErrorHandling.HandleByHost;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.None"/> indicating that the <see cref="EventSubscriberBase.NotFoundHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
-        public virtual ErrorHandling NotFoundHandling => ErrorHandling.None;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleByHost"/> indicating that the <see cref="EventSubscriberBase.NotFoundHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
+        public virtual ErrorHandling NotFoundHandling => ErrorHandling.HandleByHost;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.None"/> indicating that the <see cref="EventSubscriberBase.ConcurrencyHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
-        public virtual ErrorHandling ConcurrencyHandling => ErrorHandling.None;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleByHost"/> indicating that the <see cref="EventSubscriberBase.ConcurrencyHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
+        public virtual ErrorHandling ConcurrencyHandling => ErrorHandling.HandleByHost;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.None"/> indicating that the <see cref="EventSubscriberBase.DataConsistencyHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
-        public virtual ErrorHandling DataConsistencyHandling => ErrorHandling.None;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleByHost"/> indicating that the <see cref="EventSubscriberBase.DataConsistencyHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
+        public virtual ErrorHandling DataConsistencyHandling => ErrorHandling.HandleByHost;
 
         /// <inheritdoc/>
-        /// <remarks>Defaults to <see cref="ErrorHandling.None"/> indicating that the <see cref="EventSubscriberBase.InvalidDataHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
-        public virtual ErrorHandling InvalidDataHandling => ErrorHandling.None;
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleByHost"/> indicating that the <see cref="EventSubscriberBase.InvalidDataHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
+        public virtual ErrorHandling InvalidDataHandling => ErrorHandling.HandleByHost;
 
-        /// <summary>
-        /// Gets or sets the optional <see cref="IEventSubscriberInstrumentation"/>.
-        /// </summary>
-        public IEventSubscriberInstrumentation? Instrumentation { get; set; }
+        /// <inheritdoc/>
+        /// <remarks>Defaults to <see cref="ErrorHandling.HandleByHost"/> indicating that the <see cref="EventSubscriberBase.InvalidDataHandling"/> configuration will be used; override explicitly to set specific handling behaviour where applicable.</remarks>
+        public virtual ErrorHandling? WorkStateAlreadyFinishedHandling => ErrorHandling.HandleByHost;
 
         /// <inheritdoc/>
         public abstract Task<Result> ReceiveAsync(EventData @event, EventSubscriberArgs args, CancellationToken cancellationToken);

--- a/src/CoreEx/Events/Subscribing/SubscriberBaseT.cs
+++ b/src/CoreEx/Events/Subscribing/SubscriberBaseT.cs
@@ -12,9 +12,11 @@ namespace CoreEx.Events.Subscribing
     /// Represents an <see cref="IEventSubscriber"/> with a <see cref="ValueType"/> of <typeparamref name="TValue"/> (supports <see cref="EventData{T}"/>).
     /// </summary>
     /// <typeparam name="TValue">The <see cref="EventData{T}.Value"/> <see cref="Type"/>.</typeparam>
+    /// <param name="valueValidator">The optional <see cref="IValidator{T}"/> for the value.</param>
+    /// <param name="valueIsRequired">Indicates whether the <see cref="EventData{T}.Value"/> is required; defaults to <c>true</c>.</param>
     /// <remarks>This is for use when the <see cref="EventData{T}"/> has to be deserialized.
     /// <para>Additionally, <see cref="ValueIsRequired"/> and <see cref="ValueValidator"/> enable a consistent validation approach prior to the underlying <see cref="ReceiveAsync(EventData{TValue}, EventSubscriberArgs, CancellationToken)"/> being invoked.</para></remarks>
-    public abstract class SubscriberBase<TValue> : SubscriberBase
+    public abstract class SubscriberBase<TValue>(IValidator<TValue>? valueValidator = null, bool valueIsRequired = true) : SubscriberBase
     {
         /// <inheritdoc/>
         public override Type EventDataType => typeof(EventData<TValue>);
@@ -25,12 +27,12 @@ namespace CoreEx.Events.Subscribing
         /// <summary>
         /// Indicates whether the <see cref="EventData{T}.Value"/> is required.
         /// </summary>
-        protected bool ValueIsRequired { get; set; } = true;
+        protected bool ValueIsRequired { get; set; } = valueIsRequired;
 
         /// <summary>
         /// Gets or sets the optional <see cref="IValidator{T}"/> for the value.
         /// </summary>
-        protected IValidator<TValue>? ValueValidator { get; set; }
+        protected IValidator<TValue>? ValueValidator { get; set; } = valueValidator;
 
         /// <inheritdoc/>
         /// <remarks>Caution where overridding this method as it contains the underlying functionality to invoke <see cref="ReceiveAsync(EventData{TValue}, EventSubscriberArgs, CancellationToken)"/> that is the <i>required</i> method to be overridden.</remarks>

--- a/src/CoreEx/Hosting/FileLockSynchronizer.cs
+++ b/src/CoreEx/Hosting/FileLockSynchronizer.cs
@@ -30,7 +30,7 @@ namespace CoreEx.Hosting
         /// <param name="settings">The <see cref="SettingsBase"/>.</param>
         public FileLockSynchronizer(SettingsBase settings)
         {
-            _path = (settings.ThrowIfNull(nameof(settings))).GetValue<string>(ConfigKey);
+            _path = settings.ThrowIfNull(nameof(settings)).GetValue<string>(ConfigKey);
 
             if (string.IsNullOrEmpty(_path))
                 throw new ArgumentException($"Configuration setting '{ConfigKey}' either does not exist or has no value.", nameof(settings));

--- a/src/CoreEx/Hosting/Work/FileWorkStatePersistence.cs
+++ b/src/CoreEx/Hosting/Work/FileWorkStatePersistence.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Configuration;
+using CoreEx.Json;
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.Hosting.Work
+{
+    /// <summary>
+    /// An <see cref="IWorkStatePersistence"/> that persists the <see cref="WorkState"/> (as JSON) to a file and the related <see cref="BinaryData"/> to a separate file.
+    /// </summary>
+    public class FileWorkStatePersistence : IWorkStatePersistence
+    {
+        private static readonly Regex _invalidFileNameChars = new($"[{Regex.Escape(new string(Path.GetInvalidFileNameChars()))}]", RegexOptions.Compiled);
+
+        private readonly string _path;
+        private readonly IJsonSerializer _jsonSerializer;
+
+        /// <summary>
+        /// Gets the configuration key that defines the directory path for the work persistence files.
+        /// </summary>
+        public const string ConfigKey = "FileWorkPersistencePath";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileWorkStatePersistence"/> class.
+        /// </summary>
+        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
+        /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>. Defaults to <see cref="JsonSerializer.Default"/>.</param>
+        public FileWorkStatePersistence(SettingsBase settings, IJsonSerializer? jsonSerializer = null)
+        {
+            _path = settings.ThrowIfNull(nameof(settings)).GetValue<string>(ConfigKey);
+
+            if (string.IsNullOrEmpty(_path))
+                throw new ArgumentException($"Configuration setting '{ConfigKey}' either does not exist or has no value.", nameof(settings));
+
+            if (!Directory.Exists(_path))
+                throw new ArgumentException($"Configuration setting '{ConfigKey}' path does not exist: {_path}");
+
+            _jsonSerializer = jsonSerializer ?? JsonSerializer.Default;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="WorkState"/> <see cref="FileInfo"/>.
+        /// </summary>
+        /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+        /// <returns>The <see cref="FileInfo"/>.</returns>
+        public FileInfo GetStateFileInfo(string id) => new(Path.Combine(_path, $"{GetSanitizedName(id)}.json"));
+
+        /// <summary>
+        /// Gets the <see cref="WorkState"/> data <see cref="FileInfo"/>.
+        /// </summary>
+        /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+        /// <returns>The <see cref="FileInfo"/>.</returns>
+        public FileInfo GetDataFileInfo(string id) => new(Path.Combine(_path, $"{GetSanitizedName(id)}.data"));
+
+        /// <summary>
+        /// Gets a sanitized file name by replacing any invalid characters with an underscore.
+        /// </summary>
+        private static string GetSanitizedName(string name) => _invalidFileNameChars.Replace(name, "_");
+
+        /// <inheritdoc/>
+        public async Task<WorkState?> GetAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var fi = GetStateFileInfo(id);
+            if (!fi.Exists)
+                return default!;
+
+            using var stream = fi.OpenRead();
+            var json = await BinaryData.FromStreamAsync(stream, cancellationToken).ConfigureAwait(false);
+            return _jsonSerializer.Deserialize<WorkState>(json);
+        }
+
+        /// <inheritdoc/>
+        public Task CreateAsync(WorkState state, CancellationToken cancellationToken = default) => ReplaceAsync(state, true, cancellationToken);
+
+        /// <inheritdoc/>
+        public Task UpdateAsync(WorkState state, CancellationToken cancellationToken = default) => ReplaceAsync(state, false, cancellationToken);
+
+        /// <summary>
+        /// Replace the <see cref="WorkState"/> file.
+        /// </summary>
+        private async Task ReplaceAsync(WorkState state, bool isCreate, CancellationToken cancellationToken = default)
+        {
+            var fi = GetStateFileInfo(state.Id.ThrowIfNull());
+            if (isCreate && fi.Exists)
+                throw new ArgumentException("Create can not be performed as the WorkState already exists; the type and identifier combination should be unique.", nameof(state));
+
+            if (fi.Directory is not null && !fi.Directory.Exists)
+                fi.Directory.Create();
+
+            using var stream = fi.Open(fi.Exists ? FileMode.Truncate : FileMode.Create);
+            var json = _jsonSerializer.SerializeToBinaryData(state);
+            await stream.WriteAsync(json, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var fi = GetStateFileInfo(id);
+            if (fi.Exists)
+                fi.Delete();
+
+            fi = GetDataFileInfo(id);
+            if (fi.Exists)
+                fi.Delete();
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public async Task<BinaryData?> GetDataAsync(string id, CancellationToken cancellationToken)
+        {
+            var fi = GetDataFileInfo(id);
+            if (!fi.Exists)
+                return null;
+
+            using var fs = fi.OpenRead();
+            return await BinaryData.FromStreamAsync(fs, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task SetDataAsync(string id, BinaryData data, CancellationToken cancellationToken)
+        {
+            var fi = GetDataFileInfo(id);
+            using var fs = fi.Open(fi.Exists ? FileMode.Truncate : FileMode.Create);
+            await data.ToStream().CopyToAsync(fs, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/CoreEx/Hosting/Work/IWorkStatePersistence.cs
+++ b/src/CoreEx/Hosting/Work/IWorkStatePersistence.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.Hosting.Work
+{
+    /// <summary>
+    /// Provides the <see cref="WorkState"/> persistence capabilities for the <see cref="WorkStateOrchestrator"/>
+    /// </summary>
+    /// <remarks>The <see cref="WorkStateOrchestrator"/> contains all orchestration logic, including validation, etc. which is performed prior to invoking the <see cref="IWorkStatePersistence"/>. Therefore, there is no need to repeat within the persistence implementation; 
+    /// i.e. simply perist as requested.<para>The <see cref="GetDataAsync"/> and <see cref="SetDataAsync"/> enable simple (smallish) result data persistence; large data should be persisted independently with the result data here representing a link to a file/blob for example.</para></remarks>
+    public interface IWorkStatePersistence
+    {
+        /// <summary>
+        /// Gets (reads) the <see cref="WorkState"/> from the persistence store using the specified <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+        /// <returns>The <see cref="WorkState"/> where found; otherwise, <c>null</c>.</returns>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        Task<WorkState?> GetAsync(string id, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Creates (saves) the <paramref name="state"/> to the persistence store as new.
+        /// </summary>
+        /// <param name="state">The <see cref="WorkState"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        Task CreateAsync(WorkState state, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Updates (saves) the <paramref name="state"/> to the persistence store replacing existinf.
+        /// </summary>
+        /// <param name="state">The <see cref="WorkState"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        Task UpdateAsync(WorkState state, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Deletes the <see cref="WorkState"/> from the persistence store using the specified <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <remarks>A delete should be considered idempotent and therefore should not fail where not found.</remarks>
+        Task DeleteAsync(string id, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets the <see cref="WorkState"/> <see cref="BinaryData"/> using the specified <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The <see cref="BinaryData"/> where found; otherwise, <c>null</c>.</returns>
+        Task<BinaryData?> GetDataAsync(string id, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets the <see cref="WorkState"/> <see cref="BinaryData"/> for the specified <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">The <see cref="WorkState.Id"/>.</param>
+        /// <param name="data">The <see cref="BinaryData"/> to persist.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        Task SetDataAsync(string id, BinaryData data, CancellationToken cancellationToken);
+    }
+}

--- a/src/CoreEx/Hosting/Work/InMemoryWorkStatePersistence.cs
+++ b/src/CoreEx/Hosting/Work/InMemoryWorkStatePersistence.cs
@@ -3,7 +3,7 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,6 +18,11 @@ namespace CoreEx.Hosting.Work
         private readonly Dictionary<string, WorkState> _workStates = [];
         private readonly Dictionary<string, BinaryData> _workData = [];
         private readonly ILogger? _logger = logger;
+
+        /// <summary>
+        /// Gets all the <see cref="WorkState"/> entries.
+        /// </summary>
+        public WorkState[] GetWorkStates() => _workStates.Values.ToArray();
 
         /// <inheritdoc/>
         public Task<WorkState?> GetAsync(string id, CancellationToken cancellationToken)

--- a/src/CoreEx/Hosting/Work/InMemoryWorkStatePersistence.cs
+++ b/src/CoreEx/Hosting/Work/InMemoryWorkStatePersistence.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.Hosting.Work
+{
+    /// <summary>
+    /// An <see cref="IWorkStatePersistence"/> that persists the <see cref="WorkState"/> in-memory which can be used for the likes of testing.
+    /// </summary>
+    /// <param name="logger">The <see cref="ILogger"/>.</param>
+    public class InMemoryWorkStatePersistence(ILogger<InMemoryWorkStatePersistence>? logger = null) : IWorkStatePersistence
+    {
+        private readonly Dictionary<string, WorkState> _workStates = [];
+        private readonly Dictionary<string, BinaryData> _workData = [];
+        private readonly ILogger? _logger = logger;
+
+        /// <inheritdoc/>
+        public Task<WorkState?> GetAsync(string id, CancellationToken cancellationToken)
+            => Task.FromResult(_workStates.TryGetValue(id, out var state) ? state : null);
+
+        /// <inheritdoc/>
+        public Task CreateAsync(WorkState state, CancellationToken cancellationToken)
+        {
+            if (_workStates.ContainsKey(state.Id.ThrowIfNull()))
+                throw new ArgumentException("Create can not be performed as the WorkState already exists; the type and identifier combination should be unique.", nameof(state));
+
+            _logger?.LogDebug("Creating WorkState: {Id}", state.Id);
+            _workStates.Add(state.Id, state);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public Task UpdateAsync(WorkState state, CancellationToken cancellationToken)
+        {
+            _logger?.LogDebug("Updating WorkState: {Id}", state.Id);
+            _workStates[state.Id.ThrowIfNull()] = state;
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public Task DeleteAsync(string id, CancellationToken cancellationToken)
+        {
+            _logger?.LogDebug("Deleting WorkState: {Id}", id);
+            _workStates.Remove(id);
+            _workData.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public Task<BinaryData?> GetDataAsync(string id, CancellationToken cancellationToken)
+        {
+            _logger?.LogDebug("Getting WorkState data for: {Id}", id);
+            return Task.FromResult(_workData.TryGetValue(id, out var data) ? data : null);
+        }
+
+        /// <inheritdoc/>
+        public Task SetDataAsync(string id, BinaryData data, CancellationToken cancellationToken)
+        {
+            _logger?.LogDebug("Setting WorkState data for: {Id}", id);
+            _workData[id] = data;
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Clears the in-memory persistence.
+        /// </summary>
+        public void Clear()
+        {
+            _logger?.LogDebug("Clearing WorkState persistence.");
+            _workStates.Clear();
+            _workData.Clear();
+        }
+    }
+}

--- a/src/CoreEx/Hosting/Work/WorkState.cs
+++ b/src/CoreEx/Hosting/Work/WorkState.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Entities;
+using System;
+using System.Text.Json.Serialization;
+
+namespace CoreEx.Hosting.Work
+{
+    /// <summary>
+    /// Represents the status and result of a long-running <see cref="WorkStateOrchestrator"/>-tracked work instance.
+    /// </summary>
+    public class WorkState : IIdentifier<string>
+    {
+        /// <inheritdoc/>
+        /// <remarks>The identifier must be globally unique across all work types.</remarks>
+        public string? Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStateOrchestrator"/> type name.
+        /// </summary>
+        /// <remarks>Enables separation between one or more <see cref="WorkState"/> types.</remarks>
+        [JsonPropertyName("type")]
+        public string? TypeName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the related entity key where applicable.
+        /// </summary>
+        public string? Key { get; set; }
+
+        /// <summary>
+        /// Gets or sets the correlation identifier.
+        /// </summary>
+        public string? CorrelationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStatus"/>.
+        /// </summary>
+        public WorkStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStatus.Created"/> <see cref="DateTimeOffset"/>.
+        /// </summary>
+        public DateTimeOffset Created { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStateOrchestrator"/> expiry <see cref="DateTimeOffset"/>.
+        /// </summary>
+        /// <remarks>Where the work has not <see cref="WorkStatus.Finished"/> by the expiry it will be automatically <see cref="WorkStatus.Expired"/>.</remarks>
+        public DateTimeOffset Expiry { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStatus.Started"/> <see cref="DateTimeOffset"/>.
+        /// </summary>
+        public DateTimeOffset? Started { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStatus.Indeterminate"/> <see cref="DateTimeOffset"/>.
+        /// </summary>
+        public DateTimeOffset? Indeterminate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStatus.Finished"/> <see cref="DateTimeOffset"/>.
+        /// </summary>
+        public DateTimeOffset? Finished { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStatus.Failed"/> or <see cref="WorkStatus.Expired"/> reason.
+        /// </summary>
+        public string? Reason { get; set; }
+    }
+}

--- a/src/CoreEx/Hosting/Work/WorkStateArgs.cs
+++ b/src/CoreEx/Hosting/Work/WorkStateArgs.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Entities;
+using System;
+
+namespace CoreEx.Hosting.Work
+{
+    /// <summary>
+    /// Represents the <see cref="WorkStateOrchestrator.CreateAsync"/> arguments.
+    /// </summary>
+    public class WorkStateArgs(string typeName, string? id = null) : IIdentifier<string>
+    {
+        /// <summary>
+        /// Gets the underlying <see cref="Type"/> name for the specified <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to infer the <see cref="WorkState.TypeName"/> enabling state separation.</typeparam>
+        /// <returns>The <see cref="Type.FullName"/>.</returns>
+        public static string GetTypeName<T>() => typeof(T).FullName ?? typeof(T).Name;
+
+        /// <summary>
+        /// Creates the <see cref="WorkStateArgs"/> using the <typeparamref name="T"/> <see cref="Type.FullName"/> as the <see cref="TypeName"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to infer the <see cref="WorkState.TypeName"/> enabling state separation.</typeparam>
+        /// <param name="id">The work identifier.</param>
+        /// <returns>The newly instantiated <see cref="WorkStateArgs"/>.</returns>
+        public static WorkStateArgs Create<T>(string? id = null) => new(GetTypeName<T>(), id);
+
+        /// <summary>
+        /// Gets or sets the <see cref="WorkStateOrchestrator"/> type name.
+        /// </summary>
+        /// <remarks>Enables separation between one or more <see cref="WorkState"/> types; see <see cref="WorkStateOrchestrator.GetAsync(string, string, System.Threading.CancellationToken)"/> to minimize cross-type access challenges.</remarks>
+        public string TypeName { get; } = typeName.ThrowIfNullOrEmpty(nameof(typeName));
+
+        /// <inheritdoc/>
+        /// <remarks>The <see cref="WorkState.Id"/> will default to the <see cref="WorkStateOrchestrator.IdentifierGenerator"/> <see cref="IIdentifierGenerator.GenerateIdentifierAsync{TId, TFor}"/> value.</remarks>
+        public string? Id { get; set; } = id;
+
+        /// <summary>
+        /// Gets or sets the related entity key where applicable.
+        /// </summary>
+        public string? Key { get; set; }
+
+        /// <summary>
+        /// Gets or sets the correlation identifier.
+        /// </summary>
+        /// <remarks>The <see cref="WorkState.CorrelationId"/> will default to the <see cref="ExecutionContext.CorrelationId"/> where not specified.</remarks>
+        public string? CorrelationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiry <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <remarks>The <see cref="WorkState.Expiry"/> will default to the <see cref="WorkStateOrchestrator.ExpiryTimeSpan"/> where not specified.</remarks>
+        public TimeSpan? Expiry { get; set; }
+    }
+}

--- a/src/CoreEx/Hosting/Work/WorkStateOrchestrator.cs
+++ b/src/CoreEx/Hosting/Work/WorkStateOrchestrator.cs
@@ -1,0 +1,365 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Configuration;
+using CoreEx.Entities;
+using CoreEx.Json;
+using CoreEx.Results;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.Hosting.Work
+{
+    /// <summary>
+    /// Represents the long-running work (see <see cref="WorkState"/>) tracking orchestrator.
+    /// </summary>
+    /// <param name="persistence">The <see cref="IWorkStatePersistence"/>.</param>
+    /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
+    /// <param name="settings">The <see cref="SettingsBase"/>.</param>
+    /// <param name="identifierGenerator">The <see cref="IIdentifierGenerator"/>.</param>
+    /// <remarks>There are some basic consistency checks that occur for the methods to ensure largely correct usage (sequence of execution).</remarks>
+    public class WorkStateOrchestrator(IWorkStatePersistence persistence, SettingsBase? settings = null, IJsonSerializer? jsonSerializer = null, IIdentifierGenerator? identifierGenerator = null)
+    {
+        private TimeSpan? _expiryTimeSpan;
+
+        /// <summary>
+        /// Gets the <see cref="IWorkStatePersistence"/>.
+        /// </summary>
+        public IWorkStatePersistence Persistence = persistence.ThrowIfNull(nameof(persistence));
+
+        /// <summary>
+        /// Gets the <see cref="IIdentifierGenerator"/>.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="Entities.IdentifierGenerator"/></remarks>
+        public IIdentifierGenerator IdentifierGenerator = identifierGenerator ?? new IdentifierGenerator();
+
+        /// <summary>
+        /// Gets the <see cref="SettingsBase"/>.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="DefaultSettings"/>.</remarks>
+        public SettingsBase Settings = settings ?? new DefaultSettings();
+
+        /// <summary>
+        /// Gets the <see cref="IJsonSerializer"/>.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="Json.JsonSerializer.Default"/>.</remarks>
+        public IJsonSerializer JsonSerializer = jsonSerializer ?? Json.JsonSerializer.Default;
+
+        /// <summary>
+        /// Gets or sets the work expiry <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <remarks>Defaults to <see cref="SettingsBase.WorkerExpiryTimeSpan"/>.</remarks>
+        public TimeSpan ExpiryTimeSpan
+        {
+            get => _expiryTimeSpan ??= Settings.WorkerExpiryTimeSpan;
+            set => _expiryTimeSpan = value;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="WorkState"/> for the specified <paramref name="id"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The <see cref="WorkState"/> where found; otherwise, <c>null</c>.</returns>
+        /// <remarks>Will automatically set the <see cref="WorkState.Status"/> to <see cref="WorkStatus.Expired"/> when the work is <i>not</i> <see cref="WorkStatus.Finished"/> and has expired (see <see cref="WorkState.Expiry"/>).</remarks>
+        public async Task<WorkState?> GetAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var ws = await Persistence.GetAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken).ConfigureAwait(false);
+            if (ws is null)
+                return null;
+
+            // Automatically cancel where expired.
+            if (ws.Status != WorkStatus.Finished && DateTimeOffset.UtcNow >= ws.Expiry)
+            {
+                var wsr = await ExpireAsync(id, "The work has not finished within the expiry timeframe and is assumed to have expired.", cancellationToken).ConfigureAwait(false);
+                return wsr.Value;
+            }
+
+            return ws;
+        }
+
+        /// <summary>
+        /// Creates and persists a <b>new</b> <see cref="WorkState"/> with a <see cref="WorkStatus.Created"/> status.
+        /// </summary>
+        /// <param name="args">The <see cref="WorkStateArgs"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The <see cref="WorkState"/>.</returns>
+        /// <remarks>The <see cref="WorkState.CorrelationId"/> will default to the <see cref="ExecutionContext.CorrelationId"/> where not specified.</remarks>
+        public async Task<WorkState> CreateAsync(WorkStateArgs args, CancellationToken cancellationToken = default)
+        {
+            args.ThrowIfNull(nameof(args));
+            var now = DateTimeOffset.UtcNow;
+            var ws = new WorkState()
+            {
+                Id = string.IsNullOrEmpty(args.Id) ? await IdentifierGenerator.GenerateIdentifierAsync<string, WorkStateOrchestrator>().ConfigureAwait(false) : args.Id,
+                TypeName = args.TypeName,
+                Key = args?.Key,
+                CorrelationId = args?.CorrelationId ?? (ExecutionContext.HasCurrent ? ExecutionContext.Current.CorrelationId : Guid.NewGuid().ToString()),
+                Status = WorkStatus.Created,
+                Created = now,
+                Expiry = now.Add(args?.Expiry ?? ExpiryTimeSpan)
+            };
+
+            await Persistence.CreateAsync(ws, cancellationToken).ConfigureAwait(false);
+
+            return ws;
+        }
+
+        /// <summary>
+        /// Starts a previously <see cref="WorkStatus.Created"/> <see cref="WorkState"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The updated <see cref="WorkState"/>.</returns>
+        /// <remarks>A <see cref="Result.NotFoundError"/> or <see cref="Result.ConflictError"/> may also be returned.</remarks>
+        public async Task<Result<WorkState>> StartAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var ws = await Persistence.GetAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken).ConfigureAwait(false);
+            if (ws is null)
+                return Result.NotFoundError();
+
+            if (ws.Status != WorkStatus.Created)
+                return Result.ConflictError($"Work '{id}' can not be started due to current status of '{ws.Status}'.");
+
+            ws.Status = WorkStatus.Started;
+            ws.Started = DateTimeOffset.UtcNow;
+
+            await Persistence.UpdateAsync(ws, cancellationToken).ConfigureAwait(false);
+            return ws;
+        }
+
+        /// <summary>
+        /// Sets a previously <see cref="WorkStatus.Started"/> <see cref="WorkState"/> to <see cref="WorkStatus.Indeterminate"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="reason">The indeterminate reason.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The updated <see cref="WorkState"/>.</returns>
+        /// <remarks>A <see cref="Result.NotFoundError"/> or <see cref="Result.ConflictError"/> may also be returned.</remarks>
+        public async Task<Result<WorkState>> IndeterminateAsync(string id, string reason, CancellationToken cancellationToken = default)
+        {
+            var ws = await GetAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken).ConfigureAwait(false);
+            if (ws is null)
+                return Result.NotFoundError();
+
+            if (!WorkStatus.InProgress.HasFlag(ws.Status))
+                return Result.ConflictError($"Work '{id}' can not be set to indeterminate due to current status of '{ws.Status}'.");
+
+            ws.Status = WorkStatus.Indeterminate;
+            ws.Indeterminate = DateTimeOffset.UtcNow;
+            ws.Reason = reason.ThrowIfNullOrEmpty(nameof(reason));
+
+            await Persistence.UpdateAsync(ws, cancellationToken).ConfigureAwait(false);
+            return ws;
+        }
+
+        /// <summary>
+        /// Completes a previously <see cref="WorkStatus.Started"/> <see cref="WorkState"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The updated <see cref="WorkState"/>.</returns>
+        /// <remarks>A <see cref="Result.NotFoundError"/> or <see cref="Result.ConflictError"/> may also be returned.</remarks>
+        public async Task<Result<WorkState>> CompleteAsync(string id, CancellationToken cancellationToken = default)
+        { 
+            var ws = await GetAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken).ConfigureAwait(false);
+            if (ws is null)
+                return Result.NotFoundError();
+
+            if (!WorkStatus.InProgress.HasFlag(ws.Status))
+                return Result.ConflictError($"Work '{id}' can not be completed due to current status of '{ws.Status}'.");
+
+            ws.Status = WorkStatus.Completed;
+            ws.Finished = DateTimeOffset.UtcNow;
+            ws.Reason = null;
+
+            await Persistence.UpdateAsync(ws, cancellationToken).ConfigureAwait(false);
+            return ws;
+        }
+
+        /// <summary>
+        /// Fails a previously <see cref="WorkStatus.Started"/> <see cref="WorkState"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="reason">The failure reason.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The updated <see cref="WorkState"/>.</returns>
+        /// <remarks>A <see cref="Result.NotFoundError"/> or <see cref="Result.ConflictError"/> may also be returned.</remarks>
+        public async Task<Result<WorkState>> FailAsync(string id, string reason, CancellationToken cancellationToken = default)
+        {
+            var ws = await GetAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken).ConfigureAwait(false);
+            if (ws is null)
+                return Result.NotFoundError();
+
+            if (!WorkStatus.InProgress.HasFlag(ws.Status))
+                return Result.ConflictError($"Work '{id}' can not be failed due to current status of '{ws.Status}'.");
+
+            ws.Status = WorkStatus.Failed;
+            ws.Finished = DateTimeOffset.UtcNow;
+            ws.Reason = reason.ThrowIfNullOrEmpty(nameof(reason));
+
+            await Persistence.UpdateAsync(ws, cancellationToken).ConfigureAwait(false);
+            return ws;
+        }
+
+        /// <summary>
+        /// Fails a previously <see cref="WorkStatus.Started"/> <see cref="WorkState"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="exception">The unhandled <see cref="Exception"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The updated <see cref="WorkState"/>.</returns>
+        /// <remarks>A <see cref="Result.NotFoundError"/> or <see cref="Result.ConflictError"/> may also be returned.</remarks>
+        public Task<Result<WorkState>> FailAsync(string id, Exception exception, CancellationToken cancellationToken = default)
+            => FailAsync(id, $"Work failed due to an error: {exception.ThrowIfNull(nameof(exception)).Message}", cancellationToken);
+
+        /// <summary>
+        /// Expires a <see cref="WorkState"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="reason">The cancellation reason.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The updated <see cref="WorkState"/>.</returns>
+        /// <remarks>A <see cref="Result.NotFoundError"/> may also be returned. Expiring work that has already <see cref="WorkStatus.Finished"/> will not update the <see cref="WorkStatus"/>.</remarks>
+        public async Task<Result<WorkState>> ExpireAsync(string id, string reason, CancellationToken cancellationToken = default)
+        {
+            var ws = await GetAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken).ConfigureAwait(false);
+            if (ws is null)
+                return Result.NotFoundError();
+
+            if (!WorkStatus.Finished.HasFlag(ws.Status))
+                return ws;
+
+            ws.Status = WorkStatus.Expired;
+            ws.Finished = DateTimeOffset.UtcNow;
+            ws.Reason = reason.ThrowIfNullOrEmpty(nameof(reason));
+
+            await Persistence.UpdateAsync(ws, cancellationToken).ConfigureAwait(false);
+            return ws;
+        }
+
+        /// <summary>
+        /// Cancels a <see cref="WorkState"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="reason">The cancellation reason.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The updated <see cref="WorkState"/>.</returns>
+        /// <remarks>A <see cref="Result.NotFoundError"/> may also be returned. Cancelling work that has already <see cref="WorkStatus.Finished"/> will not update the <see cref="WorkStatus"/>.</remarks>
+        public async Task<Result<WorkState>> CancelAsync(string id, string reason, CancellationToken cancellationToken = default)
+        {
+            var ws = await GetAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken).ConfigureAwait(false);
+            if (ws is null)
+                return Result.NotFoundError();
+
+            if (WorkStatus.Finished.HasFlag(ws.Status))
+                return Result.Fail($"A cancellation can not be performed when the current status is {ws.Status}.");
+
+            ws.Status = WorkStatus.Cancelled;
+            ws.Finished = DateTimeOffset.UtcNow;
+            ws.Reason = reason.ThrowIfNullOrEmpty(nameof(reason));
+
+            await Persistence.UpdateAsync(ws, cancellationToken).ConfigureAwait(false);
+            return ws;
+        }
+
+        /// <summary>
+        /// Deletes a <see cref="WorkState"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <remarks>A <see cref="Result.ConflictError"/> will be returned where attempting to delete work that is not <see cref="WorkStatus.Finished"/>.</remarks>
+        public async Task<Result> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var ws = await GetAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken).ConfigureAwait(false);
+            if (ws is null)
+                return Result.Success;
+
+            if (!WorkStatus.Finished.HasFlag(ws.Status))
+                return Result.ConflictError($"Work '{id}' can not be deleted due to current status of '{ws.Status}'; must be considered 'Finished'.");
+
+            await Persistence.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+            return Result.Success;
+        }
+
+        /// <summary>
+        /// Gets the result data as <see cref="BinaryData"/> and then JSON deserializes to the specified <typeparamref name="TValue"/>.
+        /// </summary>
+        /// <typeparam name="TValue">The value <see cref="Type"/>.</typeparam>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The deserialized value where found; otherwise, <c>default</c>.</returns>
+        public async Task<TValue?> GetDataAsync<TValue>(string id, CancellationToken cancellationToken = default)
+        {
+            var data = await GetDataAsync(id, cancellationToken).ConfigureAwait(false);
+            if (data is null)
+                return default;
+
+            return JsonSerializer.Deserialize<TValue>(data);
+        }
+
+        /// <summary>
+        /// Gets the result data as a <see cref="BinaryData"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The <see cref="BinaryData"/> where found; otherwise, <c>null</c>.</returns>
+        public Task<BinaryData?> GetDataAsync(string id, CancellationToken cancellationToken = default)
+            => Persistence.GetDataAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken);
+
+        /// <summary>
+        /// Sets the result data as the specified <paramref name="value"/> serialized as JSON.
+        /// </summary>
+        /// <typeparam name="TValue">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="value">The value to JSON serialize as the resul data.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public Task SetDataAsync<TValue>(string id, TValue value, CancellationToken cancellationToken = default)
+        {
+            var json = JsonSerializer.SerializeToBinaryData(value.ThrowIfNull(nameof(value)));
+            return SetDataAsync(id, json, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sets the result data as the specified <see cref="BinaryData"/>.
+        /// </summary>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="data">The <see cref="BinaryData"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        public async Task SetDataAsync(string id, BinaryData data, CancellationToken cancellationToken = default)
+        {
+            if (await GetAsync(id, cancellationToken).ConfigureAwait(false) is null)
+                throw new ArgumentException($"Work '{id}' does not exist.", nameof(id));
+
+            await Persistence.SetDataAsync(id.ThrowIfNullOrEmpty(nameof(id)), data.ThrowIfNull(nameof(data)), cancellationToken).ConfigureAwait(false);
+        }
+
+        #region WithType
+
+        /// <summary>
+        /// Gets the <see cref="WorkState"/> for the specified <paramref name="type"/> and <paramref name="id"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="WorkState.TypeName"/>.</param>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The <see cref="WorkState"/> where found; otherwise, <c>null</c>.</returns>
+        /// <remarks>Will automatically set the <see cref="WorkState.Status"/> to <see cref="WorkStatus.Expired"/> when the work is <i>not</i> <see cref="WorkStatus.Finished"/> and has expired (see <see cref="WorkState.Expiry"/>).</remarks>
+        public async Task<WorkState?> GetAsync(string type, string id, CancellationToken cancellationToken = default)
+        {
+            var ws = await Persistence.GetAsync(id.ThrowIfNullOrEmpty(nameof(id)), cancellationToken).ConfigureAwait(false);
+            return ws is null || ws.TypeName != type ? null : ws;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="WorkState"/> for the specified <paramref name="id"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> to infer the <see cref="WorkState.TypeName"/> enabling state separation.</typeparam>
+        /// <param name="id">The work identifier.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The <see cref="WorkState"/> where found; otherwise, <c>null</c>.</returns>
+        /// <remarks>Will automatically set the <see cref="WorkState.Status"/> to <see cref="WorkStatus.Expired"/> when the work is <i>not</i> <see cref="WorkStatus.Finished"/> and has expired (see <see cref="WorkState.Expiry"/>).</remarks>
+        public Task<WorkState?> GetAsync<T>(string id, CancellationToken cancellationToken = default) => GetAsync(WorkStateArgs.GetTypeName<T>(), id, cancellationToken);
+
+        #endregion
+    }
+}

--- a/src/CoreEx/Hosting/Work/WorkStateOrchestrator.cs
+++ b/src/CoreEx/Hosting/Work/WorkStateOrchestrator.cs
@@ -312,7 +312,7 @@ namespace CoreEx.Hosting.Work
         /// </summary>
         /// <typeparam name="TValue">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
         /// <param name="id">The work identifier.</param>
-        /// <param name="value">The value to JSON serialize as the resul data.</param>
+        /// <param name="value">The value to JSON serialize as the result data.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         public Task SetDataAsync<TValue>(string id, TValue value, CancellationToken cancellationToken = default)
         {

--- a/src/CoreEx/Hosting/Work/WorkStatus.cs
+++ b/src/CoreEx/Hosting/Work/WorkStatus.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+namespace CoreEx.Hosting.Work
+{
+    /// <summary>
+    /// Represents the long-running work status.
+    /// </summary>
+    public enum WorkStatus
+    {
+        /// <summary>
+        /// Indicates that the work as been created; however, it is not yet <see cref="Started"/>.
+        /// </summary>
+        Created = 1,
+
+        /// <summary>
+        /// Indicates that the underlying work has been started and is in progress.
+        /// </summary>
+        Started = 2,
+
+        /// <summary>
+        /// Indicates that the underlying work is in progress; however, the progress is indeterminate, see associated <see cref="WorkState.Reason"/> for details.
+        /// </summary>
+        /// <remarks>There is a possible retry of processing and as such may/may not be completed; will eventually automatically expire without explicit completion.</remarks>
+        Indeterminate = 4,
+
+        /// <summary>
+        /// Indicates that the underlying work has been completed successfully.
+        /// </summary>
+        Completed = 8,
+
+        /// <summary>
+        /// Indicates that the underlying work has failed.
+        /// </summary>
+        Failed = 32,
+
+        /// <summary>
+        /// Indicates that the underlying work has expired.
+        /// </summary>
+        Expired = 64,
+
+        /// <summary>
+        /// Indicates that the underlying work has been cancelled.
+        /// </summary>
+        Cancelled = 128,
+
+        /// <summary>
+        /// Indicates that the underlying work is in progress; either started or indeterminate.
+        /// </summary>
+        InProgress = Started | Indeterminate,
+
+        /// <summary>
+        /// Indicates that the underlying work is executing; either created or in progress.
+        /// </summary>
+        Executing = Created | InProgress,
+
+        /// <summary>
+        /// Indicates the the underlying work has been terminated; either expired, failed or cancelled.
+        /// </summary>
+        Terminated = Expired | Failed | Cancelled,
+
+        /// <summary>
+        /// Indicates that the underlying work has been completed, expired, failed or cancelled.
+        /// </summary>
+        Finished = Completed | Expired | Failed | Cancelled
+    }
+}   

--- a/src/CoreEx/Hosting/Work/WorkStatus.cs
+++ b/src/CoreEx/Hosting/Work/WorkStatus.cs
@@ -20,7 +20,7 @@ namespace CoreEx.Hosting.Work
         /// <summary>
         /// Indicates that the underlying work is in progress; however, the progress is indeterminate, see associated <see cref="WorkState.Reason"/> for details.
         /// </summary>
-        /// <remarks>There is a possible retry of processing and as such may/may not be completed; will eventually automatically expire without explicit completion.</remarks>
+        /// <remarks>This may occur as a result of a possible retry of processing and as such may or may not be completed; will eventually automatically expire without explicit completion.</remarks>
         Indeterminate = 4,
 
         /// <summary>

--- a/src/CoreEx/Results/IResult.cs
+++ b/src/CoreEx/Results/IResult.cs
@@ -36,5 +36,12 @@ namespace CoreEx.Results
         /// <param name="error">The underlying error represented as an <see cref="Exception"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
         IResult ToFailure(Exception error);
+
+        /// <summary>
+        /// Indicates whether the result is in a failure state and the underlying error is of the specified <typeparamref name="TException"/> <see cref="Type"/>.
+        /// </summary>
+        /// <typeparam name="TException">The <see cref="Exception"/> <see cref="Type"/>.</typeparam>
+        /// <returns><c>true</c> indicates that the result is in a failure state <i>and</i> the underlying error is of the specified <typeparamref name="TException"/> <see cref="Type"/>.</returns>
+        bool IsFailureOfType<TException>() where TException : Exception;
     }
 }

--- a/src/CoreEx/Results/ITypedToResult.cs
+++ b/src/CoreEx/Results/ITypedToResult.cs
@@ -6,7 +6,7 @@ namespace CoreEx.Results
     /// Enables the <see cref="ToResult"/> to convert into a corresponding <see cref="Result{T}"/>.
     /// </summary>
     /// <returns>The resulting <see cref="Result{T}"/>.</returns>
-    public interface ITypedToResult
+    public interface ITypedToResult : IToResult
     {
         /// <summary>
         /// Converts into a corresponding <see cref="Result{T}"/>.

--- a/src/CoreEx/Results/Result.cs
+++ b/src/CoreEx/Results/Result.cs
@@ -55,6 +55,9 @@ namespace CoreEx.Results
         /// <inheritdoc/>
         IResult IResult.ToFailure(Exception error) => new Result(error);
 
+        /// <inheritdoc/>
+        public bool IsFailureOfType<TException>() where TException : Exception => _error is not null && _error.GetType() == typeof(TException);
+
         /// <summary>
         /// Converts the <see cref="Result"/> to a corresponding <see cref="Result{T}"/> (of <see cref="Type"/> <typeparamref name="T"/>) defaulting to <see cref="Result{T}.None"/> where <see cref="Result.IsSuccess"/>; otherwise, where
         /// <see cref="IsFailure"/> returns a resulting instance with the corresponding <see cref="Error"/>.
@@ -122,6 +125,12 @@ namespace CoreEx.Results
         /// <param name="message">The error message.</param>
         /// <returns>The <see cref="Result"/> that has a state of <see cref="IsFailure"/>.</returns>
         public static Result Fail(LText? message = null) => new(new BusinessException(message));
+
+        /// <summary>
+        /// Converts the <see cref="Result"/> to a <see cref="Task{TResult}"/> using <see cref="Task.FromResult{TResult}(TResult)"/>.
+        /// </summary>
+        /// <returns>The completed <see cref="Task{TResult}"/>.</returns>
+        public Task<Result> AsTask() => Task.FromResult(this);
 
         /// <inheritdoc/>
         public override string ToString() => IsSuccess ? "Success." : $"Failure: {Error.Message}";

--- a/src/CoreEx/Results/ResultT.cs
+++ b/src/CoreEx/Results/ResultT.cs
@@ -5,6 +5,7 @@ using CoreEx.Localization;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace CoreEx.Results
 {
@@ -63,6 +64,9 @@ namespace CoreEx.Results
 
         /// <inheritdoc/>
         IResult IResult.ToFailure(Exception error) => new Result<T>(error);
+
+        /// <inheritdoc/>
+        public bool IsFailureOfType<TException>() where TException : Exception => _error is not null && _error.GetType() == typeof(TException);
 
         /// <summary>
         /// Throws the <see cref="Error"/> where <see cref="IsFailure"/>; otherwise, does nothing.
@@ -125,6 +129,12 @@ namespace CoreEx.Results
 
             return this;
         }
+
+        /// <summary>
+        /// Converts the <see cref="Result"/> to a <see cref="Task{TResult}"/> using <see cref="Task.FromResult{TResult}(TResult)"/>.
+        /// </summary>
+        /// <returns>The completed <see cref="Task{TResult}"/>.</returns>
+        public Task<Result<T>> AsTask() => Task.FromResult(this);
 
         /// <summary>
         /// Implicitly converts an <see cref="Exception"/> to a <see cref="Result"/> that is considered <see cref="IsFailure"/>.

--- a/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
+++ b/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
@@ -34,7 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
+++ b/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -34,7 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.1" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Solace.Test/CoreEx.Solace.Test.csproj
+++ b/tests/CoreEx.Solace.Test/CoreEx.Solace.Test.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/CoreEx.Test/CoreEx.Test.csproj
+++ b/tests/CoreEx.Test/CoreEx.Test.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.1" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Test/CoreEx.Test.csproj
+++ b/tests/CoreEx.Test/CoreEx.Test.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\..\src\CoreEx.Newtonsoft\CoreEx.Newtonsoft.csproj" />
     <ProjectReference Include="..\..\src\CoreEx.OData\CoreEx.OData.csproj" />
     <ProjectReference Include="..\..\src\CoreEx.Solace\CoreEx.Solace.csproj" />
+    <ProjectReference Include="..\..\src\CoreEx.UnitTesting.NUnit\CoreEx.UnitTesting.NUnit.csproj" />
     <ProjectReference Include="..\..\src\CoreEx.UnitTesting\CoreEx.UnitTesting.csproj" />
     <ProjectReference Include="..\..\src\CoreEx.Validation\CoreEx.Validation.csproj" />
     <ProjectReference Include="..\..\src\CoreEx\CoreEx.csproj" />

--- a/tests/CoreEx.Test/Framework/Hosting/Work/WorkStateOrchestratorTest.cs
+++ b/tests/CoreEx.Test/Framework/Hosting/Work/WorkStateOrchestratorTest.cs
@@ -28,6 +28,9 @@ namespace CoreEx.Test.Framework.Hosting.Work
                 _ => new InMemoryWorkStatePersistence()
             };
 
+            if (p is null)
+                return null!;
+
             return new WorkStateOrchestrator(p, s);
         }
 

--- a/tests/CoreEx.Test/Framework/Hosting/Work/WorkStateOrchestratorTest.cs
+++ b/tests/CoreEx.Test/Framework/Hosting/Work/WorkStateOrchestratorTest.cs
@@ -1,0 +1,164 @@
+﻿using Azure.Data.Tables;
+using CoreEx.Azure.Storage;
+using CoreEx.Configuration;
+using CoreEx.Hosting.Work;
+using CoreEx.Test.Framework.Json.Mapping;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using UnitTestEx.NUnit;
+
+
+namespace CoreEx.Test.Framework.Hosting.Work
+{
+    [TestFixture]
+    internal class WorkStateOrchestratorTest
+    {
+        private static WorkStateOrchestrator CreateOrchestrator(string persistType)
+        {
+            var config = new ConfigurationBuilder().AddInMemoryCollection(new[] { new KeyValuePair<string, string>(FileWorkStatePersistence.ConfigKey, Path.GetTempPath()) });
+            var s = new DefaultSettings(config.Build());
+            IWorkStatePersistence p = persistType switch
+            {
+                "fs" => new FileWorkStatePersistence(s),
+                "at" => CreateTableWorkStatePersistence(),
+                _ => new InMemoryWorkStatePersistence()
+            };
+
+            return new WorkStateOrchestrator(p, s);
+        }
+
+        private static TableWorkStatePersistence CreateTableWorkStatePersistence()
+        {
+            var csn = $"{nameof(BlobAttachmentStorage)}ConnectionString";
+            var cs = Environment.GetEnvironmentVariable(csn);
+            if (string.IsNullOrEmpty(cs))
+                return null!;
+
+            var tsc = new TableServiceClient(cs);
+            return new TableWorkStatePersistence(tsc);
+        }
+
+        [Test]
+        public async Task Orchestrate_With_FileSystem() => await Orchestrate(CreateOrchestrator("fs"));
+
+        [Test]
+        public async Task Orchestrate_With_InMemory() => await Orchestrate(CreateOrchestrator("im"));
+
+        [Test]
+        public async Task Orchestrate_With_AzureTable() => await Orchestrate(CreateOrchestrator("at"));
+
+        private static async Task Orchestrate(WorkStateOrchestrator o)
+        {
+            if (o is null)
+            {
+                Assert.Inconclusive("Test cannot run as the environment variable 'TableWorkStatePersistenceConnectionString' is not defined.");
+                return;
+            }
+
+            // Clean up before we begin.
+            await o.Persistence.DeleteAsync("abc", default);
+
+            // Get where not found.
+            var wr = await o.GetAsync<Person>("abc");
+            Assert.That(wr, Is.Null);
+
+            // Create work and assert state.
+            wr = await o.CreateAsync(WorkStateArgs.Create<Person>().Adjust(x => x.Id = "abc").Adjust(x => x.Key = "bananas"));
+            Assert.That(wr, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wr.Id, Is.EqualTo("abc"));
+                Assert.That(wr.TypeName, Is.EqualTo(typeof(Person).FullName));
+                Assert.That(wr.Status, Is.EqualTo(WorkStatus.Created));
+            });
+
+            ObjectComparer.Assert(wr, await o.GetAsync<Person>("abc"));
+            Assert.That(await o.GetDataAsync("abc", default), Is.Null);
+
+            // Start work and assert state.
+            wr = await o.StartAsync("abc");
+            Assert.That(wr, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wr.Id, Is.EqualTo("abc"));
+                Assert.That(wr.Status, Is.EqualTo(WorkStatus.Started));
+            });
+
+            ObjectComparer.Assert(wr, await o.GetAsync<Person>("abc"));
+            Assert.That(await o.GetDataAsync("abc", default), Is.Null);
+
+            // Set to indeterminate and assert state.
+            wr = await o.IndeterminateAsync("abc", "Not sure!");
+            Assert.That(wr, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wr.Id, Is.EqualTo("abc"));
+                Assert.That(wr.Status, Is.EqualTo(WorkStatus.Indeterminate));
+                Assert.That(wr.Reason, Is.EqualTo("Not sure!"));
+            });
+
+            ObjectComparer.Assert(wr, await o.GetAsync<Person>("abc"));
+            Assert.That(await o.GetDataAsync("abc", default), Is.Null);
+
+            // Set the data and assert by getting and comparing.
+            var p = new Person { Id = "xyz", Name = "John" };
+            await o.SetDataAsync("abc", p);
+
+            var p2 = await o.GetDataAsync<Person>("abc", default);
+            Assert.That(p2, Is.Not.Null);
+            ObjectComparer.Assert(p, await o.GetDataAsync<Person>("abc"));
+
+            // Set to complete and assert state.
+            wr = await o.CompleteAsync("abc");
+            Assert.That(wr, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(wr.Id, Is.EqualTo("abc"));
+                Assert.That(wr.Status, Is.EqualTo(WorkStatus.Completed));
+                Assert.That(wr.Reason, Is.Null);
+            });
+
+            ObjectComparer.Assert(wr, await o.GetAsync<Person>("abc"));
+
+            // Check different type; but same id. Confirms same type as extra pre-caution!
+            wr = await o.GetAsync("other", "abc");
+            Assert.That(wr, Is.Null);
+        }
+
+        [Test]
+        public async Task Orchestrate_LargeData_With_FileSystem() => await Orchestrate_LargeData(CreateOrchestrator("fs"));
+
+        [Test]
+        public async Task Orchestrate_LargeData_With_InMemory() => await Orchestrate_LargeData(CreateOrchestrator("im"));
+
+        [Test]
+        public async Task Orchestrate_LargeData_With_AzureTable() => await Orchestrate_LargeData(CreateOrchestrator("at"));
+
+        private static async Task Orchestrate_LargeData(WorkStateOrchestrator o)
+        {
+            if (o is null)
+            {
+                Assert.Inconclusive("Test cannot run as the environment variable 'TableWorkStatePersistenceConnectionString' is not defined.");
+                return;
+            }
+
+            // Clean up before we begin.
+            await o.Persistence.DeleteAsync("large", default);
+
+            // Create the work.
+            var wr = await o.CreateAsync(WorkStateArgs.Create<Person>().Adjust(x => x.Id = "large"));
+            Assert.That(wr, Is.Not.Null);
+
+            // Set large data and assert by getting and comparing.
+            var ls = new string('x', 959998);
+            await o.SetDataAsync("large", ls);
+
+            var ls2 = await o.GetDataAsync<string>("large", default);
+            Assert.That(ls2, Is.EqualTo(ls));
+        }
+    }
+}

--- a/tests/CoreEx.Test/Framework/Results/ResultTTest.cs
+++ b/tests/CoreEx.Test/Framework/Results/ResultTTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using CoreEx.Results;
+using System.Threading.Tasks;
 
 namespace CoreEx.Test.Framework.Results
 {
@@ -206,6 +207,17 @@ namespace CoreEx.Test.Framework.Results
         {
             var r = Result<int>.Fail(new BusinessException("Test"));
             Assert.That(r.ToString(), Is.EqualTo("Failure: Test"));
+        }
+
+        [Test]
+        public async Task AsTask()
+        {
+            var r = await Result.Go(1).AsTask();
+            Assert.Multiple(() =>
+            {
+                Assert.That(r.IsSuccess, Is.True);
+                Assert.That(r.Value, Is.EqualTo(1));
+            });
         }
     }
 }

--- a/tests/CoreEx.Test/Framework/Results/ResultTest.cs
+++ b/tests/CoreEx.Test/Framework/Results/ResultTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using CoreEx.Results;
+using System.Threading.Tasks;
 
 namespace CoreEx.Test.Framework.Results
 {
@@ -132,6 +133,13 @@ namespace CoreEx.Test.Framework.Results
         public void Failure_ToString()
         {
             Assert.That(Result.Fail(new BusinessException()).ToString(), Is.EqualTo("Failure: A business error occurred."));
+        }
+
+        [Test]
+        public async Task AsTask()
+        {
+            var r = await Result.Go().AsTask();
+            Assert.That(r, Is.EqualTo(Result.Success));
         }
     }
 }

--- a/tests/CoreEx.Test/Framework/Results/ThenExtensionsTest.cs
+++ b/tests/CoreEx.Test/Framework/Results/ThenExtensionsTest.cs
@@ -60,7 +60,7 @@ namespace CoreEx.Test.Framework.Results
             Assert.That(AssertSuccess(Result.Go(1).ThenAs(i => Result.Ok(i + 1f))), Is.EqualTo(2f));
             AssertFailure(Result.Go<int>(new NotFoundException()).ThenAs(i => { Assert.Fail(); return Result.Ok(i + 1f); }));
 
-            AssertSuccess(Result.Go().Then(() => new IToResultTest()));
+            AssertSuccess(Result.Go().Then(() => { }));
             AssertFailure(Result.NotFoundError().ThenFrom(() => { Assert.Fail(); return new IToResultTest(); }));
 
             Assert.That(AssertSuccess(Result.Go(0).ThenFrom(_ => new ITypedToResultTest())), Is.EqualTo(1));
@@ -155,6 +155,8 @@ namespace CoreEx.Test.Framework.Results
         public class ITypedToResultTest : ITypedToResult
         {
             public Result<T> ToResult<T>() => Result.Ok((T)(object)1);
+
+            public Result ToResult() => Result.Success;
         }
 
         public class IToResultIntTest : IToResult<int>

--- a/tests/CoreEx.Test/TestFunction/ServiceBusSubsciberTest.cs
+++ b/tests/CoreEx.Test/TestFunction/ServiceBusSubsciberTest.cs
@@ -308,7 +308,7 @@ namespace CoreEx.Test.TestFunction
             var message = test.CreateServiceBusMessageFromValue(new { id = "A", name = "B", price = 1.99m });
 
             var sbs = test.Services.GetRequiredService<ServiceBusSubscriber>();
-            sbs.UnhandledHandling = Events.Subscribing.ErrorHandling.Handle;
+            sbs.UnhandledHandling = Events.Subscribing.ErrorHandling.HandleBySubscriber;
 
             await sbs.ReceiveAsync(message, actions, (_, _) => throw new DivideByZeroException("Zero is bad dude!"));
 
@@ -324,7 +324,7 @@ namespace CoreEx.Test.TestFunction
             var message = test.CreateServiceBusMessageFromValue(new { id = "A", name = "B", price = 1.99m });
 
             var sbs = test.Services.GetRequiredService<ServiceBusSubscriber>();
-            sbs.UnhandledHandling = Events.Subscribing.ErrorHandling.None;
+            sbs.UnhandledHandling = Events.Subscribing.ErrorHandling.HandleByHost;
 
             try
             {

--- a/tests/CoreEx.Test2/CoreEx.Test2.csproj
+++ b/tests/CoreEx.Test2/CoreEx.Test2.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/CoreEx.Test2/TestFunctionIso/ServiceBusTest.cs
+++ b/tests/CoreEx.Test2/TestFunctionIso/ServiceBusTest.cs
@@ -1,6 +1,8 @@
-﻿using CoreEx.TestFunctionIso;
-using UnitTestEx.NUnit;
+﻿using CoreEx.Hosting.Work;
+using CoreEx.TestFunctionIso;
+using Microsoft.Extensions.DependencyInjection;
 using UnitTestEx.Expectations;
+using UnitTestEx.NUnit;
 
 namespace CoreEx.Test2.TestFunctionIso
 {
@@ -8,25 +10,58 @@ namespace CoreEx.Test2.TestFunctionIso
     public class ServiceBusTest
     {
         [Test]
-        public void InvalidMessage()
+        public async Task InvalidMessage()
         {
             using var test = FunctionTester.Create<Startup>();
             var actions = test.CreateWorkerServiceBusMessageActions();
             var message = test.CreateServiceBusMessageFromValue(new { Blah = true });
+
+            var wo = test.Services.GetRequiredService<WorkStateOrchestrator>();
+            await wo.CreateAsync(new WorkStateArgs("test") { Id = message.MessageId });
 
             test.ServiceBusTrigger<ServiceBusFunction>()
                 .Run(f => f.Run(message, actions))
                 .AssertSuccess();
 
             actions.AssertDeadLetter("EventDataDeserialization", "Invalid message; body was not provided, contained invalid JSON, or was incorrectly formatted: The JSON value could not be converted to System.String");
+
+            var ws = await wo.GetAsync(message.MessageId);
+            Assert.That(ws, Is.Not.Null);
+            Assert.That(ws.Status, Is.EqualTo(WorkStatus.Failed));
         }
 
         [Test]
-        public void Success()
+        public async Task Complete_WorkStatus_Cancelled()
         {
             using var test = FunctionTester.Create<Startup>();
             var actions = test.CreateWorkerServiceBusMessageActions();
             var message = test.CreateServiceBusMessageFromValue("Bob");
+
+            var wo = test.Services.GetRequiredService<WorkStateOrchestrator>();
+            await wo.CreateAsync(new WorkStateArgs("test") { Id = message.MessageId });
+            await wo.CancelAsync(message.MessageId, "No longer needed.");
+
+            test.ServiceBusTrigger<ServiceBusFunction>()
+                .ExpectLogContains("warn: Unable to process message as corresponding work state status is Cancelled: No longer needed.")
+                .Run(f => f.Run(message, actions))
+                .AssertSuccess();
+
+            actions.AssertComplete();
+
+            var ws = await wo.GetAsync(message.MessageId);
+            Assert.That(ws, Is.Not.Null);
+            Assert.That(ws.Status, Is.EqualTo(WorkStatus.Cancelled));
+        }
+
+        [Test]
+        public async Task Success()
+        {
+            using var test = FunctionTester.Create<Startup>();
+            var actions = test.CreateWorkerServiceBusMessageActions();
+            var message = test.CreateServiceBusMessageFromValue("Bob");
+
+            var wo = test.Services.GetRequiredService<WorkStateOrchestrator>();
+            await wo.CreateAsync(new WorkStateArgs("test") { Id = message.MessageId });
 
             test.ServiceBusTrigger<ServiceBusFunction>()
                 .ExpectLogContains("Received message: Bob")
@@ -34,6 +69,10 @@ namespace CoreEx.Test2.TestFunctionIso
                 .AssertSuccess();
 
             actions.AssertComplete();
+
+            var ws = await wo.GetAsync(message.MessageId);
+            Assert.That(ws, Is.Not.Null);
+            Assert.That(ws.Status, Is.EqualTo(WorkStatus.Completed));
         }
     }
 }

--- a/tests/CoreEx.TestFunction/CoreEx.TestFunction.csproj
+++ b/tests/CoreEx.TestFunction/CoreEx.TestFunction.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />

--- a/tests/CoreEx.TestFunction/CoreEx.TestFunction.csproj
+++ b/tests/CoreEx.TestFunction/CoreEx.TestFunction.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\CoreEx.AspNetCore\CoreEx.AspNetCore.csproj" />

--- a/tests/CoreEx.TestFunction/Subscribers/ProductSubscriber.cs
+++ b/tests/CoreEx.TestFunction/Subscribers/ProductSubscriber.cs
@@ -12,17 +12,11 @@ using System.Threading.Tasks;
 namespace CoreEx.TestFunction.Subscribers
 {
     [EventSubscriber("my.product")]
-    public class ProductSubscriber : SubscriberBase<Product>
+    public class ProductSubscriber(ILogger<NoValueSubscriber> logger) : SubscriberBase<Product>(new ProductValidator().Wrap())
     {
-        private readonly ILogger _logger;
+        private readonly ILogger _logger = logger;
 
-        public static HashSet<string> EventIds { get; } = new HashSet<string>();
-
-        public ProductSubscriber(ILogger<NoValueSubscriber> logger)
-        {
-            _logger = logger;
-            ValueValidator = new ProductValidator().Wrap();
-        }
+        public static HashSet<string> EventIds { get; } = [];
 
         public async override Task<Result> ReceiveAsync(EventData<Product> @event, EventSubscriberArgs args, CancellationToken cancellationToken)
         {

--- a/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
+++ b/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
@@ -9,11 +9,11 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.20.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.15.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.16.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/CoreEx.TestFunctionIso/ServiceBusFunction.cs
+++ b/tests/CoreEx.TestFunctionIso/ServiceBusFunction.cs
@@ -15,6 +15,9 @@ namespace CoreEx.TestFunctionIso
         public Task Run([ServiceBusTrigger("test-queue", Connection = "ServiceBusConnectionString")] ServiceBusReceivedMessage message, ServiceBusMessageActions sbma)
             => _subscriber.ReceiveAsync<string>(message, sbma, (@event, args) =>
             {
+                if (@event.Value == "not-found")
+                    return Result.NotFoundError().AsTask();
+
                 _logger.LogInformation($"Received message: {@event.Value}");
                 return Result.SuccessTask;
             });

--- a/tests/CoreEx.TestFunctionIso/Startup.cs
+++ b/tests/CoreEx.TestFunctionIso/Startup.cs
@@ -1,5 +1,5 @@
-﻿using CoreEx.Azure.ServiceBus;
-using CoreEx.Hosting;
+﻿using CoreEx.Hosting;
+using CoreEx.Hosting.Work;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CoreEx.TestFunctionIso
@@ -14,7 +14,15 @@ namespace CoreEx.TestFunctionIso
                 .AddJsonSerializer()
                 .AddWebApi()
                 .AddEventDataSerializer()
-                .AddScoped<ServiceBusSubscriber>();
+                .AddAzureServiceBusSubscriber((sp, s) =>
+                {
+                    s.WorkStateAlreadyFinishedHandling = Events.Subscribing.ErrorHandling.CompleteWithWarning;
+                    s.WorkStateOrchestrator = sp.GetRequiredService<WorkStateOrchestrator>();
+                });
+
+            services
+                .AddSingleton<IWorkStatePersistence, InMemoryWorkStatePersistence>()
+                .AddSingleton<WorkStateOrchestrator>();
         }
     }
 }


### PR DESCRIPTION
- *Enhancement*: The `ITypedToResult` updated to correctly implement `IToResult` as the simple `ToResult` where required. 
- *Enhancement*: Added `Result.AsTask()` and `Result<T>.AsTask` to simplify the conversion to a completed `Task<Result>` or `Task<Result<T>>` where applicable.
- *Enhancement*: Added `IResult.IsFailureOfType<TException>` to indicate whether the result is in a failure state and the underlying error is of the specified `TException` type.
- *Enhancement*: Added `EventTemplate` property to the `WebApiPublisherArgs` and `WebApiPublisherCollectionArgs` to define an `EventData` template.
- *Enhancement*: Added `SubscriberBase<T>` constructor overload to enable specification of `valueValidator` and `ValueIsRequired` parameters versus setting properties directly simplifying usage.
- *Enhancement:* Enum renames to improve understanding of intent for event subscribing logic: `ErrorHandling.None` is now `ErrorHandling.HandleByHost` and `ErrorHandling.Handle` is now `ErrorHandling.HandleBySubscriber`.
- *Enhancement:* Simplified the `ServiceBusSubscriber.Receive` methods by removing the `afterReceive` parameter which served no real purpose; also, reversed the `validator` and `valueIsRequired` parameters (order as stated) as the `validator` is more likely to be specified than `valueIsRequired` which defaults to `true`.
- *Enhancement*: Added `CoreEx.Hosting.Work` namespace which includes light-weight/simple foundational capabilities to track and orchestrate work; intended for the likes of [_asynchronous request-response_](https://learn.microsoft.com/en-us/azure/architecture/patterns/async-request-reply) scenarios.
  - Added `IWorkStatePersistence` to enable flexible/pluggable persistence of the `WorkState` and resulting data; includes `InMemoryWorkStatePersistence` for testing, `FileWorkStatePersistence` for file-based, and `TableWorkStatePersistence` leveraging Azure table storage.
  - Added `WorkStateOrchestrator` support to `EventSubscriberBase`, including corresponding `ServiceBusSubscriber` and `ServiceBusOrchestratedSubscriber` using the `ServiceBusMessage.MessageId` as the corresponding `WorkState.Id`.
  - Extended `EventSubscriberArgs` to support a new `SetWorkStateDataAsync` operation to enable the setting of the underlying `WorkState` data is a consistent manner where using the event subscriber capabilities.