### PR TITLE
v3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Represents the **NuGet** versions.
 
+## v3.13.0
+- *Enhancement*: Added `DatabaseMapperEx` enabling extended/explicit mapping where performance is critical versus existing that uses reflection and compiled expressions; can offer up to 40%+ improvement in some scenarios.
+- *Enhancement*: The `AddMappers<TAssembly>()` and `AddValidators<TAssembly>()` extension methods now also support two or three assembly specification overloads.
+- *Enhancement*: A `WorkState.UserName` has been added to enable the tracking of the user that initiated the work; this is then checked to ensure that only the initiating user can interact with their own work state.
+- *Fixed:* The `ReferenceDataOrchestrator.GetByTypeAsync` has had the previous sync-over-async corrected to be fully async.
+- *Fixed*: Validation extensions `Exists` and `ExistsAsync` which expect a non-null resultant value have been renamed to `ValueExists` and `ValueExistsAsync` to improve usability; also they are `IResult` aware and will act accordingly.
+- *Fixed*: The `ETag` HTTP handling has been updated to correctly output and expect the weak `W/"xxxx"` format. 
+- *Fixed*: The `ETagGenerator` implementation has been further optimized to minimize unneccessary string allocations.
+- *Fixed*: The `SettingsBase` has been optimized. The internal recursion checking has been removed and as such an endless loop (`StackOverflowException`) may occur where misconfigured; given frequency of `IConfiguration` usage the resulting performance is deemed more important. Additionally, `prefixes` are now optional.
+  - The existing support of referencing a settings property by name (`settings.GetValue<T>("NamedProperty")`) and it using reflection to find before querying the `IConfiguration` has been removed. This was not a common, or intended usage, and was somewhat magical, and finally was non-performant.
+
 ## v3.12.0
 - *Enhancement*: Added new `CoreEx.Database.Postgres` project/package to support [PostgreSQL](https://www.postgresql.org/) database capabilities. Primarily encapsulates the open-source [`Npqsql`](https://www.npgsql.org/) .NET ADO database provider for PostgreSQL.
   - Added `EncodedStringToUInt32Converter` to support PostgreSQL `xmin` column encoding as the row version/etag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Represents the **NuGet** versions.
 - *Fixed*: Validation extensions `Exists` and `ExistsAsync` which expect a non-null resultant value have been renamed to `ValueExists` and `ValueExistsAsync` to improve usability; also they are `IResult` aware and will act accordingly.
 - *Fixed*: The `ETag` HTTP handling has been updated to correctly output and expect the weak `W/"xxxx"` format. 
 - *Fixed*: The `ETagGenerator` implementation has been further optimized to minimize unneccessary string allocations.
+- *Fixed*: The `ValueContentResult` will only generate a response header ETag (`ETagGenerator`) for a `GET` or `HEAD` request. The underlying result `IETag.ETag` is used as-is where there is no query string; otherwise, generates as assumes query string will alter result (i.e. filtering, paging, sorting, etc.). The result `IETag.ETag` is unchanged so the consumer can still use as required for a further operation.
 - *Fixed*: The `SettingsBase` has been optimized. The internal recursion checking has been removed and as such an endless loop (`StackOverflowException`) may occur where misconfigured; given frequency of `IConfiguration` usage the resulting performance is deemed more important. Additionally, `prefixes` are now optional.
   - The existing support of referencing a settings property by name (`settings.GetValue<T>("NamedProperty")`) and it using reflection to find before querying the `IConfiguration` has been removed. This was not a common, or intended usage, and was somewhat magical, and finally was non-performant.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.12.0</Version>
+		<Version>3.13.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx.AspNetCore/WebApis/WebApi.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApi.cs
@@ -719,10 +719,8 @@ namespace CoreEx.AspNetCore.WebApis
 
                 if (etag != null)
                 {
-                    if (!ValueContentResult.TryGetETag(getValue!, out var getEt))
-                        getEt = ValueContentResult.GenerateETag(wap.RequestOptions, getValue!, null, JsonSerializer);
-
-                    if (etag != getEt)
+                    var getEt = ValueContentResult.GenerateETag(wap.RequestOptions, getValue!, null, JsonSerializer);
+                    if (etag != getEt.etag)
                         return new ConcurrencyException();
                 }
             }

--- a/src/CoreEx.AspNetCore/WebApis/WebApi.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApi.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Abstractions;
 using CoreEx.AspNetCore.Http;
 using CoreEx.Configuration;
 using CoreEx.Entities;
@@ -710,17 +711,29 @@ namespace CoreEx.AspNetCore.WebApis
         /// </summary>
         private ConcurrencyException? ConcurrencyETagMatching<TValue>(WebApiParam wap, TValue getValue, TValue putValue, bool autoConcurrency)
         {
-            var et = putValue as IETag;
-            if (et != null || autoConcurrency)
+            var ptag = putValue as IETag;
+            if (ptag != null || autoConcurrency)
             {
-                string? etag = et?.ETag ?? wap.RequestOptions.ETag;
+                string? etag = wap.RequestOptions.ETag ?? ptag?.ETag;
                 if (string.IsNullOrEmpty(etag))
                     return new ConcurrencyException($"An 'If-Match' header is required for an HTTP {wap.Request.Method} where the underlying entity supports concurrency (ETag).");
 
                 if (etag != null)
                 {
-                    var getEt = ValueContentResult.GenerateETag(wap.RequestOptions, getValue!, null, JsonSerializer);
-                    if (etag != getEt.etag)
+                    var gtag = getValue is IETag getag ? getag.ETag : null;
+                    if (gtag is null)
+                    {
+                        var isTextSerializationEnabled = ExecutionContext.HasCurrent && ExecutionContext.Current.IsTextSerializationEnabled;
+                        if (isTextSerializationEnabled)
+                            ExecutionContext.Current.IsTextSerializationEnabled = false;
+
+                        gtag = ETagGenerator.Generate(JsonSerializer, getValue);
+
+                        if (ExecutionContext.HasCurrent)
+                            ExecutionContext.Current.IsTextSerializationEnabled = isTextSerializationEnabled;
+                    }
+
+                    if (etag != gtag)
                         return new ConcurrencyException();
                 }
             }

--- a/src/CoreEx.Azure/Storage/TableWorkStatePersistence.cs
+++ b/src/CoreEx.Azure/Storage/TableWorkStatePersistence.cs
@@ -62,6 +62,7 @@ namespace CoreEx.Azure.Storage
                 TypeName = state.TypeName;
                 Key = state.Key;
                 CorrelationId = state.CorrelationId;
+                UserName = state.UserName;
                 Status = state.Status;
                 Created = state.Created;
                 Expiry = state.Expiry;
@@ -161,6 +162,7 @@ namespace CoreEx.Azure.Storage
                 TypeName = er.Value.TypeName,
                 Key = er.Value.Key,
                 CorrelationId = er.Value.CorrelationId,
+                UserName = er.Value.UserName,
                 Status = er.Value.Status,
                 Created = er.Value.Created,
                 Expiry = er.Value.Expiry,

--- a/src/CoreEx.Database/DatabaseRecord.cs
+++ b/src/CoreEx.Database/DatabaseRecord.cs
@@ -2,6 +2,7 @@
 
 using CoreEx.Entities;
 using System;
+using System.Data;
 using System.Data.Common;
 
 namespace CoreEx.Database
@@ -22,6 +23,20 @@ namespace CoreEx.Database
         /// Gets the underlying <see cref="DbDataReader"/>.
         /// </summary>
         public DbDataReader DataReader { get; } = dataReader.ThrowIfNull(nameof(dataReader));
+
+        /// <summary>
+        /// Gets the named column value.
+        /// </summary>
+        /// <param name="columnName">The column name.</param>
+        /// <returns>The value.</returns>
+        public object? GetValue(string columnName) => GetValue(DataReader.GetOrdinal(columnName.ThrowIfNull(nameof(columnName))));
+
+        /// <summary>
+        /// Gets the specified column value.
+        /// </summary>
+        /// <param name="ordinal">The ordinal index.</param>
+        /// <returns>The value.</returns>
+        public object? GetValue(int ordinal) => DataReader.IsDBNull(ordinal) ? default! : DataReader.GetValue(ordinal);
 
         /// <summary>
         /// Gets the named column value.

--- a/src/CoreEx.Database/DatabaseRecord.cs
+++ b/src/CoreEx.Database/DatabaseRecord.cs
@@ -2,7 +2,6 @@
 
 using CoreEx.Entities;
 using System;
-using System.Data;
 using System.Data.Common;
 
 namespace CoreEx.Database
@@ -36,7 +35,14 @@ namespace CoreEx.Database
         /// </summary>
         /// <param name="ordinal">The ordinal index.</param>
         /// <returns>The value.</returns>
-        public object? GetValue(int ordinal) => DataReader.IsDBNull(ordinal) ? default! : DataReader.GetValue(ordinal);
+        public object? GetValue(int ordinal)
+        {
+            if (DataReader.IsDBNull(ordinal))
+                return default;
+
+            var val = DataReader.GetValue(ordinal);
+            return val is DateTime dt ? Cleaner.Clean(dt, Database.DateTimeTransform) : val;
+        }
 
         /// <summary>
         /// Gets the named column value.

--- a/src/CoreEx.Database/Extended/DatabaseExtendedExtensions.cs
+++ b/src/CoreEx.Database/Extended/DatabaseExtendedExtensions.cs
@@ -299,7 +299,7 @@ namespace CoreEx.Database.Extended
         /// <returns>The value where found; otherwise, <c>null</c>.</returns>
         public static Task<Result<T?>> GetWithResultAsync<T>(this DatabaseCommand command, DatabaseArgs args, CompositeKey key, CancellationToken cancellationToken = default) where T : class, new()
             => command.ThrowIfNull(nameof(command))
-                .Params(p => args.Mapper.MapPrimaryKeyParameters(p, OperationTypes.Get, key))
+                .Params(p => args.Mapper.MapKeyToDb(key, p))
                 .SelectFirstOrDefaultWithResultAsync((IDatabaseMapper<T>)args.Mapper, cancellationToken);
 
         /// <summary>
@@ -392,7 +392,7 @@ namespace CoreEx.Database.Extended
         public static async Task<Result> DeleteWithResultAsync(this DatabaseCommand command, DatabaseArgs args, CompositeKey key, CancellationToken cancellationToken = default)
         {
             var rowsAffectedResult = await command.ThrowIfNull(nameof(command))
-                .Params(p => args.Mapper.MapPrimaryKeyParameters(p, OperationTypes.Get, key))
+                .Params(p => args.Mapper.MapKeyToDb(key, p))
                 .ScalarWithResultAsync<int>(cancellationToken).ConfigureAwait(false);
 
             return rowsAffectedResult.WhenAs(rowsAffected => rowsAffected < 1, _ => Result.NotFoundError());

--- a/src/CoreEx.Database/IDatabaseMapper.cs
+++ b/src/CoreEx.Database/IDatabaseMapper.cs
@@ -3,7 +3,6 @@
 using CoreEx.Entities;
 using CoreEx.Mapping;
 using System;
-using System.Data;
 
 namespace CoreEx.Database
 {
@@ -34,21 +33,11 @@ namespace CoreEx.Database
         void MapToDb(object? value, DatabaseParameterCollection parameters, OperationTypes operationType = OperationTypes.Unspecified);
 
         /// <summary>
-        /// Maps the primary key from the <paramref name="value"/> and adds to the <paramref name="parameters"/>.
+        /// Maps the <paramref name="key"/> and adds to the <paramref name="parameters"/>.
         /// </summary>
-        /// <param name="parameters">The <see cref="DatabaseParameterCollection"/>.</param>
-        /// <param name="operationType">The single <see cref="OperationTypes"/> that indicates that a <see cref="OperationTypes.Create"/> is being performed; therefore, any key properties that are auto-generated will have a parameter
-        /// direction of <see cref="ParameterDirection.Output"/> versus <see cref="ParameterDirection.Input"/>.</param>
-        /// <param name="value">The value.</param>
-        void MapPrimaryKeyParameters(DatabaseParameterCollection parameters, OperationTypes operationType, object? value);
-
-        /// <summary>
-        /// Maps the primary key for the listed <paramref name="key"/> and adds to the <paramref name="parameters"/>.
-        /// </summary>
-        /// <param name="parameters">The <see cref="DatabaseParameterCollection"/>.</param>
-        /// <param name="operationType">The single <see cref="OperationTypes"/> that indicates that a <see cref="OperationTypes.Create"/> is being performed; therefore, any key properties that are auto-generated will have a parameter
-        /// direction of <see cref="ParameterDirection.Output"/> versus <see cref="ParameterDirection.Input"/>.</param>
         /// <param name="key">The primary <see cref="CompositeKey"/>.</param>
-        void MapPrimaryKeyParameters(DatabaseParameterCollection parameters, OperationTypes operationType, CompositeKey key);
+        /// <param name="parameters">The <see cref="DatabaseParameterCollection"/>.</param>
+        /// <remarks>This is used to map the only the key parameters; for example a <b>Get</b> or <b>Delete</b> operation.</remarks>
+        void MapKeyToDb(CompositeKey key, DatabaseParameterCollection parameters);
     }
 }

--- a/src/CoreEx.Database/IDatabaseMapperT.cs
+++ b/src/CoreEx.Database/IDatabaseMapperT.cs
@@ -3,7 +3,6 @@
 using CoreEx.Entities;
 using CoreEx.Mapping;
 using System;
-using System.Data;
 
 namespace CoreEx.Database
 {
@@ -39,18 +38,6 @@ namespace CoreEx.Database
         void MapToDb(TSource? value, DatabaseParameterCollection parameters, OperationTypes operationType = OperationTypes.Unspecified);
 
         /// <inheritdoc/>
-        void IDatabaseMapper.MapPrimaryKeyParameters(DatabaseParameterCollection parameters, OperationTypes operationType, object? value) => MapPrimaryKeyParameters(parameters, operationType, (TSource?)value);
-
-        /// <summary>
-        /// Maps the primary key from the <paramref name="value"/> and adds to the <paramref name="parameters"/>.
-        /// </summary>
-        /// <param name="parameters">The <see cref="DatabaseParameterCollection"/>.</param>
-        /// <param name="operationType">The single <see cref="OperationTypes"/> that indicates that a <see cref="OperationTypes.Create"/> is being performed; therefore, any key properties that are auto-generated will have a parameter
-        /// direction of <see cref="ParameterDirection.Output"/> versus <see cref="ParameterDirection.Input"/>.</param>
-        /// <param name="value">The value.</param>
-        void MapPrimaryKeyParameters(DatabaseParameterCollection parameters, OperationTypes operationType, TSource? value) => throw new NotSupportedException();
-
-        /// <inheritdoc/>
-        void IDatabaseMapper.MapPrimaryKeyParameters(DatabaseParameterCollection parameters, OperationTypes operationType, CompositeKey key) => throw new NotSupportedException();
+        void IDatabaseMapper.MapKeyToDb(CompositeKey key, DatabaseParameterCollection parameters) => throw new NotSupportedException();
     }
 }

--- a/src/CoreEx.Database/IDatabaseParametersExtensions.cs
+++ b/src/CoreEx.Database/IDatabaseParametersExtensions.cs
@@ -2,6 +2,7 @@
 
 using CoreEx.Database.Mapping;
 using CoreEx.Entities;
+using CoreEx.Mapping;
 using CoreEx.Mapping.Converters;
 using System;
 using System.Collections.Generic;
@@ -450,5 +451,20 @@ namespace CoreEx.Database
         }
 
         #endregion 
+
+        /// <summary>
+        /// Sets the <see cref="DbParameter.Direction"/> to <see cref="ParameterDirection.Output"/> when the <paramref name="operationType"/> is <see cref="OperationTypes.Create"/>.
+        /// </summary>
+        /// <param name="parameter">The <see cref="DbParameter"/>.</param>
+        /// <param name="operationType">The single <see cref="OperationTypes"/> value being performed to enable conditional execution where appropriate.</param>
+        /// <returns>The <paramref name="parameter"/> to support fluent-style method-chaining.</returns>
+        /// <remarks>Where not <see cref="OperationTypes.Create"/> then the <see cref="DbParameter.Direction"/> will remain unchanged.</remarks>
+        public static DbParameter SetDirectionToOutputOnCreate(this DbParameter parameter, OperationTypes operationType)
+        {
+            if (operationType == OperationTypes.Create)
+                parameter.Direction = ParameterDirection.Output;
+
+            return parameter;
+        }
     }
 }

--- a/src/CoreEx.Database/Mapping/DatabaseMapper.cs
+++ b/src/CoreEx.Database/Mapping/DatabaseMapper.cs
@@ -1,5 +1,9 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Entities;
+using CoreEx.Mapping;
+using System;
+
 namespace CoreEx.Database.Mapping
 {
     /// <summary>
@@ -8,16 +12,25 @@ namespace CoreEx.Database.Mapping
     public static class DatabaseMapper
     {
         /// <summary>
-        /// Creates a <see cref="DatabaseMapper{TSource}"/> where properties are added manually.
+        /// Creates a <see cref="DatabaseMapper{TSource}"/> where properties are added manually (leverages reflection).
         /// </summary>
         /// <returns>A <see cref="DatabaseMapper{TSource}"/>.</returns>
+        /// <remarks>Where performance is critical consider using <see cref="CreateExtended{TSource}"/>.</remarks>
         public static DatabaseMapper<TSource> Create<TSource>() where TSource : class, new() => new(false);
 
         /// <summary>
-        /// Creates a <see cref="DatabaseMapper{TSource}"/> where properties are added automatically (assumes the property, column and parameter names share the same name).
+        /// Creates a <see cref="DatabaseMapper{TSource}"/> where properties are added automatically using reflection (assumes the property, column and parameter names share the same name).
         /// </summary>
         /// <param name="ignoreSrceProperties">An array of source property names to ignore.</param>
         /// <returns>A <see cref="DatabaseMapper{TSource}"/>.</returns>
+        /// <remarks>Where performance is critical consider using <see cref="CreateExtended{TSource}"/>.</remarks>
         public static DatabaseMapper<TSource> CreateAuto<TSource>(params string[] ignoreSrceProperties) where TSource : class, new() => new(true, ignoreSrceProperties);
+
+        /// <summary>
+        /// Creates a <see cref="DatabaseMapperEx{TSource}"/> where the underlying implementation is added explicitly (extended, offers potential performance benefits).
+        /// </summary>
+        /// <returns>A <see cref="DatabaseMapperEx{TSource}"/>.</returns>
+        public static DatabaseMapperEx<TSource> CreateExtended<TSource>(Action<DatabaseRecord, TSource, OperationTypes>? mapFromDb = null, Action<CompositeKey, DatabaseParameterCollection>? mapKeyToDb = null, Action<TSource?, DatabaseParameterCollection, OperationTypes>? mapToDb = null) where TSource : class, new()
+            => new(mapFromDb, mapKeyToDb, mapToDb);
     }
 }

--- a/src/CoreEx.Database/Mapping/DatabaseMapperExT.cs
+++ b/src/CoreEx.Database/Mapping/DatabaseMapperExT.cs
@@ -1,0 +1,175 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Entities;
+using CoreEx.Mapping;
+using System;
+
+namespace CoreEx.Database.Mapping
+{
+    /// <summary>
+    /// Provides mapping from a <typeparamref name="TSource"/> <see cref="Type"/> and database with the extended/explicitly provided logic.
+    /// </summary>
+    /// <typeparam name="TSource">The source <see cref="Type"/>.</typeparam>
+    /// <param name="mapFromDb">The <see cref="MapFromDb(DatabaseRecord, OperationTypes)"/> implementation.</param>
+    /// <param name="mapKeyToDb">The <see cref="IDatabaseMapper.MapKeyToDb(CompositeKey, DatabaseParameterCollection)"/> implementation.</param>
+    /// <param name="mapToDb">The <see cref="MapToDb(TSource?, DatabaseParameterCollection, OperationTypes)"/> implementation.</param>
+    /// <remarks>This enables the most optimized performance by enabling explicit code to be specified.</remarks>
+    public class DatabaseMapperEx<TSource>(Action<DatabaseRecord, TSource, OperationTypes>? mapFromDb = null, Action<CompositeKey, DatabaseParameterCollection>? mapKeyToDb = null, Action<TSource?, DatabaseParameterCollection, OperationTypes>? mapToDb = null) : IDatabaseMapperEx<TSource> where TSource : class, new()
+    {
+        private readonly Action<DatabaseRecord, TSource, OperationTypes>? _mapFromDb = mapFromDb;
+        private readonly Action<TSource?, DatabaseParameterCollection, OperationTypes>? _mapToDb = mapToDb;
+        private readonly Action<CompositeKey, DatabaseParameterCollection>? _mapKeyToDb = mapKeyToDb;
+        private IDatabaseMapperEx? _extendMapper;
+
+        /// <summary>
+        /// Indicates that a <c>null</c> should be returned from <see cref="MapFromDb(DatabaseRecord, OperationTypes)"/> where the resulting value <see cref="IInitial.IsInitial"/>.
+        /// </summary>
+        /// <remarks>Defaults to <c>true</c>.</remarks>
+        public bool NullWhenInitial { get; set; } = true;
+
+        /// <summary>
+        /// Inherits (includes) the mappings from the selected <paramref name="baseMapper"/>.
+        /// </summary>
+        /// <typeparam name="TBase">The <paramref name="baseMapper"/> source <see cref="Type"/>; <typeparamref name="TSource"/> must inherit from <typeparamref name="TBase"/>.</typeparam>
+        /// <param name="baseMapper">The <see cref="IDatabaseMapperEx{TSource}"/> to inherit from.</param>
+        /// <returns>The <see cref="DatabaseMapperEx{TSource}"/> to support fluent-style method-chaining.</returns>
+        public DatabaseMapperEx<TSource> InheritMapper<TBase>(IDatabaseMapperEx<TBase> baseMapper) where TBase : class, new()
+        {
+            if (_extendMapper is not null)
+                throw new InvalidOperationException($"An {nameof(InheritMapper)} may only be invoked once for a mapper.");
+
+            if (!typeof(TSource).IsSubclassOf(typeof(TBase)))
+                throw new ArgumentException($"Type {typeof(TSource).Name} must inherit from {typeof(TBase).Name}.", nameof(baseMapper));
+
+            _extendMapper = baseMapper.ThrowIfNull(nameof(baseMapper));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public void MapFromDb(DatabaseRecord record, TSource value, OperationTypes operationType)
+        {
+            record.ThrowIfNull(nameof(record));
+            value.ThrowIfNull(nameof(value));
+
+            _extendMapper?.MapFromDb(record, value, operationType);
+            _mapFromDb?.Invoke(record, value, operationType);
+            OnMapFromDb(record, value, operationType);
+        }
+
+        /// <inheritdoc/>
+        public TSource? MapFromDb(DatabaseRecord record, OperationTypes operationType = OperationTypes.Unspecified)
+        {
+            var value = new TSource();
+            MapFromDb(record, value, operationType);
+            return NullWhenInitial ? ((value is not null && value is IInitial ii && ii.IsInitial) ? null : value) : null;
+        }
+
+        /// <summary>
+        /// Extension opportunity when performing a <see cref="MapFromDb(DatabaseRecord, OperationTypes)"/>.
+        /// </summary>
+        /// <param name="value">The source value.</param>
+        /// <param name="record">The <see cref="DatabaseRecord"/>.</param>
+        /// <param name="operationType">The single <see cref="OperationTypes"/> value being performed to enable conditional execution where appropriate.</param>
+        /// <returns>The source value.</returns>
+        protected virtual void OnMapFromDb(DatabaseRecord record, TSource value, OperationTypes operationType) { }
+
+        /// <inheritdoc/>
+        public void MapToDb(TSource? value, DatabaseParameterCollection parameters, OperationTypes operationType = OperationTypes.Unspecified)
+        {
+            parameters.ThrowIfNull(nameof(parameters));
+            if (value is not null)
+            {
+                _extendMapper?.MapToDb(value, parameters, operationType);
+                _mapToDb?.Invoke(value, parameters, operationType);
+                OnMapToDb(value, parameters, operationType);
+            }
+        }
+
+        /// <summary>
+        /// Extension opportunity when performing a <see cref="MapToDb(TSource, DatabaseParameterCollection, OperationTypes)"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="parameters">The <see cref="DatabaseParameterCollection"/> to update from the <paramref name="value"/>.</param>
+        /// <param name="operationType">The single <see cref="OperationTypes"/> value being performed to enable conditional execution where appropriate.</param>
+        protected virtual void OnMapToDb(TSource value, DatabaseParameterCollection parameters, OperationTypes operationType) { }
+
+        /// <inheritdoc/>
+        void IDatabaseMapper.MapKeyToDb(CompositeKey key, DatabaseParameterCollection parameters)
+        {
+            parameters.ThrowIfNull(nameof(parameters));
+            _extendMapper?.MapKeyToDb(key, parameters);
+            _mapKeyToDb?.Invoke(key, parameters);
+            OnMapKeyToDb(key, parameters);
+        }
+
+        /// <summary>
+        /// Extension opportunity when performing a <see cref="IDatabaseMapper.MapKeyToDb"/>.
+        /// </summary>
+        /// <param name="key">The primary <see cref="CompositeKey"/>.</param>
+        /// <param name="parameters">The <see cref="DatabaseParameterCollection"/>.</param>
+        /// <remarks>This is used to map the only the key parameters; for example a <b>Get</b> or <b>Delete</b> operation.</remarks>
+        protected virtual void OnMapKeyToDb(CompositeKey key, DatabaseParameterCollection parameters) { }
+
+        #region When*
+
+        /// <summary>
+        /// When <paramref name="operationType"/> is a <see cref="OperationTypes.Get"/> then the action is invoked.
+        /// </summary>
+        /// <param name="operationType">The singular <see cref="OperationTypes"/>.</param>
+        /// <param name="action">The action to invoke.</param>
+        public static void WhenGet(OperationTypes operationType, Action action) => WhenOperationType(OperationTypes.Get, operationType, action);
+
+        /// <summary>
+        /// When <paramref name="operationType"/> is a <see cref="OperationTypes.Create"/> then the action is invoked.
+        /// </summary>
+        /// <param name="operationType">The singular <see cref="OperationTypes"/>.</param>
+        /// <param name="action">The action to invoke.</param>
+        public static void WhenCreate(OperationTypes operationType, Action action) => WhenOperationType(OperationTypes.Create, operationType, action);
+
+        /// <summary>
+        /// When <paramref name="operationType"/> is an <see cref="OperationTypes.Update"/> then the action is invoked.
+        /// </summary>
+        /// <param name="operationType">The singular <see cref="OperationTypes"/>.</param>
+        /// <param name="action">The action to invoke.</param>
+        public static void WhenUpdate(OperationTypes operationType, Action action) => WhenOperationType(OperationTypes.Update, operationType, action);
+
+        /// <summary>
+        /// When <paramref name="operationType"/> is a <see cref="OperationTypes.Delete"/> then the action is invoked.
+        /// </summary>
+        /// <param name="operationType">The singular <see cref="OperationTypes"/>.</param>
+        /// <param name="action">The action to invoke.</param>
+        public static void WhenDelete(OperationTypes operationType, Action action) => WhenOperationType(OperationTypes.Delete, operationType, action);
+
+        /// <summary>
+        /// When <paramref name="operationType"/> is a <see cref="OperationTypes.AnyExceptGet"/> then the action is invoked.
+        /// </summary>
+        /// <param name="operationType">The singular <see cref="OperationTypes"/>.</param>
+        /// <param name="action">The action to invoke.</param>
+        public static void WhenAnyExceptGet(OperationTypes operationType, Action action) => WhenOperationType(OperationTypes.AnyExceptGet, operationType, action);
+
+        /// <summary>
+        /// When <paramref name="operationType"/> is a <see cref="OperationTypes.AnyExceptCreate"/> then the action is invoked.
+        /// </summary>
+        /// <param name="operationType">The singular <see cref="OperationTypes"/>.</param>
+        /// <param name="action">The action to invoke.</param>
+        public static void WhenAnyExceptCreate(OperationTypes operationType, Action action) => WhenOperationType(OperationTypes.AnyExceptCreate, operationType, action);
+
+        /// <summary>
+        /// When <paramref name="operationType"/> is a <see cref="OperationTypes.AnyExceptUpdate"/> then the action is invoked.
+        /// </summary>
+        /// <param name="operationType">The singular <see cref="OperationTypes"/>.</param>
+        /// <param name="action">The action to invoke.</param>
+        public static void WhenAnyExceptUpdate(OperationTypes operationType, Action action) => WhenOperationType(OperationTypes.AnyExceptUpdate, operationType, action);
+
+        /// <summary>
+        /// When the <paramref name="operationType"/> matches the <paramref name="expectedOperationTypes"/> then the <paramref name="action"/> is invoked.
+        /// </summary>
+        private static void WhenOperationType(OperationTypes expectedOperationTypes, OperationTypes operationType, Action action)
+        {
+            if (expectedOperationTypes.HasFlag(operationType))
+                action?.Invoke();
+        }
+
+        #endregion
+    }
+}

--- a/src/CoreEx.Database/Mapping/DatabaseMapperExT2.cs
+++ b/src/CoreEx.Database/Mapping/DatabaseMapperExT2.cs
@@ -5,12 +5,11 @@ using System;
 namespace CoreEx.Database.Mapping
 {
     /// <summary>
-    /// Provides <see cref="DatabaseMapper{TSource}"/> with a singleton <see cref="Default"/>.
+    /// Provides <see cref="DatabaseMapperEx{TSource}"/> with a singleton <see cref="Default"/>.
     /// </summary>
     /// <typeparam name="TSource">The source <see cref="Type"/>.</typeparam>
     /// <typeparam name="TMapper">The mapper <see cref="Type"/>.</typeparam>
-    /// <remarks>Where performance is critical consider using <see cref="DatabaseMapperEx{TSource, TMapper}"/>.</remarks>
-    public abstract class DatabaseMapper<TSource, TMapper> : DatabaseMapper<TSource> where TSource : class, new() where TMapper : DatabaseMapper<TSource, TMapper>, new()
+    public abstract class DatabaseMapperEx<TSource, TMapper> : DatabaseMapperEx<TSource> where TSource : class, new() where TMapper : DatabaseMapperEx<TSource, TMapper>, new()
     {
         private static readonly TMapper _default = new();
 

--- a/src/CoreEx.Database/Mapping/IDatabaseMapperEx.cs
+++ b/src/CoreEx.Database/Mapping/IDatabaseMapperEx.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Mapping;
+
+namespace CoreEx.Database.Mapping
+{
+    /// <summary>
+    /// Defines a database extended/explicit mapper.
+    /// </summary>
+    public interface IDatabaseMapperEx : IDatabaseMapper
+    {
+        /// <summary>
+        /// Maps from a <paramref name="record"/> into the <paramref name="value"/>
+        /// </summary>
+        /// <param name="record">The <see cref="DatabaseRecord"/>.</param>
+        /// <param name="value">The value to map into.</param>
+        /// <param name="operationType">The single <see cref="OperationTypes"/> value being performed to enable conditional execution where appropriate.</param>
+        void MapFromDb(DatabaseRecord record, object value, OperationTypes operationType = OperationTypes.Unspecified);
+    }
+}

--- a/src/CoreEx.Database/Mapping/IDatabaseMapperExT.cs
+++ b/src/CoreEx.Database/Mapping/IDatabaseMapperExT.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Mapping;
+
+namespace CoreEx.Database.Mapping
+{
+    /// <summary>
+    /// Defines a database extended/explicit mapper.
+    /// </summary>
+    /// <typeparam name="TSource">The <see cref="IDatabaseMapper.SourceType"/>.</typeparam>
+    public interface IDatabaseMapperEx<TSource> : IDatabaseMapperEx, IDatabaseMapper<TSource>
+    {
+        /// <inheritdoc/>
+        void IDatabaseMapperEx.MapFromDb(DatabaseRecord record, object value, OperationTypes operationType)
+            => MapFromDb(record, (TSource)value, operationType);
+
+        /// <summary>
+        /// Maps from a <paramref name="record"/> into the <paramref name="value"/>
+        /// </summary>
+        /// <param name="record">The <see cref="DatabaseRecord"/>.</param>
+        /// <param name="value">The value to extend map into.</param>
+        /// <param name="operationType">The single <see cref="OperationTypes"/> value being performed to enable conditional execution where appropriate.</param>
+        /// <returns>The updated <paramref name="value"/>.</returns>
+        void MapFromDb(DatabaseRecord record, TSource value, OperationTypes operationType = OperationTypes.Unspecified);
+    }
+}

--- a/src/CoreEx.Database/Mapping/PropertyColumnMapper.cs
+++ b/src/CoreEx.Database/Mapping/PropertyColumnMapper.cs
@@ -207,7 +207,7 @@ namespace CoreEx.Database.Mapping
             if (!OperationTypes.HasFlag(operationType))
                 return;
 
-            TSourceProperty? pval = default;
+            TSourceProperty? pval;
             if (Mapper != null)
                 pval = (TSourceProperty?)Mapper.MapFromDb(record, operationType);
             else
@@ -219,6 +219,8 @@ namespace CoreEx.Database.Mapping
                     else
                         pval = (TSourceProperty)Converter.ConvertToSource(record.DataReader.GetValue(ordinal))!;
                 }
+                else
+                    pval = default;
             }
 
             _propertyExpression.SetValue(value, pval);

--- a/src/CoreEx.Validation/ValidationExtensions.cs
+++ b/src/CoreEx.Validation/ValidationExtensions.cs
@@ -238,7 +238,7 @@ namespace CoreEx.Validation
             => rule.ThrowIfNull(nameof(rule)).AddRule(new ExistsRule<TEntity, TProperty>(exists) { ErrorText = errorText });
 
         /// <summary>
-        /// Adds a validation where the rule <paramref name="exists"/> value is <c>true</c> to verify it exists (see <see cref="ExistsRule{TEntity, TProperty}"/>).
+        /// Adds a validation where the rule <paramref name="exists"/> resultant value is <c>true</c> to verify it exists (see <see cref="ExistsRule{TEntity, TProperty}"/>).
         /// </summary>
         /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
         /// <typeparam name="TProperty">The property <see cref="Type"/>.</typeparam>
@@ -257,20 +257,22 @@ namespace CoreEx.Validation
         /// <param name="rule">The <see cref="IPropertyRule{TEntity, TProperty}"/> being extended.</param>
         /// <param name="exists">The exists function.</param>
         /// <param name="errorText">The error message format text <see cref="LText"/> (overrides the default).</param>
+        /// <remarks>Where the resultant value is an <see cref="IResult"/> then existence is confirmed when <see cref="IResult.IsSuccess"/> and the the underlying <see cref="IResult.Value"/> is not null.</remarks>
         /// <returns>A <see cref="IPropertyRule{TEntity, TProperty}"/>.</returns>
-        public static IPropertyRule<TEntity, TProperty> ExistsAsync<TEntity, TProperty>(this IPropertyRule<TEntity, TProperty> rule, Func<TEntity, CancellationToken, Task<object?>> exists, LText? errorText = null) where TEntity : class
+        public static IPropertyRule<TEntity, TProperty> ValueExistsAsync<TEntity, TProperty>(this IPropertyRule<TEntity, TProperty> rule, Func<TEntity, CancellationToken, Task<object?>> exists, LText? errorText = null) where TEntity : class
             => rule.ThrowIfNull(nameof(rule)).AddRule(new ExistsRule<TEntity, TProperty>(exists) { ErrorText = errorText });
 
         /// <summary>
-        /// Adds a validation where the rule <paramref name="exists"/> is <b>not null</b> to verify it exists (see <see cref="ExistsRule{TEntity, TProperty}"/>).
+        /// Adds a validation where the rule <paramref name="exists"/> resultant value is <b>not null</b> to verify it exists (see <see cref="ExistsRule{TEntity, TProperty}"/>).
         /// </summary>
         /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
         /// <typeparam name="TProperty">The property <see cref="Type"/>.</typeparam>
         /// <param name="rule">The <see cref="IPropertyRule{TEntity, TProperty}"/> being extended.</param>
         /// <param name="exists">The exists function.</param>
         /// <param name="errorText">The error message format text <see cref="LText"/> (overrides the default).</param>
+        /// <remarks>Where the resultant value is an <see cref="IResult"/> then existence is confirmed when <see cref="IResult.IsSuccess"/> and the the underlying <see cref="IResult.Value"/> is not null.</remarks>
         /// <returns>A <see cref="IPropertyRule{TEntity, TProperty}"/>.</returns>
-        public static IPropertyRule<TEntity, TProperty> Exists<TEntity, TProperty>(this IPropertyRule<TEntity, TProperty> rule, object? exists, LText? errorText = null) where TEntity : class
+        public static IPropertyRule<TEntity, TProperty> ValueExists<TEntity, TProperty>(this IPropertyRule<TEntity, TProperty> rule, object? exists, LText? errorText = null) where TEntity : class
             => rule.ThrowIfNull(nameof(rule)).AddRule(new ExistsRule<TEntity, TProperty>((_, __) => Task.FromResult(exists != null)) { ErrorText = errorText });
 
         /// <summary>

--- a/src/CoreEx.Validation/ValidatorT.cs
+++ b/src/CoreEx.Validation/ValidatorT.cs
@@ -5,7 +5,6 @@ using CoreEx.Entities;
 using CoreEx.Localization;
 using CoreEx.Results;
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;

--- a/src/CoreEx/Abstractions/ETagGenerator.cs
+++ b/src/CoreEx/Abstractions/ETagGenerator.cs
@@ -90,10 +90,22 @@ namespace CoreEx.Abstractions
         }
 
         /// <summary>
-        /// Parses an <see cref="IETag.ETag"/> by removing double quotes character bookends; for example '<c>"abc"</c>' would be formatted as '<c>abc</c>'.
+        /// Parses an <see cref="IETag.ETag"/> by removing any weak prefix ('<c>W/</c>') double quotes character bookends; for example '<c>"abc"</c>' would be formatted as '<c>abc</c>'.
         /// </summary>
         /// <param name="etag">The <see cref="IETag.ETag"/> to unformat.</param>
         /// <returns>The unformatted value.</returns>
-        public static string? ParseETag(string? etag) => etag is not null && etag.Length > 1 && etag.StartsWith("\"", StringComparison.InvariantCultureIgnoreCase) && etag.EndsWith("\"", StringComparison.InvariantCultureIgnoreCase) ? etag[1..^1] : etag;
+        public static string? ParseETag(string? etag)
+        {
+            if (string.IsNullOrEmpty(etag))
+                return null;
+
+            if (etag.StartsWith('\"') && etag.EndsWith('\"'))
+                return etag[1..^1];
+
+            if (etag.StartsWith("W/\"") && etag.EndsWith('\"'))
+                return etag[2..^1];
+
+            return etag;
+        }
     }
 }

--- a/src/CoreEx/Abstractions/ETagGenerator.cs
+++ b/src/CoreEx/Abstractions/ETagGenerator.cs
@@ -3,8 +3,7 @@
 using CoreEx.Entities;
 using CoreEx.Json;
 using System;
-using System.Globalization;
-using System.Text;
+using System.Security.Cryptography;
 
 namespace CoreEx.Abstractions
 {
@@ -14,80 +13,61 @@ namespace CoreEx.Abstractions
     public static class ETagGenerator
     {
         /// <summary>
-        /// Represents the divider character where ETag value is made up of multiple parts.
-        /// </summary>
-        public const char DividerCharacter = '|';
-
-        /// <summary>
-        /// Generates an ETag for a value by serializing to JSON and performing an <see cref="System.Security.Cryptography.SHA256"/> hash.
+        /// Generates an ETag for a value by serializing to JSON and performing an <see cref="SHA256"/> hash.
         /// </summary>
         /// <typeparam name="T">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
         /// <param name="value">The value.</param>
-        /// <param name="parts">Optional extra part(s) to append to the JSON to include in the underlying hash computation.</param>
         /// <returns>The generated ETag.</returns>
-        public static string? Generate<T>(IJsonSerializer jsonSerializer, T? value, params string[] parts) where T : class
+        public static string? Generate<T>(IJsonSerializer jsonSerializer, T? value)
         {
             jsonSerializer.ThrowIfNull(nameof(jsonSerializer));
-
             if (value == null)
                 return null;
 
-            // Where value is IFormattable/IComparable use ToString; otherwise, JSON serialize.
-            var txt = ConvertToString(jsonSerializer, value);
-
-            if (parts.Length > 0)
-            {
-                var sb = new StringBuilder(txt);
-                foreach (var ex in parts)
-                {
-                    sb.Append(DividerCharacter);
-                    sb.Append(ex);
-                }
-
-                txt = sb.ToString();
-            }
-
-            return GenerateHash(txt);
-        }
-
-        /// <summary>
-        /// Generates a hash of the string using <see cref="System.Security.Cryptography.SHA256"/>.
-        /// </summary>
-        /// <param name="text">The text value to hash.</param>
-        /// <returns>The hashed value.</returns>
-        public static string GenerateHash(string text)
-        {
-            var buf = Encoding.UTF8.GetBytes(text.ThrowIfNull(nameof(text)));
+            // Serialize to JSON and then hash.
+            byte[] hash;
+            var bd = jsonSerializer.SerializeToBinaryData(value);
 #if NETSTANDARD2_1
-            using var sha256 = System.Security.Cryptography.SHA256.Create();
-            var hash = new BinaryData(sha256.ComputeHash(buf));
+            using var sha256 = SHA256.Create();
+            hash = sha256.ComputeHash(bd.ToArray());
 #else
-            var hash = System.Security.Cryptography.SHA256.HashData(buf);
+            hash = SHA256.HashData(bd);
 #endif
             return Convert.ToBase64String(hash);
         }
 
         /// <summary>
-        /// Converts the <paramref name="value"/> to a corresponding <see cref="string"/>.
+        /// Generates a hash of the parts using <see cref="SHA256"/>.
         /// </summary>
-        /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
-        /// <param name="value">The value to convert.</param>
-        /// <returns>A <see cref="string"/> representation of the value.</returns>
-        private static string ConvertToString(IJsonSerializer jsonSerializer, object? value)
+        /// <param name="parts">The parts to hash.</param>
+        /// <returns>The hashed value.</returns>
+        public static string? GenerateHash(params string[] parts)
         {
-            if (value == null)
-                return string.Empty;
+            if (parts == null || parts.Length == 0)
+                return null;
 
-            if (value is string str)
-                return str;
+            byte[] hash;
+#if NETSTANDARD2_1
+            var input = parts.Length == 1 ? parts[0] : string.Concat(parts);
+            using var sha256 = SHA256.Create();
+            hash = sha256.ComputeHash(new BinaryData(input).ToArray());
+#else
+            if (parts.Length == 1)
+                hash = SHA256.HashData(new BinaryData(parts[0]));
+            else
+            {
+                using var ih = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+                foreach (var part in parts)
+                {
+                    ih.AppendData(new BinaryData(part));
+                }
 
-            if (value is DateTime dte)
-                return dte.ToString("o");
+                hash = ih.GetCurrentHash();
+            }
 
-            return (value is IFormattable ic)
-                ? ic.ToString(null, CultureInfo.InvariantCulture)
-                : ((value is IComparable) ? value.ToString() : jsonSerializer.Serialize(value)) ?? string.Empty;
+#endif
+            return Convert.ToBase64String(hash);
         }
 
         /// <summary>
@@ -95,7 +75,19 @@ namespace CoreEx.Abstractions
         /// </summary>
         /// <param name="value">The value to format.</param>
         /// <returns>The formatted <see cref="IETag.ETag"/>.</returns>
-        public static string? FormatETag(string? value) => value == null || (value.Length > 1 && value.StartsWith("\"", StringComparison.InvariantCultureIgnoreCase) && value.EndsWith("\"", StringComparison.InvariantCultureIgnoreCase)) ? value : "\"" + value + "\"";
+        public static string? FormatETag(string? value)
+        { 
+            if (value is null)
+                return null;
+
+            if (value.StartsWith('\"') && value.EndsWith('\"'))
+                return value;
+
+            if (value.StartsWith("W/\"") && value.EndsWith('\"'))
+                return value[2..];
+            
+            return $"\"{value}\"";
+        }
 
         /// <summary>
         /// Parses an <see cref="IETag.ETag"/> by removing double quotes character bookends; for example '<c>"abc"</c>' would be formatted as '<c>abc</c>'.

--- a/src/CoreEx/Abstractions/IServiceCollectionExtensions.cs
+++ b/src/CoreEx/Abstractions/IServiceCollectionExtensions.cs
@@ -321,6 +321,27 @@ namespace Microsoft.Extensions.DependencyInjection
             => AddMappers(services, [typeof(TAssembly).Assembly]);
 
         /// <summary>
+        /// Registers all the <see cref="IMapper{TSource, TDestination}"/>(s) from the specified <typeparamref name="TAssembly1"/> and <typeparamref name="TAssembly2"/> into a new <see cref="Mapper"/> that is then registered as a singleton service.
+        /// </summary>
+        /// <typeparam name="TAssembly1">The <see cref="Type"/> to infer the underlying <see cref="Type.Assembly"/>.</typeparam>
+        /// <typeparam name="TAssembly2">The <see cref="Type"/> to infer the underlying <see cref="Type.Assembly"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/> for fluent-style method-chaining.</returns>
+        public static IServiceCollection AddMappers<TAssembly1, TAssembly2>(this IServiceCollection services)
+            => AddMappers(services, [typeof(TAssembly1).Assembly, typeof(TAssembly2).Assembly]);
+
+        /// <summary>
+        /// Registers all the <see cref="IMapper{TSource, TDestination}"/>(s) from the specified <typeparamref name="TAssembly1"/>, <typeparamref name="TAssembly2"/> and <typeparamref name="TAssembly3"/> into a new <see cref="Mapper"/> that is then registered as a singleton service.
+        /// </summary>
+        /// <typeparam name="TAssembly1">The <see cref="Type"/> to infer the underlying <see cref="Type.Assembly"/>.</typeparam>
+        /// <typeparam name="TAssembly2">The <see cref="Type"/> to infer the underlying <see cref="Type.Assembly"/>.</typeparam>
+        /// <typeparam name="TAssembly3">The <see cref="Type"/> to infer the underlying <see cref="Type.Assembly"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/> for fluent-style method-chaining.</returns>
+        public static IServiceCollection AddMappers<TAssembly1, TAssembly2, TAssembly3>(this IServiceCollection services)
+            => AddMappers(services, [typeof(TAssembly1).Assembly, typeof(TAssembly2).Assembly, typeof(TAssembly3).Assembly]);
+
+        /// <summary>
         /// Registers all the <see cref="IMapper{TSource, TDestination}"/>(s) from the specified <paramref name="assemblies"/> into a new <see cref="Mapper"/> that is then registered as a singleton service.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>

--- a/src/CoreEx/Abstractions/ObjectExtensions.cs
+++ b/src/CoreEx/Abstractions/ObjectExtensions.cs
@@ -12,6 +12,7 @@ namespace CoreEx
     /// <summary>
     /// Provides standard <see cref="object"/> extensions.
     /// </summary>
+    [System.Diagnostics.DebuggerStepThrough]
     public static class ObjectExtensions
     {
         /// <summary>

--- a/src/CoreEx/Abstractions/Reflection/IReflectionCache.cs
+++ b/src/CoreEx/Abstractions/Reflection/IReflectionCache.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using Microsoft.Extensions.Caching.Memory;
+
+namespace CoreEx.Abstractions.Reflection
+{
+    /// <summary>
+    /// Represents a cache for reflection operations.
+    /// </summary>
+    public interface IReflectionCache : IMemoryCache { }
+}

--- a/src/CoreEx/Abstractions/Reflection/ITypeReflector.cs
+++ b/src/CoreEx/Abstractions/Reflection/ITypeReflector.cs
@@ -45,8 +45,7 @@ namespace CoreEx.Abstractions.Reflection
         /// <summary>
         /// Gets all the properties for the <see cref="Type"/>.
         /// </summary>
-        /// <returns>A read-only <see cref="IPropertyReflector"/> collection.</returns>
-        IReadOnlyCollection<IPropertyReflector> GetProperties();
+        IEnumerable<IPropertyReflector> GetProperties();
 
         /// <summary>
         /// Gets the <see cref="IPropertyReflector"/> for the specified property name where it exists.

--- a/src/CoreEx/Abstractions/Reflection/PropertyExpression.cs
+++ b/src/CoreEx/Abstractions/Reflection/PropertyExpression.cs
@@ -17,7 +17,7 @@ namespace CoreEx.Abstractions.Reflection
         /// <summary>
         /// Gets the <see cref="IMemoryCache"/>.
         /// </summary>
-        internal static IMemoryCache Cache => ExecutionContext.GetService<IMemoryCache>() ?? (_fallbackCache ??= new MemoryCache(new MemoryCacheOptions()));
+        internal static IMemoryCache Cache => ExecutionContext.GetService<IReflectionCache>() ?? (_fallbackCache ??= new MemoryCache(new MemoryCacheOptions()));
 
         /// <summary>
         /// Validates, creates and compiles the property expression; whilst also determinig the property friendly <see cref="PropertyExpression{TEntity, TProperty}.Text"/>.

--- a/src/CoreEx/Abstractions/Reflection/PropertyExpressionT.cs
+++ b/src/CoreEx/Abstractions/Reflection/PropertyExpressionT.cs
@@ -43,7 +43,7 @@ namespace CoreEx.Abstractions.Reflection
         /// <returns>A <see cref="PropertyExpression{TEntity, TProperty}"/> which contains (in order) the compiled <see cref="System.Func{TEntity, TProperty}"/>, member name and resulting property text.</returns>
         internal static PropertyExpression<TEntity, TProperty> CreateInternal(Expression<Func<TEntity, TProperty>> propertyExpression, IJsonSerializer jsonSerializer)
         {
-            if ((propertyExpression.ThrowIfNull(nameof(propertyExpression))).Body.NodeType != ExpressionType.MemberAccess)
+            if (propertyExpression.ThrowIfNull(nameof(propertyExpression)).Body.NodeType != ExpressionType.MemberAccess)
                 throw new InvalidOperationException("Only Member access expressions are supported.");
 
             var cache = PropertyExpression.Cache;

--- a/src/CoreEx/Abstractions/Reflection/TypeReflectorArgs.cs
+++ b/src/CoreEx/Abstractions/Reflection/TypeReflectorArgs.cs
@@ -12,8 +12,8 @@ namespace CoreEx.Abstractions.Reflection
     /// Provides the arguments passed to and through a <see cref="TypeReflector"/>.
     /// </summary>
     /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>. Defaults to <see cref="Json.JsonSerializer.Default"/>.</param>
-    /// <param name="cache">The <see cref="IMemoryCache"/> to use versus instantiating each <see cref="TypeReflector"/> per use (expensive operation).</param>
-    public class TypeReflectorArgs(IJsonSerializer? jsonSerializer = null, IMemoryCache? cache = null)
+    /// <param name="cache">The <see cref="IReflectionCache"/> to use versus instantiating each <see cref="TypeReflector"/> per use (expensive operation).</param>
+    public class TypeReflectorArgs(IJsonSerializer? jsonSerializer = null, IReflectionCache? cache = null)
     {
         private static readonly Lazy<TypeReflectorArgs> _default = new(() => new TypeReflectorArgs());
 
@@ -31,7 +31,7 @@ namespace CoreEx.Abstractions.Reflection
         /// Gets the <see cref="IMemoryCache"/> to use versus instantiating each <see cref="TypeReflector"/> per use.
         /// </summary>
         /// <remarks>The <see cref="AbsoluteExpirationTimespan"/> and <see cref="SlidingExpirationTimespan"/> enable additional basic policy configuration for the cached items.</remarks>
-        public IMemoryCache Cache { get; } = cache ?? new MemoryCache(new MemoryCacheOptions());
+        public IMemoryCache Cache { get; } = (MemoryCache?)cache ?? new MemoryCache(new MemoryCacheOptions());
 
         /// <summary>
         /// Gets or sets the <see cref="IMemoryCache"/> absolute expiration <see cref="TimeSpan"/>. Default to <c>24</c> hours.

--- a/src/CoreEx/Abstractions/Reflection/TypeReflectorT.cs
+++ b/src/CoreEx/Abstractions/Reflection/TypeReflectorT.cs
@@ -125,7 +125,7 @@ namespace CoreEx.Abstractions.Reflection
         /// <summary>
         /// Gets all the properties.
         /// </summary>
-        public IReadOnlyCollection<IPropertyReflector> GetProperties() => new ReadOnlyCollection<IPropertyReflector>(_properties.Values.OfType<IPropertyReflector>().ToList());
+        public IEnumerable<IPropertyReflector> GetProperties() => _properties.Values;
 
         /// <inheritdoc/>
         public ITypeReflector? GetItemTypeReflector() => _itemReflector ??= TypeReflector.GetReflector(Args, ItemType!);

--- a/src/CoreEx/Configuration/SettingsBase.cs
+++ b/src/CoreEx/Configuration/SettingsBase.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Threading;
 using CoreEx.Hosting.Work;
 using CoreEx.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
 
 namespace CoreEx.Configuration
 {
@@ -19,9 +16,7 @@ namespace CoreEx.Configuration
     /// </summary>
     public abstract class SettingsBase
     {
-        private readonly ThreadLocal<bool> _isReflectionCall = new();
         private readonly List<string> _prefixes = [];
-        private readonly Dictionary<string, PropertyInfo> _allProperties;
         private bool? _validationUseJsonNames;
 
         /// <summary>
@@ -34,15 +29,13 @@ namespace CoreEx.Configuration
             Configuration = configuration;
             Deployment = new DeploymentInfo(configuration);
 
-            foreach (var prefix in prefixes.ThrowIfNull(nameof(prefixes)))
+            foreach (var prefix in prefixes)
             {
                 if (string.IsNullOrEmpty(prefix))
-                    throw new ArgumentException("Prefixes cannot be null or empty.", nameof(prefixes));
+                    throw new ArgumentException("A prefix cannot be null or empty.", nameof(prefixes));
 
                 _prefixes.Add(prefix.EndsWith('/') ? prefix : string.Concat(prefix, '/'));
             }
-
-            _allProperties = GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy).ToDictionary(p => p.Name, p => p);
         }
 
         /// <summary>
@@ -61,33 +54,22 @@ namespace CoreEx.Configuration
         /// '<c>Product/Foo</c>', '<c>Common/Foo</c>', '<c>Foo</c>' (no prefix), then finally the <paramref name="defaultValue"/> will be returned.</remarks>
         public T GetValue<T>([CallerMemberName] string key = "", T defaultValue = default!)
         {
-            key.ThrowIfNullOrEmpty(nameof(key));
+            // One-off replace double underscore with colon; enables support for both types.
+            var ckey = key.ThrowIfNullOrEmpty(nameof(key)).Replace("__", ":");
 
-            if (Configuration == null)
+            if (Configuration is null)
                 return defaultValue;
 
-            // Do not allow recursive calls to go too deep
-            if (_allProperties.TryGetValue(key, out PropertyInfo? pi) && !_isReflectionCall.Value)
-            {
-                try
-                {
-                    _isReflectionCall.Value = true;
-                    return pi.GetValue(this) is T value ? value : defaultValue;
-                }
-                finally
-                {
-                    _isReflectionCall.Value = false;
-                }
-            }
-
+            // Try each prefix until found.
             T kv;
             foreach (var prefix in _prefixes)
             {
-                if (TryGetValue(string.Concat(prefix, key), out kv))
+                if (TryGetValue(string.Concat(prefix, ckey), out kv))
                     return kv;
             }
 
-            return TryGetValue(key, out kv) ? kv : defaultValue;
+            // Final without prefix.
+            return TryGetValue(ckey, out kv) ? kv : defaultValue;
         }
 
         /// <summary>
@@ -99,22 +81,6 @@ namespace CoreEx.Configuration
             if (Configuration!.GetSection(key)?.Value != null)
             {
                 value = Configuration.GetValue<T>(key)!;
-                return true;
-            }
-
-            // Colon is read as double underscore by Configuration.
-            var alternateKey = key.Replace(":", "__");
-            if (alternateKey != key && Configuration.GetSection(alternateKey)?.Value != null)
-            {
-                value = Configuration.GetValue<T>(alternateKey)!;
-                return true;
-            }
-
-            // Double underscore is read as ":" by Configuration.
-            alternateKey = key.Replace("__", ":");
-            if (alternateKey != key && Configuration.GetSection(alternateKey)?.Value != null)
-            {
-                value = Configuration.GetValue<T>(alternateKey)!;
                 return true;
             }
 
@@ -134,18 +100,22 @@ namespace CoreEx.Configuration
         /// <exception cref="ArgumentException">Thrown where the <paramref name="key"/> has not been configured.</exception>
         public T GetRequiredValue<T>([CallerMemberName] string key = "")
         {
-            key.ThrowIfNullOrEmpty(nameof(key));
-            if (Configuration == null)
-                throw new InvalidOperationException("An IConfiguration instance is required where GetRequiredValue is used.");
+            // One-off replace double underscore with colon; enables support for both types.
+            var ckey = key.ThrowIfNullOrEmpty(nameof(key)).Replace("__", ":");
 
+            if (Configuration == null)
+                throw new InvalidOperationException($"An IConfiguration instance is required where {nameof(GetRequiredValue)} is used.");
+
+            // Try each prefix until found.
             T kv;
             foreach (var prefix in _prefixes)
             {
-                if (TryGetValue(string.Concat(prefix, key), out kv))
+                if (TryGetValue(string.Concat(prefix, ckey), out kv))
                     return kv;
             }
 
-            return TryGetValue(key, out kv) ? kv : throw new ArgumentException($"Configuration key '{key}' has not been configured and the value is required.", nameof(key));
+            // Final without prefix.
+            return TryGetValue(ckey, out kv) ? kv : throw new ArgumentException($"Configuration key '{key}' has not been configured and the value is required.", nameof(key));
         }
 
         /// <summary>
@@ -164,6 +134,16 @@ namespace CoreEx.Configuration
         public double HttpRetrySeconds => GetValue(nameof(HttpRetrySeconds), 1.8d);
 
         /// <summary>
+        /// Gets the default <see cref="TypedHttpClientBase{TSelf}"/> timeout. Defaults to <c>90</c> seconds.
+        /// </summary>
+        public int HttpTimeoutSeconds => GetValue(defaultValue: 90);
+
+        /// <summary>
+        /// Gets the default <see cref="TypedHttpClientBase{TSelf}"/> maximum retry delay. Defaults to <c>2</c> minutes.
+        /// </summary>
+        public TimeSpan HttpMaxRetryDelay => TimeSpan.FromSeconds(GetValue(defaultValue: 120));
+
+        /// <summary>
         /// Indicates whether to the include the underlying <see cref="Exception"/> content in the externally returned result. Defaults to <c>false</c>.
         /// </summary>
         public bool IncludeExceptionInResult => GetValue(nameof(IncludeExceptionInResult), false);
@@ -177,16 +157,6 @@ namespace CoreEx.Configuration
         /// Gets the <see cref="DeploymentInfo"/> from the environment variables. 
         /// </summary>
         public DeploymentInfo Deployment { get; }
-
-        /// <summary>
-        /// Gets the default <see cref="TypedHttpClientBase{TSelf}"/> timeout. Defaults to <c>90</c> seconds.
-        /// </summary>
-        public int HttpTimeoutSeconds => GetValue(defaultValue: 90);
-
-        /// <summary>
-        /// Gets the default <see cref="TypedHttpClientBase{TSelf}"/> maximum retry delay. Defaults to <c>2</c> minutes.
-        /// </summary>
-        public TimeSpan MaxRetryDelay => TimeSpan.FromSeconds(GetValue(defaultValue: 120));
 
         /// <summary>
         /// Gets the <see cref="Entities.PagingArgs.DefaultTake"/>; i.e. page size.

--- a/src/CoreEx/Entities/CompositeKey.cs
+++ b/src/CoreEx/Entities/CompositeKey.cs
@@ -106,6 +106,22 @@ namespace CoreEx.Entities
         public ImmutableArray<object?> Args => _args;
 
         /// <summary>
+        /// Asserts the <see cref="Args"/> length and throws an <see cref="ArgumentException"/> where the length is not as expected.
+        /// </summary>
+        /// <param name="length">The expected length.</param>
+        /// <returns>The <see cref="CompositeKey"/> to support fluent-style method-chaining.</returns>
+        public CompositeKey AssertLength(int length)
+        {
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), "Length must be greater than or equal to zero.");
+
+            if (_args.Length != length)
+                throw new ArgumentException($"The number of arguments within the {nameof(CompositeKey)} must equal {length}.", nameof(length));
+
+            return this;
+        }
+
+        /// <summary>
         /// Determines whether the current <see cref="CompositeKey"/> is equal to another <see cref="CompositeKey"/>.
         /// </summary>
         /// <param name="other">The other <see cref="CompositeKey"/>.</param>

--- a/src/CoreEx/Events/Subscribing/ErrorHandler.cs
+++ b/src/CoreEx/Events/Subscribing/ErrorHandler.cs
@@ -83,6 +83,7 @@ namespace CoreEx.Events.Subscribing
                         await args.WorkOrchestrator.FailAsync(args.Identifier!, args.Exception.Message, cancellationToken);
 
                     args.Instrumentation?.Instrument(args.ErrorHandling, args.Exception);
+                    args.Logger.LogDebug(ex, LogFormat, args.Exception.Message, args.Exception.ExceptionSource, args.ErrorHandling.ToString());
                     break;
 
                 case ErrorHandling.CompleteWithInformation:

--- a/src/CoreEx/Events/Subscribing/ErrorHandling.cs
+++ b/src/CoreEx/Events/Subscribing/ErrorHandling.cs
@@ -35,6 +35,7 @@ namespace CoreEx.Events.Subscribing
         /// <summary>
         /// Indicates that when the corresponding <i>error</i> occurs this is expected and the current event/message should be completed without further processing and logging (i.e. silently).
         /// </summary>
+        /// <remarks>A <see cref="LogLevel.Debug"/> will be logged where applicable to support debugging.</remarks>
         CompleteAsSilent,
 
         /// <summary>

--- a/src/CoreEx/ExecutionContext.cs
+++ b/src/CoreEx/ExecutionContext.cs
@@ -132,7 +132,7 @@ namespace CoreEx
         /// <summary>
         /// Gets the <see cref="ServiceProvider"/>.
         /// </summary>
-        /// <remarks>This is automatically set via the <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollectionExtensions.AddExecutionContext(IServiceCollection, Func{IServiceProvider, ExecutionContext}?)"/>.</remarks>
+        /// <remarks>This is automatically set via the <see cref="IServiceCollectionExtensions.AddExecutionContext(IServiceCollection, Func{IServiceProvider, ExecutionContext}?)"/>.</remarks>
         public IServiceProvider? ServiceProvider { get; set; }
 
         /// <summary>
@@ -150,11 +150,6 @@ namespace CoreEx
         /// Indicates whether text serialization is enabled; see <see cref="HttpConsts.IncludeTextQueryStringName"/>.
         /// </summary>
         public bool IsTextSerializationEnabled { get; set; }
-
-        /// <summary>
-        /// Gets or sets the <b>result</b> entity tag (used where the value does not explicitly implement <see cref="IETag"/>).
-        /// </summary>
-        public string? ResultETag { get; set; }
 
         /// <summary>
         /// Gets or sets the corresponding user name.
@@ -202,15 +197,14 @@ namespace CoreEx
         {
             var ec = Create == null ? throw new InvalidOperationException($"The {nameof(Create)} function must not be null to create a copy.") : Create();
             ec._timestamp = _timestamp;
-            ec._referenceDataContext = _referenceDataContext;
             ec._messages = _messages;
             ec._properties = _properties;
+            ec._referenceDataContext = _referenceDataContext;
             ec._roles = _roles;
             ec.ServiceProvider = ServiceProvider;
             ec.CorrelationId = CorrelationId;
             ec.OperationType = OperationType;
             ec.IsTextSerializationEnabled = IsTextSerializationEnabled;
-            ec.ResultETag = ResultETag;
             ec.UserName = UserName;
             ec.UserId = UserId;
             ec.TenantId = TenantId;
@@ -229,7 +223,6 @@ namespace CoreEx
                     if (!_disposed)
                     {
                         _disposed = true;
-                        Reset();
                         Dispose(true);
                     }
                 }
@@ -243,7 +236,7 @@ namespace CoreEx
         /// Releases the unmanaged resources used by the <see cref="ExecutionContext"/> and optionally releases the managed resources.
         /// </summary>
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing) { }
+        protected virtual void Dispose(bool disposing) => Reset();
 
         #region Security
 

--- a/src/CoreEx/Hosting/Work/WorkState.cs
+++ b/src/CoreEx/Hosting/Work/WorkState.cs
@@ -38,6 +38,12 @@ namespace CoreEx.Hosting.Work
         public WorkStatus Status { get; set; }
 
         /// <summary>
+        /// Gets or sets the owning user name.
+        /// </summary>
+        /// <remarks>This provides a basic authorization-style opportunity by verifying <i>only</i> the initiating user has ongoing access.</remarks>
+        public string? UserName { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="WorkStatus.Created"/> <see cref="DateTimeOffset"/>.
         /// </summary>
         public DateTimeOffset Created { get; set; }

--- a/src/CoreEx/Hosting/Work/WorkStateArgs.cs
+++ b/src/CoreEx/Hosting/Work/WorkStateArgs.cs
@@ -51,5 +51,11 @@ namespace CoreEx.Hosting.Work
         /// </summary>
         /// <remarks>The <see cref="WorkState.Expiry"/> will default to the <see cref="WorkStateOrchestrator.ExpiryTimeSpan"/> where not specified.</remarks>
         public TimeSpan? Expiry { get; set; }
+
+        /// <summary>
+        /// Gets or sets the owning user name.
+        /// </summary>
+        /// <remarks>This provides a basic authorization opportunity by verifying only the initiating user has ongoing access. This will default to <see cref="ExecutionContext.UserName"/>; otherwise, <c>null</c>.</remarks>
+        public string? UserName { get; set; }
     }
 }

--- a/src/CoreEx/Http/HttpExtensions.cs
+++ b/src/CoreEx/Http/HttpExtensions.cs
@@ -96,9 +96,9 @@ namespace CoreEx.Http
             if (!string.IsNullOrEmpty(etag))
             {
                 if (httpRequest.Method == HttpMethod.Get || httpRequest.Method == HttpMethod.Head)
-                    httpRequest.Headers.IfNoneMatch.Add(new System.Net.Http.Headers.EntityTagHeaderValue(ETagGenerator.FormatETag(etag)!));
+                    httpRequest.Headers.IfNoneMatch.Add(new System.Net.Http.Headers.EntityTagHeaderValue(ETagGenerator.FormatETag(etag)!, true));
                 else
-                    httpRequest.Headers.IfMatch.Add(new System.Net.Http.Headers.EntityTagHeaderValue(ETagGenerator.FormatETag(etag)!));
+                    httpRequest.Headers.IfMatch.Add(new System.Net.Http.Headers.EntityTagHeaderValue(ETagGenerator.FormatETag(etag)!, true));
             }
 
             return httpRequest;

--- a/src/CoreEx/Http/HttpExtensions.cs
+++ b/src/CoreEx/Http/HttpExtensions.cs
@@ -89,7 +89,7 @@ namespace CoreEx.Http
         /// <param name="httpRequest">The <see cref="HttpRequestMessage"/>.</param>
         /// <param name="etag">The <i>ETag</i> value.</param>
         /// <returns>The <see cref="HttpRequestMessage"/> to support fluent-style method-chaining.</returns>
-        /// <remarks>Automatically adds quoting to be ETag format compliant.</remarks>
+        /// <remarks>Automatically adds quoting to be ETag format compliant and sets the ETag as weak ('<c>W/</c>').</remarks>
         public static HttpRequestMessage ApplyETag(this HttpRequestMessage httpRequest, string? etag)
         {
             // Apply the ETag header.

--- a/src/CoreEx/Http/TypedHttpClientBase.cs
+++ b/src/CoreEx/Http/TypedHttpClientBase.cs
@@ -105,7 +105,6 @@ namespace CoreEx.Http
 
             // Access the query string.
             var uri = new Uri(requestUri, UriKind.RelativeOrAbsolute);
-
             var ub = new UriBuilder(uri.IsAbsoluteUri ? uri : new Uri(new Uri("https://coreex"), requestUri));
             var qs = HttpUtility.ParseQueryString(ub.Query);
 

--- a/src/CoreEx/Http/TypedHttpClientBaseT.cs
+++ b/src/CoreEx/Http/TypedHttpClientBaseT.cs
@@ -325,7 +325,7 @@ namespace CoreEx.Http
                         delay ??= TimeSpan.FromSeconds(Math.Pow(options.RetrySeconds ?? 0, attempt)).Add(TimeSpan.FromMilliseconds(_random.Next(0, 500)));
 
                         // Do not go over max delay.
-                        var maxDelay = options.MaxRetryDelay ?? Settings.MaxRetryDelay;
+                        var maxDelay = options.MaxRetryDelay ?? Settings.HttpMaxRetryDelay;
                         return delay.Value > maxDelay ? maxDelay : delay.Value;
                     },
                     onRetryAsync: async (result, timeSpan, retryCount, context) =>

--- a/src/CoreEx/Json/IJsonPreFilterInspector.cs
+++ b/src/CoreEx/Json/IJsonPreFilterInspector.cs
@@ -9,7 +9,7 @@ namespace CoreEx.Json
     public interface IJsonPreFilterInspector
     {
         /// <summary>
-        /// Gets the underlying JSON object (as per the underlying implementation).
+        /// Gets the underlying JSON object (as per the underlying <see cref="IJsonSerializer"/> implementation).
         /// </summary>
         object Json { get; }
 

--- a/src/CoreEx/Mapping/Converters/ConverterT.cs
+++ b/src/CoreEx/Mapping/Converters/ConverterT.cs
@@ -25,5 +25,17 @@ namespace CoreEx.Mapping.Converters
         /// Gets the destination to source <see cref="IValueConverter{TDestination, TSource}"/>.
         /// </summary>
         public readonly IValueConverter<TDestination, TSource> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((TSource)source!);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((TDestination)destination!);
+
+        /// <inheritdoc />
+        public readonly TDestination ConvertToDestination(TSource source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly TSource ConvertToSource(TDestination destination) => ToSource.Convert(destination); 
     }
 }

--- a/src/CoreEx/Mapping/Converters/DateTimeToStringConverter.cs
+++ b/src/CoreEx/Mapping/Converters/DateTimeToStringConverter.cs
@@ -50,5 +50,17 @@ namespace CoreEx.Mapping.Converters
         /// Gets the destination to source <see cref="IValueConverter{TDestination, TSource}"/>.
         /// </summary>
         public IValueConverter<string?, DateTime?> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((DateTime?)source);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((string?)destination);
+
+        /// <inheritdoc />
+        public readonly string? ConvertToDestination(DateTime? source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly DateTime? ConvertToSource(string? destination) => ToSource.Convert(destination);
     }
 }

--- a/src/CoreEx/Mapping/Converters/EncodedStringToDateTimeConverter.cs
+++ b/src/CoreEx/Mapping/Converters/EncodedStringToDateTimeConverter.cs
@@ -31,5 +31,17 @@ namespace CoreEx.Mapping.Converters
         /// Gets the destination to source <see cref="IValueConverter{TDestination, TSource}"/>.
         /// </summary>
         public IValueConverter<DateTime?, string?> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((string?)source);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((DateTime?)destination);
+
+        /// <inheritdoc />
+        public readonly DateTime? ConvertToDestination(string? source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly string? ConvertToSource(DateTime? destination) => ToSource.Convert(destination);
     }
 }

--- a/src/CoreEx/Mapping/Converters/EncodedStringToUInt32Converter.cs
+++ b/src/CoreEx/Mapping/Converters/EncodedStringToUInt32Converter.cs
@@ -31,5 +31,17 @@ namespace CoreEx.Mapping.Converters
         /// Gets the destination to source <see cref="IValueConverter{TDestination, TSource}"/>.
         /// </summary>
         public IValueConverter<uint, string?> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((string?)source);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((uint)destination!);
+
+        /// <inheritdoc />
+        public readonly uint ConvertToDestination(string? source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly string? ConvertToSource(uint destination) => ToSource.Convert(destination);
     }
 }

--- a/src/CoreEx/Mapping/Converters/IConverterT.cs
+++ b/src/CoreEx/Mapping/Converters/IConverterT.cs
@@ -17,12 +17,6 @@ namespace CoreEx.Mapping.Converters
         /// <inheritdoc/>
         Type IConverter.DestinationType => typeof(TDestination);
 
-        /// <inheritdoc/>
-        object? IConverter.ConvertToDestination(object? source) => ToDestination.Convert((TSource)source!);
-
-        /// <inheritdoc/>
-        object? IConverter.ConvertToSource(object? destination) => ToSource.Convert((TDestination)destination!);
-
         /// <summary>
         /// Gets the source to destination <see cref="IValueConverter{TSource, TDestination}"/>.
         /// </summary>
@@ -32,5 +26,19 @@ namespace CoreEx.Mapping.Converters
         /// Gets the destination to source <see cref="IValueConverter{TDestination, TSource}"/>.
         /// </summary>
         IValueConverter<TDestination, TSource> ToSource { get; }
+
+        /// <summary>
+        /// Converts the source to the destination value (converts to).
+        /// </summary>
+        /// <param name="source">The source value to convert.</param>
+        /// <returns>The converted destination value.</returns>
+        TDestination ConvertToDestination(TSource source);
+
+        /// <summary>
+        /// Converts the destination to the source value (converts back from).
+        /// </summary>
+        /// <param name="destination">The destination value to convert.</param>
+        /// <returns>The converted source value.</returns>
+        TSource ConvertToSource(TDestination destination);
     }
 }

--- a/src/CoreEx/Mapping/Converters/ObjectToJsonConverter.cs
+++ b/src/CoreEx/Mapping/Converters/ObjectToJsonConverter.cs
@@ -44,5 +44,17 @@ namespace CoreEx.Mapping.Converters
         /// Gets the destination to source <see cref="IValueConverter{TDestination, TSource}"/>.
         /// </summary>
         public IValueConverter<string?, T?> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((T?)source);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((string?)destination);
+
+        /// <inheritdoc />
+        public readonly string? ConvertToDestination(T? source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly T? ConvertToSource(string? destination) => ToSource.Convert(destination);
     }
 }

--- a/src/CoreEx/Mapping/Converters/ReferenceDataCodeConverter.cs
+++ b/src/CoreEx/Mapping/Converters/ReferenceDataCodeConverter.cs
@@ -33,5 +33,17 @@ namespace CoreEx.Mapping.Converters
         /// Gets the destination to source <see cref="IValueConverter{TDestination, TSource}"/>.
         /// </summary>
         public IValueConverter<string?, TRef?> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((TRef?)source);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((string?)destination);
+
+        /// <inheritdoc />
+        public readonly string? ConvertToDestination(TRef? source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly TRef? ConvertToSource(string? destination) => ToSource.Convert(destination);
     }
 }

--- a/src/CoreEx/Mapping/Converters/ReferenceDataIdConverter.cs
+++ b/src/CoreEx/Mapping/Converters/ReferenceDataIdConverter.cs
@@ -35,5 +35,17 @@ namespace CoreEx.Mapping.Converters
         /// Gets the destination to source <see cref="IValueConverter{TDestination, TSource}"/>.
         /// </summary>
         public IValueConverter<TId, TRef?> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((TRef?)source);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((TId)destination!);
+
+        /// <inheritdoc />
+        public readonly TId ConvertToDestination(TRef? source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly TRef? ConvertToSource(TId destination) => ToSource.Convert(destination);
     }
 }

--- a/src/CoreEx/Mapping/Converters/StringToBase64Converter.cs
+++ b/src/CoreEx/Mapping/Converters/StringToBase64Converter.cs
@@ -31,5 +31,17 @@ namespace CoreEx.Mapping.Converters
         /// Gets the destination to source <see cref="IValueConverter{TDestination, TSource}"/>.
         /// </summary>
         public IValueConverter<byte[]?, string?> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((string?)source);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((byte[]?)destination);
+
+        /// <inheritdoc />
+        public readonly byte[]? ConvertToDestination(string? source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly string? ConvertToSource(byte[]? destination) => ToSource.Convert(destination);
     }
 }

--- a/src/CoreEx/Mapping/Converters/StringToTypeConverter.cs
+++ b/src/CoreEx/Mapping/Converters/StringToTypeConverter.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 namespace CoreEx.Mapping.Converters
 {
     /// <summary>
-    /// Represents a <see cref="string"/> to <typeparamref name="T"/> to conversion.
+    /// Represents a <see cref="string"/> to <typeparamref name="T"/> to conversion using a <see cref="TypeConverter"/>.
     /// </summary>
     /// <typeparam name="T">The <see cref="Type"/> to convert.</typeparam>
     /// <remarks>See also <see cref="TypeToStringConverter{T}"/>.</remarks>
@@ -31,5 +31,17 @@ namespace CoreEx.Mapping.Converters
 
         /// <inheritdoc/>
         public readonly IValueConverter<T, string?> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((string?)source);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((T)destination!);
+
+        /// <inheritdoc />
+        public readonly T ConvertToDestination(string? source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly string? ConvertToSource(T destination) => ToSource.Convert(destination);
     }
 }

--- a/src/CoreEx/Mapping/Converters/TypeToStringConverter.cs
+++ b/src/CoreEx/Mapping/Converters/TypeToStringConverter.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 namespace CoreEx.Mapping.Converters
 {
     /// <summary>
-    /// Represents a <typeparamref name="T"/> to <see cref="string"/> conversion.
+    /// Represents a <typeparamref name="T"/> to <see cref="string"/> conversion using a <see cref="TypeConverter"/>.
     /// </summary>
     /// <typeparam name="T">The <see cref="Type"/> to convert.</typeparam>
     /// <remarks>See also <see cref="StringToTypeConverter{T}"/>.</remarks>
@@ -31,5 +31,17 @@ namespace CoreEx.Mapping.Converters
 
         /// <inheritdoc/>
         public readonly IValueConverter<string?, T> ToSource => _convertToSource;
+
+        /// <inheritdoc />
+        public readonly object? ConvertToDestination(object? source) => ConvertToDestination((T)source!);
+
+        /// <inheritdoc />
+        public readonly object? ConvertToSource(object? destination) => ConvertToSource((string?)destination);
+
+        /// <inheritdoc />
+        public readonly string? ConvertToDestination(T source) => ToDestination.Convert(source);
+
+        /// <inheritdoc />
+        public readonly T ConvertToSource(string? destination) => ToSource.Convert(destination);
     }
 }

--- a/src/CoreEx/RefData/IReferenceDataCollection.cs
+++ b/src/CoreEx/RefData/IReferenceDataCollection.cs
@@ -10,7 +10,7 @@ namespace CoreEx.RefData
     /// <summary>
     /// Provides <see cref="GetById(object)"/> and <see cref="GetByCode(string)"/> functionality for an <see cref="IReferenceData"/> collection.
     /// </summary>
-    public interface IReferenceDataCollection : IETag
+    public interface IReferenceDataCollection
     {
         /// <summary>
         /// Gets the underlying item <see cref="Type"/>.

--- a/src/CoreEx/RefData/ReferenceDataCollection.cs
+++ b/src/CoreEx/RefData/ReferenceDataCollection.cs
@@ -44,9 +44,6 @@ namespace CoreEx.RefData
         /// </summary>
         public ReferenceDataSortOrder SortOrder { get; set; }
 
-        /// <inheritdoc/>
-        public string? ETag { get; set; }
-
         /// <summary>
         /// Gets the item for the specified <see cref="IReferenceData.Code"/>.
         /// </summary>

--- a/tests/CoreEx.Test/Framework/Abstractions/Reflection/TypeReflectorTest.cs
+++ b/tests/CoreEx.Test/Framework/Abstractions/Reflection/TypeReflectorTest.cs
@@ -4,6 +4,7 @@ using CoreEx.RefData;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Text.Json.Serialization;
 
 namespace CoreEx.Test.Framework.Abstractions.Reflection
@@ -239,6 +240,39 @@ namespace CoreEx.Test.Framework.Abstractions.Reflection
                 Assert.That(TypeReflector.GetReflector<Dictionary<string, Person>>(new TypeReflectorArgs()).ItemType, Is.EqualTo(typeof(Person)));
                 Assert.That(TypeReflector.GetReflector<Person>(new TypeReflectorArgs()).ItemType, Is.EqualTo(null));
             });
+        }
+
+        [Test]
+        public void SetValues()
+        {
+            var tr = TypeReflector.GetReflector<Person>(new TypeReflectorArgs());
+            var p = new Person();
+            tr.GetProperty("Id").PropertyExpression.SetValue(p, 88);
+            tr.GetProperty("Name").PropertyExpression.SetValue(p, "foo");
+
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < 100000; i++)
+            {
+                _ = new Person
+                {
+                    Id = 88,
+                    Name = "foo"
+                };
+            }
+
+            sw.Stop();
+            System.Console.WriteLine($"Raw 100K validations - elapsed: {sw.Elapsed.TotalMilliseconds}ms (per {sw.Elapsed.TotalMilliseconds / 100000}ms)");
+
+            sw = Stopwatch.StartNew();
+            for (int i = 0; i < 100000; i++)
+            {
+                p = new Person();
+                tr.GetProperty("Id").PropertyExpression.SetValue(p, 88);
+                tr.GetProperty("Name").PropertyExpression.SetValue(p, "foo");
+            }
+
+            sw.Stop();
+            System.Console.WriteLine($"Expression 100K validations - elapsed: {sw.Elapsed.TotalMilliseconds}ms (per {sw.Elapsed.TotalMilliseconds / 100000}ms)");
         }
     }
 

--- a/tests/CoreEx.Test/Framework/Configuration/SettingsBaseTest.cs
+++ b/tests/CoreEx.Test/Framework/Configuration/SettingsBaseTest.cs
@@ -20,6 +20,7 @@ namespace CoreEx.Test.Framework.Configuration
 
             public string PropTest => GetValue<string>();
 
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "<Pending>")]
             public string PropTest2 => "some hardcoded value";
 
             public string SomethingGlobal => GetValue<string>();
@@ -27,7 +28,7 @@ namespace CoreEx.Test.Framework.Configuration
 
         }
 
-        private IConfiguration CreateTestConfiguration()
+        private static IConfiguration CreateTestConfiguration()
         {
             Environment.SetEnvironmentVariable("this_is_a_unittest_underscore__key", "underscoreValue");
             ConfigurationBuilder builder = new();
@@ -47,7 +48,7 @@ namespace CoreEx.Test.Framework.Configuration
         [Test]
         public void CommonSettings_Should_Not_ThrowException_When_ConfigurationNull()
         {
-            new SettingsForTesting(null!);
+            _ = new SettingsForTesting(null!);
         }
 
         [Test]
@@ -57,10 +58,10 @@ namespace CoreEx.Test.Framework.Configuration
             var configuration = CreateTestConfiguration();
 
             // Act
-            Action act = () => new SettingsForTesting(configuration, prefixes: null!);
+            Action act = () => _ = new SettingsForTesting(configuration, prefixes: null!);
 
             // Assert
-            act.Should().Throw<ArgumentNullException>();
+            act.Should().NotThrow<ArgumentNullException>();
         }
 
         [Test]
@@ -71,7 +72,7 @@ namespace CoreEx.Test.Framework.Configuration
             var prefixes = new string[] { "foo", string.Empty };
 
             // Act
-            Action act = () => new SettingsForTesting(configuration, prefixes);
+            Action act = () => _ = new SettingsForTesting(configuration, prefixes);
 
             // Assert
             act.Should().Throw<ArgumentException>();
@@ -161,14 +162,13 @@ namespace CoreEx.Test.Framework.Configuration
             result.Should().Be("underscoreValue");
         }
 
-
         [Test]
         public void GetValue_Should_Return_Value_From_Property_When_Class_Has_it()
         {
             var configuration = CreateTestConfiguration();
             var settings = new SettingsForTesting(configuration, new string[] { "Sample/", "Common/" });
 
-            var result = settings.GetValue<string>("PropTest2");
+            var result = settings.PropTest2;
 
             // Assert
             result.Should().Be("some hardcoded value");
@@ -180,7 +180,7 @@ namespace CoreEx.Test.Framework.Configuration
             var configuration = CreateTestConfiguration();
             var settings = new SettingsForTesting(configuration, new string[] { "Sample/", "Common/" });
 
-            var result = settings.GetValue<string>("PropTestNested");
+            var result = settings.PropTestNested;
 
             // Assert
             settings.SomethingGlobal.Should().Be("foo");
@@ -198,7 +198,7 @@ namespace CoreEx.Test.Framework.Configuration
 
             var testResult = Parallel.ForEach(reps, (i) =>
             {
-                var result = settings.GetValue<string>("PropTestNested");
+                var result = settings.PropTestNested;
 
                 // Assert
                 settings.SomethingGlobal.Should().Be("foo");
@@ -212,16 +212,15 @@ namespace CoreEx.Test.Framework.Configuration
 
         static async Task ExamineValuesOfLocalObjectsEitherSideOfAwait(SettingsForTesting settings)
         {
-            var result = settings.GetValue<string>("PropTestNested");
+            var result = settings.PropTestNested;
             settings.SomethingGlobal.Should().Be("foo");
             result.Should().Be("foo");
 
             await Task.Delay(100);
 
-            result = settings.GetValue<string>("PropTestNested");
+            result = settings.PropTestNested;
             settings.SomethingGlobal.Should().Be("foo");
             result.Should().Be("foo");
         }
-
     }
 }

--- a/tests/CoreEx.Test/Framework/Hosting/Work/WorkStateOrchestratorTest.cs
+++ b/tests/CoreEx.Test/Framework/Hosting/Work/WorkStateOrchestratorTest.cs
@@ -62,6 +62,9 @@ namespace CoreEx.Test.Framework.Hosting.Work
                 return;
             }
 
+            ExecutionContext.Reset();
+            ExecutionContext.SetCurrent(new ExecutionContext { UserName = ExecutionContext.EnvironmentUserName });
+
             // Clean up before we begin.
             await o.Persistence.DeleteAsync("abc", default);
 
@@ -129,6 +132,17 @@ namespace CoreEx.Test.Framework.Hosting.Work
 
             // Check different type; but same id. Confirms same type as extra pre-caution!
             wr = await o.GetAsync("other", "abc");
+            Assert.That(wr, Is.Null);
+
+            // Check different username; but same id. Confirms same user as extra/extra pre-caution!
+            ExecutionContext.Reset();
+            ExecutionContext.SetCurrent(new ExecutionContext { UserName = "other" });
+            wr = await o.GetAsync<Person>("abc");
+            Assert.That(wr, Is.Null);
+
+            // Check no username set; but same id. Confirms same user as extra/extra/extra pre-caution!
+            ExecutionContext.Reset();
+            wr = await o.GetAsync<Person>("abc");
             Assert.That(wr, Is.Null);
         }
 

--- a/tests/CoreEx.Test/Framework/Validation/Rules/ExistsRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/ExistsRuleTest.cs
@@ -2,6 +2,7 @@
 using CoreEx.Validation;
 using CoreEx.Entities;
 using System.Threading.Tasks;
+using CoreEx.Results;
 
 namespace CoreEx.Test.Framework.Validation.Rules
 {
@@ -53,10 +54,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").ExistsAsync((_, __) => Task.FromResult<object?>(new object())).ValidateAsync();
+            v1 = await 123.Validate("value").ValueExistsAsync((_, __) => Task.FromResult<object?>(new object())).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 123.Validate("value").ExistsAsync((_, __) => Task.FromResult((object?)null)).ValidateAsync();
+            v1 = await 123.Validate("value").ValueExistsAsync((_, __) => Task.FromResult((object?)null)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -91,6 +92,11 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Type, Is.EqualTo(MessageType.Error));
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
+
+            v1 = await 123.Validate("value").ValueExistsAsync(async (_, __) => await GetBlahAsync()).ValidateAsync();
+            Assert.That(v1.HasErrors, Is.True); // Result.Success is not a valid value
         }
+
+        private static Task<Result> GetBlahAsync() => Task.FromResult(Result.Success);
     }
 }

--- a/tests/CoreEx.Test/Framework/WebApis/WebApiPublisherTest.cs
+++ b/tests/CoreEx.Test/Framework/WebApis/WebApiPublisherTest.cs
@@ -329,7 +329,7 @@ namespace CoreEx.Test.Framework.WebApis
             Assert.That(ed, Has.Length.EqualTo(1));
             ObjectComparer.Assert(new Product { Id = "A", Name = "B", Price = 1.99m }, ed[0].Value);
 
-            var ws2 = wso.GetAsync<Product>(ed[0].Id!).Result;
+            var ws2 = wso.GetAsync(ed[0].Id!).Result;
             Assert.That(ws2, Is.Not.Null);
             Assert.That(ws2.Status, Is.EqualTo(WorkStatus.Created));
             

--- a/tests/CoreEx.Test/Framework/WebApis/WebApiTest.cs
+++ b/tests/CoreEx.Test/Framework/WebApis/WebApiTest.cs
@@ -223,13 +223,35 @@ namespace CoreEx.Test.Framework.WebApis
         {
             using var test = FunctionTester.Create<Startup>();
             var vcr = test.Type<WebApi>()
+                .Run(f => f.GetAsync(test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget"), r => Task.FromResult(new Person { Id = 1, Name = "Angela" })))
+                .ToActionResultAssertor()
+                .AssertOK()
+                .Result as ValueContentResult;
+
+            Assert.That(vcr, Is.Not.Null);
+            Assert.That(vcr!.ETag, Is.EqualTo("iVsGVb/ELj5dvXpe3ImuOy/vxLIJnUtU2b8nIfpX5PM="));
+
+            var p = test.JsonSerializer.Deserialize<Person>(vcr.Content!);
+            Assert.That(p, Is.Not.Null);
+            Assert.That(p.ETag, Is.EqualTo("iVsGVb/ELj5dvXpe3ImuOy/vxLIJnUtU2b8nIfpX5PM="));
+        }
+
+        [Test]
+        public void GetAsync_WithGenETagValue_QueryString()
+        {
+            using var test = FunctionTester.Create<Startup>();
+            var vcr = test.Type<WebApi>()
                 .Run(f => f.GetAsync(test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget?fruit=apples"), r => Task.FromResult(new Person { Id = 1, Name = "Angela" })))
                 .ToActionResultAssertor()
                 .AssertOK()
                 .Result as ValueContentResult;
 
             Assert.That(vcr, Is.Not.Null);
-            Assert.That(vcr!.ETag, Is.EqualTo("F/BIL6G5jbvZxc4fnCc5BekkmFM9/BuXSSl/i5bQj5Q="));
+            Assert.That(vcr!.ETag, Is.EqualTo("cpDn3xugV1xKSHF9AY4kQRNQ1yC/SU49xC66C92WZbE="));
+
+            var p = test.JsonSerializer.Deserialize<Person>(vcr.Content!);
+            Assert.That(p, Is.Not.Null);
+            Assert.That(p.ETag, Is.EqualTo("iVsGVb/ELj5dvXpe3ImuOy/vxLIJnUtU2b8nIfpX5PM="));
         }
 
         [Test]
@@ -237,7 +259,7 @@ namespace CoreEx.Test.Framework.WebApis
         {
             using var test = FunctionTester.Create<Startup>();
             var hr = test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget?fruit=apples");
-            hr.Headers.Add(HeaderNames.IfMatch, "\\W\"F/BIL6G5jbvZxc4fnCc5BekkmFM9/BuXSSl/i5bQj5Q=\"");
+            hr.Headers.Add(HeaderNames.IfMatch, "\\W\"cpDn3xugV1xKSHF9AY4kQRNQ1yC/SU49xC66C92WZbE=\"");
 
             test.Type<WebApi>()
                 .Run(f => f.GetAsync(hr, r => Task.FromResult(new Person { Id = 1, Name = "Angela" })))
@@ -650,7 +672,7 @@ namespace CoreEx.Test.Framework.WebApis
                 .Run(f => f.PatchAsync(hr, get: _ => Task.FromResult<Person?>(new Person { Id = 13, Name = "Deano" }), put: _ => Task.FromResult<Person>(new Person { Id = 13, Name = "Gazza" }), simulatedConcurrency: true))
                 .ToActionResultAssertor()
                 .AssertOK()
-                .AssertValue(new Person { Id = 13, Name = "Gazza" });
+                .AssertValue(new Person { Id = 13, Name = "Gazza", ETag = "tEEokPXk+4Q5MoiGqyAs1+6A00e2ww59Zm57LJgvBcg=" });
         }
 
         private static HttpRequest CreatePatchRequest(UnitTestEx.NUnit.Internal.FunctionTester<Startup> test, string? json, string? etag = null)

--- a/tests/CoreEx.Test/Framework/WebApis/WebApiWithResultTest.cs
+++ b/tests/CoreEx.Test/Framework/WebApis/WebApiWithResultTest.cs
@@ -48,7 +48,7 @@ namespace CoreEx.Test.Framework.WebApis
         {
             using var test = FunctionTester.Create<Startup>();
             var vcr = test.Type<WebApi>()
-                .Run(f => f.GetWithResultAsync(test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget?fruit=apples"), r => Task.FromResult(Result.Ok(new Person { Id = 1, Name = "Angela", ETag = "my-etag" }))))
+                .Run(f => f.GetWithResultAsync(test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget"), r => Task.FromResult(Result.Ok(new Person { Id = 1, Name = "Angela", ETag = "my-etag" }))))
                 .ToActionResultAssertor()
                 .AssertOK()
                 .Result as ValueContentResult;
@@ -61,8 +61,8 @@ namespace CoreEx.Test.Framework.WebApis
         public void GetWithResultAsync_WithETagValueNotModified()
         {
             using var test = FunctionTester.Create<Startup>();
-            var hr = test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget?fruit=apples");
-            hr.Headers.Add(HeaderNames.IfMatch, "my-etag");
+            var hr = test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget");
+            hr.Headers.Add(HeaderNames.IfMatch, "\\W\"my-etag\"");
 
             test.Type<WebApi>()
                 .Run(f => f.GetWithResultAsync(hr, r => Task.FromResult(Result.Ok(new Person { Id = 1, Name = "Angela", ETag = "my-etag" }))))
@@ -81,7 +81,7 @@ namespace CoreEx.Test.Framework.WebApis
                 .Result as ValueContentResult;
 
             Assert.That(vcr, Is.Not.Null);
-            Assert.That(vcr!.ETag, Is.EqualTo("iVsGVb/ELj5dvXpe3ImuOy/vxLIJnUtU2b8nIfpX5PM="));
+            Assert.That(vcr!.ETag, Is.EqualTo("F/BIL6G5jbvZxc4fnCc5BekkmFM9/BuXSSl/i5bQj5Q="));
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace CoreEx.Test.Framework.WebApis
         {
             using var test = FunctionTester.Create<Startup>();
             var hr = test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget?fruit=apples");
-            hr.Headers.Add(HeaderNames.IfMatch, "iVsGVb/ELj5dvXpe3ImuOy/vxLIJnUtU2b8nIfpX5PM=");
+            hr.Headers.Add(HeaderNames.IfMatch, "\\W\"F/BIL6G5jbvZxc4fnCc5BekkmFM9/BuXSSl/i5bQj5Q=\"");
 
             test.Type<WebApi>()
                 .Run(f => f.GetWithResultAsync(hr, r => Task.FromResult(Result.Ok(new Person { Id = 1, Name = "Angela" }))))

--- a/tests/CoreEx.Test/Framework/WebApis/WebApiWithResultTest.cs
+++ b/tests/CoreEx.Test/Framework/WebApis/WebApiWithResultTest.cs
@@ -75,13 +75,35 @@ namespace CoreEx.Test.Framework.WebApis
         {
             using var test = FunctionTester.Create<Startup>();
             var vcr = test.Type<WebApi>()
+                .Run(f => f.GetWithResultAsync(test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget"), r => Task.FromResult(Result.Ok(new Person { Id = 1, Name = "Angela" }))))
+                .ToActionResultAssertor()
+                .AssertOK()
+                .Result as ValueContentResult;
+
+            Assert.That(vcr, Is.Not.Null);
+            Assert.That(vcr!.ETag, Is.EqualTo("iVsGVb/ELj5dvXpe3ImuOy/vxLIJnUtU2b8nIfpX5PM="));
+
+            var p = test.JsonSerializer.Deserialize<Person>(vcr.Content!);
+            Assert.That(p, Is.Not.Null);
+            Assert.That(p.ETag, Is.EqualTo("iVsGVb/ELj5dvXpe3ImuOy/vxLIJnUtU2b8nIfpX5PM="));
+        }
+
+        [Test]
+        public void GetWithResultAsync_WithGenETagValue_QueryString()
+        {
+            using var test = FunctionTester.Create<Startup>();
+            var vcr = test.Type<WebApi>()
                 .Run(f => f.GetWithResultAsync(test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget?fruit=apples"), r => Task.FromResult(Result.Ok(new Person { Id = 1, Name = "Angela" }))))
                 .ToActionResultAssertor()
                 .AssertOK()
                 .Result as ValueContentResult;
 
             Assert.That(vcr, Is.Not.Null);
-            Assert.That(vcr!.ETag, Is.EqualTo("F/BIL6G5jbvZxc4fnCc5BekkmFM9/BuXSSl/i5bQj5Q="));
+            Assert.That(vcr!.ETag, Is.EqualTo("cpDn3xugV1xKSHF9AY4kQRNQ1yC/SU49xC66C92WZbE="));
+
+            var p = test.JsonSerializer.Deserialize<Person>(vcr.Content!);
+            Assert.That(p, Is.Not.Null);
+            Assert.That(p.ETag, Is.EqualTo("iVsGVb/ELj5dvXpe3ImuOy/vxLIJnUtU2b8nIfpX5PM="));
         }
 
         [Test]
@@ -89,7 +111,7 @@ namespace CoreEx.Test.Framework.WebApis
         {
             using var test = FunctionTester.Create<Startup>();
             var hr = test.CreateHttpRequest(HttpMethod.Get, "https://unittest/testget?fruit=apples");
-            hr.Headers.Add(HeaderNames.IfMatch, "\\W\"F/BIL6G5jbvZxc4fnCc5BekkmFM9/BuXSSl/i5bQj5Q=\"");
+            hr.Headers.Add(HeaderNames.IfMatch, "\\W\"cpDn3xugV1xKSHF9AY4kQRNQ1yC/SU49xC66C92WZbE=\"");
 
             test.Type<WebApi>()
                 .Run(f => f.GetWithResultAsync(hr, r => Task.FromResult(Result.Ok(new Person { Id = 1, Name = "Angela" }))))
@@ -523,7 +545,7 @@ namespace CoreEx.Test.Framework.WebApis
                 .Run(f => f.PatchWithResultAsync(hr, get: _ => Task.FromResult(Result<Person?>.Ok(new Person { Id = 13, Name = "Deano" })), put: _ => Task.FromResult(Result.Ok(new Person { Id = 13, Name = "Gazza" })), simulatedConcurrency: true))
                 .ToActionResultAssertor()
                 .AssertOK()
-                .AssertValue(new Person { Id = 13, Name = "Gazza" });
+                .AssertValue(new Person { Id = 13, Name = "Gazza", ETag = "tEEokPXk+4Q5MoiGqyAs1+6A00e2ww59Zm57LJgvBcg=" });
         }
 
         [Test]


### PR DESCRIPTION
- *Enhancement*: Added `DatabaseMapperEx` enabling extended/explicit mapping where performance is critical versus existing that uses reflection and compiled expressions; can offer up to 40%+ improvement in some scenarios.
- *Enhancement*: The `AddMappers<TAssembly>()` and `AddValidators<TAssembly>()` extension methods now also support two or three assembly specification overloads.
- *Enhancement*: A `WorkState.UserName` has been added to enable the tracking of the user that initiated the work; this is then checked to ensure that only the initiating user can interact with their own work state.
- *Fixed:* The `ReferenceDataOrchestrator.GetByTypeAsync` has had the previous sync-over-async corrected to be fully async.
- *Fixed*: Validation extensions `Exists` and `ExistsAsync` which expect a non-null resultant value have been renamed to `ValueExists` and `ValueExistsAsync` to improve usability; also they are `IResult` aware and will act accordingly.
- *Fixed*: The `ETag` HTTP handling has been updated to correctly output and expect the weak `W/"xxxx"` format. 
- *Fixed*: The `ETagGenerator` implementation has been further optimized to minimize unneccessary string allocations.
- *Fixed*: The `ValueContentResult` will only generate a response header ETag (`ETagGenerator`) for a `GET` or `HEAD` request. The underlying result `IETag.ETag` is used as-is where there is no query string; otherwise, generates as assumes query string will alter result (i.e. filtering, paging, sorting, etc.). The result `IETag.ETag` is unchanged so the consumer can still use as required for a further operation.
- *Fixed*: The `SettingsBase` has been optimized. The internal recursion checking has been removed and as such an endless loop (`StackOverflowException`) may occur where misconfigured; given frequency of `IConfiguration` usage the resulting performance is deemed more important. Additionally, `prefixes` are now optional.
  - The existing support of referencing a settings property by name (`settings.GetValue<T>("NamedProperty")`) and it using reflection to find before querying the `IConfiguration` has been removed. This was not a common, or intended usage, and was somewhat magical, and finally was non-performant.
