### PR TITLE
v3.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v3.14.1
+- *Fixed*: The `Result.ValidatesAsync` extension method signature has had the value nullability corrected to enable fluent-style method-chaining.
+- *Fixed*: The fully qualified type and property name is now correctly used as the `LText.KeyAndOrText` when creating within the `PropertyExpression<TEntity, TProperty>` to enable a qualified _key_ that can be used by the `ITextProvider` to substitute the text at runtime; the existing text fallback behavior remains such that an appropriate text is used. The `PropertyExpression.CreatePropertyLTextKey` function can be overridden to change this behavior.
+
 ## v3.14.0
 - *Enhancement*: Planned feature obsoletion. The `TypedHttpClientBase` methods `WithRetry`, `WithTimeout`, `WithCustomRetryPolicy` and `WithMaxRetryDelay` are now marked as obsolete and will result in a compile-time warning. Related `TypedHttpClientOptions`, `HttpRequestLogger` and `SettingsBase` capabilities have also been obsoleted.
   - Why? Primarily based on Microsoft guidance around [`IHttpClientFactory`](https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory) usage. Specifically advances in native HTTP [resilency](https://learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience) support, and the [.NET 8 networking improvements](https://devblogs.microsoft.com/dotnet/dotnet-8-networking-improvements/).

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.14.0</Version>
+		<Version>3.14.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
+++ b/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
@@ -21,7 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.4.0" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.5.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
+++ b/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
@@ -20,14 +20,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CoreEx.Azure/CoreEx.Azure.csproj
+++ b/src/CoreEx.Azure/CoreEx.Azure.csproj
@@ -14,13 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Data.Tables" Version="12.8.2" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.2" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.4" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.16.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.13.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.14.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.1.0" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
+++ b/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
@@ -12,8 +12,8 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.38.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.8" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Database.SqlServer/CoreEx.Database.SqlServer.csproj
+++ b/src/CoreEx.Database.SqlServer/CoreEx.Database.SqlServer.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.EntityFrameworkCore/CoreEx.EntityFrameworkCore.csproj
+++ b/src/CoreEx.EntityFrameworkCore/CoreEx.EntityFrameworkCore.csproj
@@ -13,15 +13,15 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.28" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.17" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
+++ b/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.2.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
+++ b/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="UnitTestEx" Version="4.2.0" />
+    <PackageReference Include="UnitTestEx" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreEx.Validation/IEntityRule.cs
+++ b/src/CoreEx.Validation/IEntityRule.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.Validation
+{
+    /// <summary>
+    /// Provides a validation rule for an entity.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
+    public interface IEntityRule<TEntity> where TEntity : class
+    {
+        /// <summary>
+        /// Validates an entity given a <see cref="ValidationContext{TEntity}"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="ValidationContext{TEntity}"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        Task ValidateAsync(ValidationContext<TEntity> context, CancellationToken cancellationToken);
+    }
+}

--- a/src/CoreEx.Validation/IPropertyRule.cs
+++ b/src/CoreEx.Validation/IPropertyRule.cs
@@ -1,22 +1,48 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
-using System;
+using CoreEx.Localization;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace CoreEx.Validation
 {
     /// <summary>
-    /// Provides a validation rule for a property.
+    /// Enables a validation rule for an entity property. 
     /// </summary>
-    /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
-    public interface IPropertyRule<TEntity> where TEntity : class
+    public interface IPropertyRule
     {
         /// <summary>
-        /// Validates an entity given a <see cref="ValidationContext{TEntity}"/>.
+        /// Gets the property name.
         /// </summary>
-        /// <param name="context">The <see cref="ValidationContext{TEntity}"/></param>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the JSON property name.
+        /// </summary>
+        public string JsonName { get; }
+
+        /// <summary>
+        /// Gets or sets the friendly text name used in validation messages.
+        /// </summary>
+        public LText Text { get; set; }
+
+        /// <summary>
+        /// Executes the validation for the property value.
+        /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        Task ValidateAsync(ValidationContext<TEntity> context, CancellationToken cancellationToken);
+        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
+        Task<IValidationResult> ValidateAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the validation for the property value.
+        /// </summary>
+        /// <param name="throwOnError">Indicates whether to automatically throw a <see cref="ValidationException"/> where <see cref="IValidationResult.HasErrors"/>.</param>
+        /// <param name="cancellationToken">>The <see cref="CancellationToken"/>.</param>
+        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
+        public async Task<IValidationResult> ValidateAsync(bool throwOnError, CancellationToken cancellationToken = default)
+        {
+            var ir = await ValidateAsync(cancellationToken).ConfigureAwait(false);
+            return throwOnError ? ir.ThrowOnError() : ir;
+        }
     }
 }

--- a/src/CoreEx.Validation/IPropertyRuleT2.cs
+++ b/src/CoreEx.Validation/IPropertyRuleT2.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
-using CoreEx.Localization;
 using CoreEx.Validation.Clauses;
 using CoreEx.Validation.Rules;
 using System;
 using System.Linq.Expressions;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace CoreEx.Validation
 {
@@ -15,23 +12,8 @@ namespace CoreEx.Validation
     /// </summary>
     /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
     /// <typeparam name="TProperty">The property <see cref="Type"/>.</typeparam>
-    public interface IPropertyRule<TEntity, in TProperty> where TEntity : class
+    public interface IPropertyRule<TEntity, in TProperty> : IPropertyRule where TEntity : class
     {
-        /// <summary>
-        /// Gets the property name.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Gets the JSON property name.
-        /// </summary>
-        public string JsonName { get; }
-
-        /// <summary>
-        /// Gets or sets the friendly text name used in validation messages.
-        /// </summary>
-        public LText Text { get; set; }
-
         /// <summary>
         /// Adds a clause (<see cref="IPropertyRuleClause{TEntity, TProperty}"/>) to the rule.
         /// </summary>
@@ -44,25 +26,6 @@ namespace CoreEx.Validation
         /// <param name="rule">The <see cref="IValueRule{TEntity, TProperty}"/>.</param>
         /// <returns>The <see cref="PropertyRuleBase{TEntity, TProperty}"/>.</returns>
         IPropertyRule<TEntity, TProperty> AddRule(IValueRule<TEntity, TProperty> rule);
-
-        /// <summary>
-        /// Executes the validation for the property value.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
-        Task<IValidationResult> ValidateAsync(CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Executes the validation for the property value.
-        /// </summary>
-        /// <param name="throwOnError">Indicates whether to automatically throw a <see cref="ValidationException"/> where <see cref="IValidationResult.HasErrors"/>.</param>
-        /// <param name="cancellationToken">>The <see cref="CancellationToken"/>.</param>
-        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
-        public async Task<IValidationResult> ValidateAsync(bool throwOnError, CancellationToken cancellationToken = default)
-        {
-            var ir = await ValidateAsync(cancellationToken).ConfigureAwait(false);
-            return throwOnError ? ir.ThrowOnError() : ir;
-        }
 
         /// <summary>
         /// Adds a <see cref="DependsOnClause{TEntity, TProperty}"/> to this <see cref="PropertyRule{TEntity, TProperty}"/> in that another specified property of the entity must have a non-default value (and not have a validation error) to continue.

--- a/src/CoreEx.Validation/IncludeBaseRule.cs
+++ b/src/CoreEx.Validation/IncludeBaseRule.cs
@@ -11,7 +11,7 @@ namespace CoreEx.Validation
     /// </summary>
     /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
     /// <typeparam name="TInclude">The entity base <see cref="Type"/>.</typeparam>
-    public class IncludeBaseRule<TEntity, TInclude> : ValidatorBase<TEntity>, IPropertyRule<TEntity> where TEntity : class where TInclude : class
+    public class IncludeBaseRule<TEntity, TInclude> : ValidatorBase<TEntity>, IEntityRule<TEntity> where TEntity : class where TInclude : class
     {
         private readonly IValidatorEx<TInclude> _include;
 

--- a/src/CoreEx.Validation/PropertyRule.cs
+++ b/src/CoreEx.Validation/PropertyRule.cs
@@ -15,7 +15,7 @@ namespace CoreEx.Validation
     /// </summary>
     /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
     /// <typeparam name="TProperty">The property <see cref="Type"/>.</typeparam>
-    public class PropertyRule<TEntity, TProperty> : PropertyRuleBase<TEntity, TProperty>, IPropertyRule<TEntity>, IValueRule<TEntity, TProperty> where TEntity : class
+    public class PropertyRule<TEntity, TProperty> : PropertyRuleBase<TEntity, TProperty>, IEntityRule<TEntity>, IValueRule<TEntity, TProperty> where TEntity : class
     {
         private readonly PropertyExpression<TEntity, TProperty> _property;
 

--- a/src/CoreEx.Validation/PropertyRuleBase.cs
+++ b/src/CoreEx.Validation/PropertyRuleBase.cs
@@ -108,6 +108,6 @@ namespace CoreEx.Validation
         public abstract Task<ValueValidatorResult<TEntity, TProperty>> ValidateAsync(CancellationToken cancellationToken = default);
 
         /// <inheritdoc/>
-        async Task<IValidationResult> IPropertyRule<TEntity, TProperty>.ValidateAsync(CancellationToken cancellationToken) => await ValidateAsync(cancellationToken).ConfigureAwait(false);
+        async Task<IValidationResult> IPropertyRule.ValidateAsync(CancellationToken cancellationToken) => await ValidateAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/CoreEx.Validation/RuleSet.cs
+++ b/src/CoreEx.Validation/RuleSet.cs
@@ -10,7 +10,7 @@ namespace CoreEx.Validation
     /// Represents a validation rule set for an entity, in that it groups one or more <see cref="Rules"/> together for a specified condition.
     /// </summary>
     /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
-    public class RuleSet<TEntity> : ValidatorBase<TEntity>, IPropertyRule<TEntity> where TEntity : class
+    public class RuleSet<TEntity> : ValidatorBase<TEntity>, IEntityRule<TEntity> where TEntity : class
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RuleSet{TEntity}"/> class to be invoked where the predicate is true.

--- a/src/CoreEx.Validation/ValidationExtensions.cs
+++ b/src/CoreEx.Validation/ValidationExtensions.cs
@@ -26,7 +26,7 @@ namespace CoreEx.Validation
         #region Text
 
         /// <summary>
-        /// Updates the rule friendly name text used in validation messages (see <see cref="IPropertyRule{TEntity, TProperty}.Text"/>.
+        /// Updates the rule friendly name text used in validation messages (see <see cref="IPropertyRule.Text"/>.
         /// </summary>
         /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
         /// <typeparam name="TProperty">The property <see cref="Type"/>.</typeparam>
@@ -1212,7 +1212,7 @@ namespace CoreEx.Validation
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
         /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T>, IPropertyRule>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #else
         /// <summary>
         /// Executes the <paramref name="validator"/> for the specified <paramref name="value"/> where the <paramref name="result"/> is <see cref="Result.IsSuccess"/>.
@@ -1227,7 +1227,7 @@ namespace CoreEx.Validation
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
         /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T>, IPropertyRule>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #endif
         {
             if (validator is null || result.IsFailure)
@@ -1252,7 +1252,7 @@ namespace CoreEx.Validation
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
         /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T>, IPropertyRule>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #else
         /// <summary>
         /// Executes the <paramref name="validator"/> for the specified <paramref name="value"/> where the <paramref name="result"/> is <see cref="Result.IsSuccess"/>.
@@ -1267,7 +1267,7 @@ namespace CoreEx.Validation
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
         /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T?>, IPropertyRule<ValidationValue<T?>, T?>>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T>, IPropertyRule>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #endif
         {
             var r = await result.ConfigureAwait(false);

--- a/src/CoreEx.Validation/ValidatorBase.cs
+++ b/src/CoreEx.Validation/ValidatorBase.cs
@@ -17,7 +17,7 @@ namespace CoreEx.Validation
         /// <summary>
         /// Gets the underlying rules collection.
         /// </summary>
-        internal protected List<IPropertyRule<TEntity>> Rules { get; } = [];
+        internal protected List<IEntityRule<TEntity>> Rules { get; } = [];
 
         /// <summary>
         /// Gets the <see cref="ExecutionContext.Current"/> instance.

--- a/src/CoreEx/Abstractions/Reflection/PropertyExpression.cs
+++ b/src/CoreEx/Abstractions/Reflection/PropertyExpression.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using CoreEx.Json;
+using CoreEx.Localization;
+using CoreEx.Text;
 using Microsoft.Extensions.Caching.Memory;
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace CoreEx.Abstractions.Reflection
 {
@@ -18,6 +22,25 @@ namespace CoreEx.Abstractions.Reflection
         /// Gets the <see cref="IMemoryCache"/>.
         /// </summary>
         internal static IMemoryCache Cache => ExecutionContext.GetService<IReflectionCache>() ?? (_fallbackCache ??= new MemoryCache(new MemoryCacheOptions()));
+
+        /// <summary>
+        /// Gets or sets the <see cref="IMemoryCache"/> absolute expiration <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <remarks>Defaults to <c>4</c> hours.</remarks>
+        public static TimeSpan? AbsoluteExpirationTimespan { get; set; } = TimeSpan.FromHours(4);
+
+        /// <summary>
+        /// Gets or sets the <see cref="IMemoryCache"/> sliding expiration <see cref="TimeSpan"/>.
+        /// </summary>
+        /// <remarks>Defaults to <c>30</c> minutes.</remarks>
+        public static TimeSpan? SlidingExpirationTimespan { get; set; } = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// Gets or sets the function to create the <see cref="LText"/> for the specified entity <see cref="Type"/>, <see cref="PropertyInfo"/> and <i>inferred</i> text (being either the corresponding <see cref="DisplayAttribute.Name"/> where specified
+        /// or the <see cref="MemberInfo.Name"/> converted to <see cref="SentenceCase.ToSentenceCase"/>).
+        /// </summary>
+        /// <remarks>Defaults the <see cref="LText.KeyAndOrText"/> to the fully qualified name (being <see cref="Type.FullName"/> + '.' + <see cref="MemberInfo.Name"/>) and the <see cref="LText.FallbackText"/> to the <i>inferred</i> text.</remarks>
+        public static Func<Type, PropertyInfo, string, LText> CreatePropertyLText { get; set; } = (entityType, propertyInfo, text) => new LText($"{entityType.FullName}.{propertyInfo.Name}", text);
 
         /// <summary>
         /// Validates, creates and compiles the property expression; whilst also determinig the property friendly <see cref="PropertyExpression{TEntity, TProperty}.Text"/>.

--- a/src/CoreEx/AuthenticationException.cs
+++ b/src/CoreEx/AuthenticationException.cs
@@ -13,7 +13,7 @@ namespace CoreEx
     /// <remarks>The <see cref="Exception.Message"/> defaults to: <i>An authentication error occured; the credentials you provided are not valid.</i></remarks>
     public class AuthenticationException : Exception, IExtendedException
     {
-        private const string _message = "An authorization error occurred; you are not permitted to perform this action.";
+        private const string _message = "An authentication error occurred; the credentials you provided are not valid.";
 
         /// <summary>
         /// Get or sets the <see cref="ShouldBeLogged"/> value.

--- a/src/CoreEx/CoreEx.csproj
+++ b/src/CoreEx/CoreEx.csproj
@@ -15,20 +15,20 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.Memory.Data" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.15" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.17" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
@@ -41,7 +41,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.26" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.28" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
@@ -54,7 +54,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.25" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.28" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
@@ -69,7 +69,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageReference Include="YamlDotNet" Version="15.1.1" />
+    <PackageReference Include="YamlDotNet" Version="15.1.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/CoreEx/Localization/LText.cs
+++ b/src/CoreEx/Localization/LText.cs
@@ -7,8 +7,14 @@ namespace CoreEx.Localization
     /// <summary>
     /// Represents the <b>localization text</b> key/identifier to be used by the <see cref="TextProvider"/>.
     /// </summary>
-    public struct LText
+    public struct LText : IEquatable<LText>
     {
+        /// <summary>
+        /// Gets the empty <see cref="LText"/>.
+        /// </summary>
+        /// <remarks>The <see cref="KeyAndOrText"/> and <see cref="FallbackText"/> are both <c>null</c>.</remarks>
+        public static readonly LText Empty = new();
+
         /// <summary>
         /// Gets or sets the numeric (<see cref="long"/>) key/identifier format to convert to a standardized <see cref="string"/>.
         /// </summary>
@@ -52,15 +58,39 @@ namespace CoreEx.Localization
         public string? KeyAndOrText { get; }
 
         /// <summary>
-        /// Gets or sets the optional fallback text to be used when the <see cref="KeyAndOrText"/> is not found by the <see cref="TextProvider"/> (where not specified that <see cref="KeyAndOrText"/> becomes the fallback text).
+        /// Gets or sets the optional fallback text to be used when the <see cref="KeyAndOrText"/> is not found by the <see cref="TextProvider"/> (where not specified the <see cref="KeyAndOrText"/> becomes the fallback text).
         /// </summary>
         public string? FallbackText { get; set; }
+
+        /// <summary>
+        /// Indicates whether the <see cref="LText"/> is empty; i.e. the <see cref="KeyAndOrText"/> and <see cref="FallbackText"/> are both <c>null</c>.
+        /// </summary>
+        public readonly bool IsEmpty => KeyAndOrText is null && FallbackText is null;
 
         /// <summary>
         /// Returns the <see cref="LText"/> as a <see cref="string"/> (see <see cref="TextProvider"/> <see cref="TextProvider.Current"/> <see cref="TextProviderBase.GetText(LText)"/>).
         /// </summary>
         /// <returns>The <see cref="LText"/> string value.</returns>
         public override readonly string ToString() => this!;
+
+        /// <inheritdoc/>
+        public override readonly bool Equals(object? obj) => obj is LText r && Equals(r);
+
+        /// <inheritdoc/>
+        public readonly bool Equals(LText other) => KeyAndOrText == other.KeyAndOrText && FallbackText == other.FallbackText;
+
+        /// <inheritdoc/>
+        public override readonly int GetHashCode() => HashCode.Combine(KeyAndOrText, FallbackText);
+
+        /// <summary>
+        /// Indicates whether the current <see cref="LText"/> is equal to another <see cref="LText"/>.
+        /// </summary>
+        public static bool operator ==(LText left, LText right) => left.Equals(right);
+
+        /// <summary>
+        /// Indicates whether the current <see cref="LText"/> is not equal to another <see cref="LText"/>.
+        /// </summary>
+        public static bool operator !=(LText left, LText right) => !(left == right);
 
         /// <summary>
         /// An implicit cast from an <see cref="LText"/> to a <see cref="string"/> (see <see cref="TextProvider"/> <see cref="TextProvider.Current"/> <see cref="TextProviderBase.GetText(LText)"/>).
@@ -73,6 +103,6 @@ namespace CoreEx.Localization
         /// An implicit cast from a text <see cref="string"/> to an <see cref="LText"/> value updating the <see cref="KeyAndOrText"/>.
         /// </summary>
         /// <param name="keyAndOrText">The key and/or text.</param>
-        public static implicit operator LText(string keyAndOrText) => new(keyAndOrText);
+        public static implicit operator LText(string keyAndOrText) => keyAndOrText is null ? Empty : new(keyAndOrText);
     }
 }

--- a/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
+++ b/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
@@ -22,19 +22,19 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.2.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Solace.Test/CoreEx.Solace.Test.csproj
+++ b/tests/CoreEx.Solace.Test/CoreEx.Solace.Test.csproj
@@ -13,14 +13,14 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/CoreEx.Test/CoreEx.Test.csproj
+++ b/tests/CoreEx.Test/CoreEx.Test.csproj
@@ -4,25 +4,26 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.2.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Test/Framework/Abstractions/Reflection/PropertyExpressionTest.cs
+++ b/tests/CoreEx.Test/Framework/Abstractions/Reflection/PropertyExpressionTest.cs
@@ -16,6 +16,7 @@ namespace CoreEx.Test.Framework.Abstractions.Reflection
                 Assert.That(pe1.Name, Is.EqualTo("Id"));
                 Assert.That(pe1.JsonName, Is.EqualTo("id"));
                 Assert.That((string)pe1.Text, Is.EqualTo("Identifier"));
+                Assert.That(pe1.Text.KeyAndOrText, Is.EqualTo("CoreEx.Test.Framework.Abstractions.Reflection.Person.Id"));
                 Assert.That(pe1.IsJsonSerializable, Is.True);
             });
 

--- a/tests/CoreEx.Test/Framework/Results/ValidationExtensionsTest.cs
+++ b/tests/CoreEx.Test/Framework/Results/ValidationExtensionsTest.cs
@@ -78,6 +78,7 @@ namespace CoreEx.Test.Framework.Results
         [Test]
         public async Task Validation_Success_Other_Value()
         {
+            1.Validate().Mandatory().CompareValue(CompareOperator.LessThanEqual, 10);
             var r = await Result.Go().ValidatesAsync(1, v => v.Mandatory().CompareValue(CompareOperator.LessThanEqual, 10));
             Assert.That(r.IsSuccess, Is.True);
         }
@@ -88,6 +89,28 @@ namespace CoreEx.Test.Framework.Results
             var id = 88;
             var r = await Result.Go().ValidatesAsync(id, v => v.Mandatory().CompareValue(CompareOperator.LessThanEqual, 10));
             Assert.That(r.Error, Is.Not.Null.And.Message.EqualTo("A data validation error occurred. [id: Identifier must be less than or equal to 10.]"));
+        }
+
+        [Test]
+        public async Task Validation_Success_Other_String()
+        {
+            string? email = "a@b";
+
+            IPropertyRule<ValidationValue<string?>, string> x = email.Validate().Email();
+
+            var r = await Result.Go().ValidatesAsync(email, v => v.Email());
+            Assert.That(r.IsSuccess, Is.True);
+        }
+
+        [Test]
+        public async Task Validation_Success_Other_String2()
+        {
+            string email = "a@b";
+
+            email.Validate().Email();
+
+            var r = await Result.Go(email).ValidatesAsync(email, v => v.Email());
+            Assert.That(r.IsSuccess, Is.True);
         }
 
         [Test]

--- a/tests/CoreEx.Test/Framework/Validation/ValidatorTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/ValidatorTest.cs
@@ -274,7 +274,7 @@ namespace CoreEx.Test.Framework.Validation
 
         public class TestEntity
         {
-            public List<TestItem>? Items { get; set; } = new List<TestItem>();
+            public List<TestItem>? Items { get; set; } = [];
 
             public TestItem? Item { get; set; }
 
@@ -306,11 +306,9 @@ namespace CoreEx.Test.Framework.Validation
 
         }
 
-        public class TestDataString
+        public class TestDataString(string name)
         {
-            public TestDataString(string name) => Name = name;
-
-            public string Name { get; set; }
+            public string Name { get; set; } = name;
         }
 
         [Test]
@@ -412,7 +410,7 @@ namespace CoreEx.Test.Framework.Validation
 
             var type = vxc.GetType();
             var mi = type.GetMethod("ValidateAsync")!;
-            var vc = ((Task<ValidationContext<TestInjectChild>>)mi.Invoke(vxc, new object?[] { context.Value, context.CreateValidationArgs(), System.Threading.CancellationToken.None })!).GetAwaiter().GetResult();
+            var vc = ((Task<ValidationContext<TestInjectChild>>)mi.Invoke(vxc, [context.Value, context.CreateValidationArgs(), System.Threading.CancellationToken.None])!).GetAwaiter().GetResult();
             context.Parent.MergeResult(vc);
             return Result.Success;
         }

--- a/tests/CoreEx.Test2/CoreEx.Test2.csproj
+++ b/tests/CoreEx.Test2/CoreEx.Test2.csproj
@@ -4,19 +4,22 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
+    <LangVersion>preview</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.0.1">
+    <PackageReference Include="NUnit.Analyzers" Version="4.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -24,6 +27,7 @@
     <ProjectReference Include="..\..\src\CoreEx.Azure\CoreEx.Azure.csproj" />
     <ProjectReference Include="..\..\src\CoreEx.UnitTesting.NUnit\CoreEx.UnitTesting.NUnit.csproj" />
     <ProjectReference Include="..\..\src\CoreEx.UnitTesting\CoreEx.UnitTesting.csproj" />
+    <ProjectReference Include="..\..\src\CoreEx.Validation\CoreEx.Validation.csproj" />
     <ProjectReference Include="..\..\src\CoreEx\CoreEx.csproj" />
     <ProjectReference Include="..\CoreEx.TestFunctionIso\CoreEx.TestFunctionIso.csproj" />
   </ItemGroup>

--- a/tests/CoreEx.Test2/Framework/Validation/ValidationExtensionsTest.cs
+++ b/tests/CoreEx.Test2/Framework/Validation/ValidationExtensionsTest.cs
@@ -1,0 +1,35 @@
+﻿using CoreEx.Results;
+using CoreEx.Validation;
+
+namespace CoreEx.Test2.Framework.Validation
+{
+    [TestFixture]
+    public class ValidationExtensionsTest
+    {
+        [Test]
+        public async Task Validation_Success_Other_String()
+        {
+            string? email = "a@b";
+            var r = await Result.Go(email).ValidatesAsync(email, v => v.Email());
+            Assert.That(r.IsSuccess, Is.True);
+        }
+
+        [Test]
+        public async Task Validation_Success_Other_String2()
+        {
+            string? email = "a@b";
+            var r = await ValidateAsync(email);
+            Assert.That(r.IsSuccess, Is.True);
+        }
+
+        private async Task<Result<string>> ValidateAsync(string? email2)
+        {
+            return await Result.Go().ValidatesAsync(email2, v =>
+            {
+                var v2 = v;
+                var v3 = v.Email();
+                return v3;
+            });
+        }
+    }
+}

--- a/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
+++ b/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.16.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- *Fixed*: The `Result.ValidatesAsync` extension method signature has had the value nullability corrected to enable fluent-style method-chaining.
- *Fixed*: The fully qualified type and property name is now correctly used as the `LText.KeyAndOrText` when creating within the `PropertyExpression<TEntity, TProperty>` to enable a qualified _key_ that can be used by the `ITextProvider` to substitute the text at runtime; the existing text fallback behavior remains such that an appropriate text is used. The `PropertyExpression.CreatePropertyLTextKey` function can be overridden to change this behavior.