### PR TITLE
v3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Represents the **NuGet** versions.
 
+## v3.18.0
+- *Fixed*: Removed `Azure.Identity` dependency as no longer required; also see `https://github.com/advisories/GHSA-wvxc-855f-jvrv`.
+- *Fixed*: Removed `AspNetCore.HealthChecks.SqlServer` dependency as no longer required.
+- *Fixed:* Updated all dependencies to latest versions.
+- *Fixed*: `CoreEx.AutoMapper` updated to leverage latest major version (`13.0.1`); as such `netstandard` support dropped.
+- *Fixed*: The `TimerHostedServiceBase` was incorrectly resetting the `LastException` on sleep versus wake. 
+- *Fixed*: The `AddEventSender` dependency injection extension methods now correctly register as _Scoped_.
+- *Fixed*: Reduced `Logger.LogInformation` invocations (refactored to `Logger.LogDebug`) to reduce noise in the logs.
+- *Enhancement*: Added `AfterSend` event to `IEventSender` to enable post-send processing.
+- *Enhancement*: Added `EventOutboxHostedService.OneOffTrigger` method to enable a _one-off_ trigger interval to be specified for the registered (DI) instance.
+
 ## v3.17.0
 - *Enhancement*: Additional `CoreEx.Validation` usability improvements:
   - `Validator.CreateFor<T>` added to enable the creation of a `CommonValidator<T>` instance for a specified type `T` (more purposeful name); synonym for existing `CommonValidator.Create<T>` (unchanged).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@
 Represents the **NuGet** versions.
 
 ## v3.18.0
-- *Fixed*: Removed `Azure.Identity` dependency as no longer required; also see `https://github.com/advisories/GHSA-wvxc-855f-jvrv`.
+- *Fixed*: Removed `Azure.Identity` dependency as no longer required; related to `https://github.com/advisories/GHSA-wvxc-855f-jvrv`.
 - *Fixed*: Removed `AspNetCore.HealthChecks.SqlServer` dependency as no longer required.
 - *Fixed:* Updated all dependencies to latest versions.
-- *Fixed*: `CoreEx.AutoMapper` updated to leverage latest major version (`13.0.1`); as such `netstandard` support dropped.
+- *Fixed*: `CoreEx.AutoMapper` updated to leverage latest major version (`13.0.1`); as such `netstandard` no longer supported.
 - *Fixed*: The `TimerHostedServiceBase` was incorrectly resetting the `LastException` on sleep versus wake. 
 - *Fixed*: The `AddEventSender` dependency injection extension methods now correctly register as _Scoped_.
-- *Fixed*: Reduced `Logger.LogInformation` invocations (refactored to `Logger.LogDebug`) to reduce noise in the logs.
+- *Fixed*: The `Logger.LogInformation` invocations refactored to `Logger.LogDebug` where applicable to reduce noise in the logs.
+- *Fixed*: The `IPropertyRule.ValidateAsync` method removed as it was not required and could lead to incorrect usage.
+- *Fixed:* The `ValueValidator` now only supports a `Configure` method to enable `IPropertyRule`-based configuration (versus directly).
+- *Fixed:* The `CommonValidator.ValidateAsync` is now internal as this was not intended and could lead to incorrect usage.
 - *Enhancement*: Added `AfterSend` event to `IEventSender` to enable post-send processing.
 - *Enhancement*: Added `EventOutboxHostedService.OneOffTrigger` method to enable a _one-off_ trigger interval to be specified for the registered (DI) instance.
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.17.0</Version>
+		<Version>3.18.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
+++ b/samples/My.Hr/My.Hr.Api/My.Hr.Api.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
   </ItemGroup>
   

--- a/src/CoreEx.AutoMapper/CoreEx.AutoMapper.csproj
+++ b/src/CoreEx.AutoMapper/CoreEx.AutoMapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>CoreEx.Mapping</RootNamespace>
     <Product>CoreEx.AutoMapper</Product>
     <Title>CoreEx .NET AutoMapper Extensions.</Title>
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Azure/CoreEx.Azure.csproj
+++ b/src/CoreEx.Azure/CoreEx.Azure.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.4" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusSender.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusSender.cs
@@ -126,7 +126,7 @@ namespace CoreEx.Azure.ServiceBus
 
                         try
                         {
-                            Logger.LogInformation("Sending {Count} message(s) to {Name}.", batch.Count, qn);
+                            Logger.LogDebug("Sending {Count} message(s) to {Name}.", batch.Count, qn);
                             await sender.SendMessagesAsync(batch, cancellationToken).ConfigureAwait(false);
                         }
                         catch (Exception ex)
@@ -139,6 +139,9 @@ namespace CoreEx.Azure.ServiceBus
                         unsentEvents.RemoveAll(esd => sentIds.Contains(esd.Id ?? string.Empty));
                     }
                 }
+
+                // Raise the event.
+                AfterSend?.Invoke(this, EventArgs.Empty);
             }, cancellationToken, nameof(SendAsync));
         }
 
@@ -146,5 +149,8 @@ namespace CoreEx.Azure.ServiceBus
         /// Prepend the sent stats to the message.
         /// </summary>
         private static string PrependStats(string message, int totalCount, int unsentCount) => $"{unsentCount} of the total {totalCount} events were not successfully sent. {message}";
+
+        /// <inheritdoc/>
+        public event EventHandler? AfterSend;
     }
 }

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriber.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriber.cs
@@ -143,7 +143,7 @@ namespace CoreEx.Azure.ServiceBus
 
                 // Invoke the actual function logic.
                 Result.Go(await function(@event!, args, ct).ConfigureAwait(false))
-                      .Then(() => Logger.LogInformation("{Type} executed successfully - Service Bus message '{Message}'.", GetType().Name, message.MessageId))
+                      .Then(() => Logger.LogDebug("{Type} executed successfully - Service Bus message '{Message}'.", GetType().Name, message.MessageId))
                       .ThrowOnError();
 
                 // Perform the complete/success instrumentation.
@@ -234,7 +234,7 @@ namespace CoreEx.Azure.ServiceBus
 
                 // Invoke the actual function logic.
                 Result.Go(await function(@event!, args, ct).ConfigureAwait(false))
-                      .Then(() => Logger.LogInformation("{Type} executed successfully - Service Bus message '{Message}'.", GetType().Name, message.MessageId))
+                      .Then(() => Logger.LogDebug("{Type} executed successfully - Service Bus message '{Message}'.", GetType().Name, message.MessageId))
                       .ThrowOnError();
 
                 // Perform the complete/success instrumentation.

--- a/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
+++ b/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.10" />
   </ItemGroup>
 

--- a/src/CoreEx.Database.SqlServer/CoreEx.Database.SqlServer.csproj
+++ b/src/CoreEx.Database.SqlServer/CoreEx.Database.SqlServer.csproj
@@ -12,8 +12,6 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.0" />
-    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
   </ItemGroup>
 

--- a/src/CoreEx.Database.SqlServer/Outbox/EventOutboxDequeueBase.cs
+++ b/src/CoreEx.Database.SqlServer/Outbox/EventOutboxDequeueBase.cs
@@ -98,13 +98,13 @@ namespace CoreEx.Database.SqlServer.Outbox
                     return 0;
                 }
 
-                Logger.LogInformation("{EventCount} event(s) were dequeued. [Elapsed={Elapsed}ms]", events.Count(), sw.Elapsed.TotalMilliseconds);
+                Logger.LogDebug("{EventCount} event(s) were dequeued. [Elapsed={Elapsed}ms]", events.Count(), sw.Elapsed.TotalMilliseconds);
 
                 // Send the events.
                 sw = Stopwatch.StartNew();
                 await EventSender.SendAsync(events.ToArray(), cancellationToken).ConfigureAwait(false);
                 sw.Stop();
-                Logger.LogInformation("{EventCount} event(s) were sent successfully. [Sender={Sender}, Elapsed={Elapsed}ms]", events.Count(), EventSender.GetType().Name, sw.Elapsed.TotalMilliseconds);
+                Logger.LogDebug("{EventCount} event(s) were sent successfully. [Sender={Sender}, Elapsed={Elapsed}ms]", events.Count(), EventSender.GetType().Name, sw.Elapsed.TotalMilliseconds);
 
                 // Commit the transaction.
                 txn.Complete();

--- a/src/CoreEx.Database.SqlServer/Outbox/EventOutboxEnqueueBase.cs
+++ b/src/CoreEx.Database.SqlServer/Outbox/EventOutboxEnqueueBase.cs
@@ -66,7 +66,7 @@ namespace CoreEx.Database.SqlServer.Outbox
         public string DefaultDestination { get; set; } = "$default";
 
         /// <summary>
-        /// Sets the optional <see cref="IEventSender"/> to act as the primary <see cref="IEventSender"/> where <i>outbox enqueue</i> is to provide backup/audit capabilities.
+        /// Sets the <see cref="IEventSender"/> to act as the primary <see cref="IEventSender"/> where <i>outbox enqueue</i> is to provide backup/audit capabilities.
         /// </summary>
         public void SetPrimaryEventSender(IEventSender eventSender)
         {
@@ -125,6 +125,8 @@ namespace CoreEx.Database.SqlServer.Outbox
             sw.Stop();
             Logger.LogDebug("{EventCount} event(s) were enqueued; {SuccessCount} as sent, {ErrorCount} to be sent. [Sender={Sender}, Elapsed={Elapsed}ms]",
                 events.Count(), events.Count() - unsentEvents.Count, unsentEvents.Count, GetType().Name, sw.Elapsed.TotalMilliseconds);
+
+            AfterSend?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>
@@ -163,5 +165,8 @@ namespace CoreEx.Database.SqlServer.Outbox
 
             return tvp;
         }
+
+        /// <inheritdoc/>
+        public event EventHandler? AfterSend;
     }
 }

--- a/src/CoreEx.EntityFrameworkCore/CoreEx.EntityFrameworkCore.csproj
+++ b/src/CoreEx.EntityFrameworkCore/CoreEx.EntityFrameworkCore.csproj
@@ -13,15 +13,15 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.28" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.29" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.18" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Solace/CoreEx.Solace.csproj
+++ b/src/CoreEx.Solace/CoreEx.Solace.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SolaceSystems.Solclient.Messaging" Version="10.23.0" />
+    <PackageReference Include="SolaceSystems.Solclient.Messaging" Version="10.24.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Solace/PubSub/PubSubSender.cs
+++ b/src/CoreEx.Solace/PubSub/PubSubSender.cs
@@ -159,7 +159,7 @@ namespace CoreEx.Solace.PubSub
 
                         try
                         {
-                            Logger.LogInformation("Sending {Count} message(s) to PubSub Broker.", messageBatch.Count);
+                            Logger.LogDebug("Sending {Count} message(s) to PubSub Broker.", messageBatch.Count);
                             var returnCode = session.Send([.. messageBatch], 0, messageBatch.Count, out int sentCount);
 
                             if (returnCode != ReturnCode.SOLCLIENT_OK)
@@ -174,7 +174,7 @@ namespace CoreEx.Solace.PubSub
                                 throw new InvalidOperationException("Not all messages in batch were sent; only {sentCount} of {messageBatch.Count} were sent.");
                             }
 
-                            Logger.LogInformation("Successful send of {Count} message(s).", messageBatch.Count);
+                            Logger.LogDebug("Successful send of {Count} message(s).", messageBatch.Count);
                         }
                         catch (Exception ex)
                         {
@@ -186,6 +186,9 @@ namespace CoreEx.Solace.PubSub
                         unsentEvents.RemoveAll(esd => sentIds.Contains(esd.Id ?? string.Empty));
                     }
                 }
+
+                // Raise the event.
+                AfterSend?.Invoke(this, EventArgs.Empty);
             }, nameof(SendAsync));
 
             return Task.CompletedTask;
@@ -211,5 +214,8 @@ namespace CoreEx.Solace.PubSub
         /// Prepend the sent stats to the message.
         /// </summary>
         private static string PrependStats(string message, int totalCount, int unsentCount) => $"{unsentCount} of the total {totalCount} events were not successfully sent. {message}";
+
+        /// <inheritdoc/>
+        public event EventHandler? AfterSend;
     }
 }

--- a/src/CoreEx.Validation/CommonValidatorT.cs
+++ b/src/CoreEx.Validation/CommonValidatorT.cs
@@ -9,18 +9,30 @@ using System.Threading.Tasks;
 namespace CoreEx.Validation
 {
     /// <summary>
-    /// Provides a common value rule that can be used by other validators that share the same <see cref="Type"/> being <typeparamref name="T"/>.
+    /// Provides a common value rule that can be used by other validators that share the same <see cref="Type"/> of <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T">The value <see cref="Type"/>.</typeparam>
     /// <remarks>Note: the <see cref="PropertyRuleBase{TEntity, TProperty}.Name"/>, <see cref="PropertyRuleBase{TEntity, TProperty}.JsonName"/> and <see cref="PropertyRuleBase{TEntity, TProperty}.Text"/> initially default to <see cref="Validation.ValueNameDefault"/>.</remarks>
     public class CommonValidator<T> : PropertyRuleBase<ValidationValue<T>, T>, IValidatorEx<T>
     {
         private Func<PropertyContext<ValidationValue<T>, T>, CancellationToken, Task<Result>>? _additionalAsync;
+        private bool _textOverridden;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommonValidator{T}"/>.
         /// </summary>
-        public CommonValidator() : base(Validation.ValueNameDefault) { }
+        public CommonValidator() : base(Validation.ValueNameDefault) => _textOverridden = false;
+
+        /// <inheritdoc/>
+        public override LText Text 
+        { 
+            get => base.Text;
+            set
+            {
+                base.Text = value;
+                _textOverridden = true;
+            }
+        }
 
         /// <summary>
         /// Enables the validator to be further configured.
@@ -31,58 +43,6 @@ namespace CoreEx.Validation
         {
             validator?.Invoke(this);
             return this;
-        }
-
-        /// <inheritdoc/>
-        /// <remarks>This method is <b>not supported</b> and as such will throw a <see cref="NotSupportedException"/>.</remarks>
-        /// <exception cref="NotSupportedException"/>
-        public override Task<ValueValidatorResult<ValidationValue<T>, T>> ValidateAsync(CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("The ValidateAsync(CancellationToken) method is not supported for a CommonValidator<T> as no value has been specified; please use other overloads.");
-
-        /// <summary>
-        /// Validates the value.
-        /// </summary>
-        /// <param name="value">The value to validate.</param>
-        /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
-        /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
-        /// <param name="throwOnError">Indicates to throw a <see cref="ValidationException"/> where an error was found.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
-        public Task<ValueValidatorResult<ValidationValue<T>, T>> ValidateAsync(T? value, string? name = null, LText? text = null, bool throwOnError = false, CancellationToken cancellationToken = default)
-            => ValidateAsync(value, name, name, text, throwOnError, cancellationToken);
-
-        /// <summary>
-        /// Validates the value.
-        /// </summary>
-        /// <param name="value">The value to validate.</param>
-        /// <param name="name">The value name.</param>
-        /// <param name="jsonName">The value JSON name.</param>
-        /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
-        /// <param name="throwOnError">Indicates to throw a <see cref="ValidationException"/> where an error was found.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
-        public async Task<ValueValidatorResult<ValidationValue<T>, T>> ValidateAsync(T? value, string? name, string? jsonName, LText? text = null, bool throwOnError = false, CancellationToken cancellationToken = default)
-        {
-            var vv = new ValidationValue<T>(null, value);
-            var ctx = new PropertyContext<ValidationValue<T>, T>(new ValidationContext<ValidationValue<T>>(vv,
-                new ValidationArgs()), value, name ?? Name, jsonName ?? JsonName, text ?? name.ToSentenceCase() ?? Text);
-
-            await InvokeAsync(ctx, cancellationToken).ConfigureAwait(false);
-            var res = new ValueValidatorResult<ValidationValue<T>, T>(ctx);
-
-            if (ctx.Parent.FailureResult is null)
-            {
-                var result = await OnValidateAsync(ctx, cancellationToken).ConfigureAwait(false);
-                if (result.IsSuccess && _additionalAsync != null)
-                    result = await _additionalAsync(ctx, cancellationToken).ConfigureAwait(false);
-
-                ctx.Parent.SetFailureResult(result);
-            }
-
-            if (throwOnError)
-                res.ThrowOnError();
-
-            return res;
         }
 
         /// <summary>
@@ -103,7 +63,7 @@ namespace CoreEx.Validation
                 UseJsonNames = context.UseJsonName
             });
 
-            var ctx = new PropertyContext<ValidationValue<T>, T>(vc, context.Value, context.Name, context.JsonName, context.Text);
+            var ctx = new PropertyContext<ValidationValue<T>, T>(vc, context.Value, context.Name, context.JsonName, _textOverridden ? Text : context.Text);
             await InvokeAsync(ctx, cancellationToken).ConfigureAwait(false);
 
             await (ctx.Parent.FailureResult ?? Result.Success)
@@ -146,6 +106,40 @@ namespace CoreEx.Validation
             var ir = await ValidateAsync(value, context.FullyQualifiedEntityName, context.FullyQualifiedEntityName, Text, cancellationToken: cancellationToken).ConfigureAwait(false);
             context.MergeResult(ir.Messages);
             return context;
+        }
+
+        /// <summary>
+        /// Validates the value.
+        /// </summary>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="name">The value name.</param>
+        /// <param name="jsonName">The value JSON name.</param>
+        /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
+        /// <param name="throwOnError">Indicates to throw a <see cref="ValidationException"/> where an error was found.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
+        private async Task<ValueValidatorResult<ValidationValue<T>, T>> ValidateAsync(T? value, string? name, string? jsonName, LText? text = null, bool throwOnError = false, CancellationToken cancellationToken = default)
+        {
+            var vv = new ValidationValue<T>(null, value);
+            var ctx = new PropertyContext<ValidationValue<T>, T>(new ValidationContext<ValidationValue<T>>(vv,
+                new ValidationArgs()), value, name ?? Name, jsonName ?? JsonName, text ?? name.ToSentenceCase() ?? Text);
+
+            await InvokeAsync(ctx, cancellationToken).ConfigureAwait(false);
+            var res = new ValueValidatorResult<ValidationValue<T>, T>(ctx);
+
+            if (ctx.Parent.FailureResult is null)
+            {
+                var result = await OnValidateAsync(ctx, cancellationToken).ConfigureAwait(false);
+                if (result.IsSuccess && _additionalAsync != null)
+                    result = await _additionalAsync(ctx, cancellationToken).ConfigureAwait(false);
+
+                ctx.Parent.SetFailureResult(result);
+            }
+
+            if (throwOnError)
+                res.ThrowOnError();
+
+            return res;
         }
     }
 }

--- a/src/CoreEx.Validation/IPropertyRule.cs
+++ b/src/CoreEx.Validation/IPropertyRule.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using CoreEx.Localization;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace CoreEx.Validation
 {
@@ -31,26 +28,5 @@ namespace CoreEx.Validation
         /// Gets or sets the error message format text (overrides the default) used for all validation errors.
         /// </summary>
         public LText? ErrorText { get; set; }
-
-        /// <summary>
-        /// Executes the validation for the property value.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
-        /// <remarks>This may not be supported by all implementations; in which case a <see cref="NotSupportedException"/> may be thrown.</remarks>
-        Task<IValidationResult> ValidateAsync(CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Executes the validation for the property value.
-        /// </summary>
-        /// <param name="throwOnError">Indicates whether to automatically throw a <see cref="ValidationException"/> where <see cref="IValidationResult.HasErrors"/>.</param>
-        /// <param name="cancellationToken">>The <see cref="CancellationToken"/>.</param>
-        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
-        /// <remarks>This may not be supported by all implementations; in which case a <see cref="NotSupportedException"/> may be thrown.</remarks>
-        public async Task<IValidationResult> ValidateAsync(bool throwOnError, CancellationToken cancellationToken = default)
-        {
-            var ir = await ValidateAsync(cancellationToken).ConfigureAwait(false);
-            return throwOnError ? ir.ThrowOnError() : ir;
-        }
     }
 }

--- a/src/CoreEx.Validation/PropertyRule.cs
+++ b/src/CoreEx.Validation/PropertyRule.cs
@@ -77,10 +77,5 @@ namespace CoreEx.Validation
 
         /// <inheritdoc/>
         Task IValueRule<TEntity, TProperty>.ValidateAsync(IPropertyContext<TEntity, TProperty> context, CancellationToken cancellationToken) => throw new NotSupportedException("A property value validation should not occur directly on a PropertyRule.");
-
-        /// <inheritdoc/>
-        /// <remarks>This method is <b>not supported</b> and as such will throw a <see cref="NotSupportedException"/>.</remarks>
-        /// <exception cref="NotSupportedException"/>
-        public override Task<ValueValidatorResult<TEntity, TProperty>> ValidateAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException("The ValidateAsync method is not supported for a PropertyRule<TEntity, TProperty>.");
     }
 }

--- a/src/CoreEx.Validation/PropertyRuleBase.cs
+++ b/src/CoreEx.Validation/PropertyRuleBase.cs
@@ -41,10 +41,10 @@ namespace CoreEx.Validation
         public string JsonName { get; internal set; }
 
         /// <inheritdoc/>
-        public LText Text { get; set; }
+        public virtual LText Text { get; set; }
 
         /// <inheritdoc/>
-        public LText? ErrorText { get; set; }
+        public virtual LText? ErrorText { get; set; }
 
         /// <inheritdoc/>
         IPropertyRule<TEntity, TProperty> IPropertyRule<TEntity, TProperty>.WithMessage(LText errorText)
@@ -74,7 +74,7 @@ namespace CoreEx.Validation
         }
 
         /// <summary>
-        /// Adds a clause (<see cref="IPropertyRuleClause{TEntity, TProperty}"/>) to the rule.
+        /// Adds a clause (<see cref="IPropertyRuleClause{TEntity, TProperty}"/>) to the last rule added.
         /// </summary>
         /// <param name="clause">The <see cref="IPropertyRuleClause{TEntity, TProperty}"/>.</param>
         public void AddClause(IPropertyRuleClause<TEntity> clause)
@@ -115,15 +115,5 @@ namespace CoreEx.Validation
                     break;
             }
         }
-
-        /// <summary>
-        /// Executes the validation for the property value.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>A <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
-        public abstract Task<ValueValidatorResult<TEntity, TProperty>> ValidateAsync(CancellationToken cancellationToken = default);
-
-        /// <inheritdoc/>
-        async Task<IValidationResult> IPropertyRule.ValidateAsync(CancellationToken cancellationToken) => await ValidateAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/CoreEx.Validation/ValidationExtensions.cs
+++ b/src/CoreEx.Validation/ValidationExtensions.cs
@@ -1577,7 +1577,31 @@ namespace CoreEx.Validation
         /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
-        public static ValueValidator<T?> Validate<T>(this T? value, string? name = null, LText? text = null) => new(value, name, text);
+        public static ValueValidator<T> Validate<T>(this T value, string? name = null, LText? text = null) => new(value, name, text);
+
+        /// <summary>
+        /// Enables (sets up) validation for a value.
+        /// </summary>
+        /// <typeparam name="T">The value <see cref="Type"/>.</typeparam>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="configure">The value validation configuration logic.</param>
+        /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
+        /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
+        /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
+        public static ValueValidator<T> Validate<T>(this T value, Action<ValueValidatorConfiguration<T>> configure, string? name = null, LText? text = null) 
+            => new ValueValidator<T>(value, name, text).Configure(configure);
+
+        /// <summary>
+        /// Enables (sets up) validation for a value.
+        /// </summary>
+        /// <typeparam name="T">The value <see cref="Type"/>.</typeparam>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="validator">The <see cref="CommonValidator{T}"/>.</param>
+        /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
+        /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
+        /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
+        public static ValueValidator<T> Validate<T>(this T value, CommonValidator<T> validator, string? name = null, LText? text = null)
+            => new ValueValidator<T>(value, name, text).Configure(c => c.Common(validator));
 #else
         /// <summary>
         /// Enables (sets up) validation for a value.
@@ -1587,42 +1611,32 @@ namespace CoreEx.Validation
         /// <param name="name">The value name (defaults to <paramref name="value"/> name using the <see cref="CallerArgumentExpressionAttribute"/>).</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
-        public static ValueValidator<T?> Validate<T>(this T? value, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null) => new(value, name, text);
+        public static ValueValidator<T> Validate<T>(this T value, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null) => new(value, name, text);
+
+        /// <summary>
+        /// Enables (sets up) validation for a value.
+        /// </summary>
+        /// <typeparam name="T">The value <see cref="Type"/>.</typeparam>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="configure">The value validation configuration logic.</param>
+        /// <param name="name">The value name (defaults to <paramref name="value"/> name using the <see cref="CallerArgumentExpressionAttribute"/>).</param>
+        /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
+        /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
+        public static ValueValidator<T> Validate<T>(this T value, Action<ValueValidatorConfiguration<T>> configure, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null) 
+            => new ValueValidator<T>(value, name, text).Configure(configure);
+
+        /// <summary>
+        /// Enables (sets up) validation for a value.
+        /// </summary>
+        /// <typeparam name="T">The value <see cref="Type"/>.</typeparam>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="validator">The <see cref="CommonValidator{T}"/>.</param>
+        /// <param name="name">The value name (defaults to <paramref name="value"/> name using the <see cref="CallerArgumentExpressionAttribute"/>).</param>
+        /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
+        /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
+        public static ValueValidator<T> Validate<T>(this T value, CommonValidator<T> validator, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null)
+            => new ValueValidator<T>(value, name, text).Configure(c => c.Common(validator));
 #endif
-
-        #endregion
-
-        #region As
-
-        /// <summary>
-        /// Cast the <paramref name="rule"/> to the originating <see cref="CommonValidator{T}"/>.
-        /// </summary>
-        /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TProperty">The property <see cref="Type"/>.</typeparam>
-        /// <param name="rule">The <see cref="IPropertyRule{TEntity, TProperty}"/> being extended.</param>
-        /// <returns>The <paramref name="rule"/> cast to a <see cref="CommonValidator{T}"/>; otherwise, throws an <see cref="InvalidCastException"/>.</returns>
-        public static CommonValidator<TProperty> AsCommonValidator<TEntity, TProperty>(this IPropertyRule<TEntity, TProperty> rule) where TEntity : class
-            => rule is CommonValidator<TProperty> cv ? cv : throw new InvalidCastException("The rule is not an instance of CommonValidator<TEntity>.");
-
-        /// <summary>
-        /// Cast the <paramref name="rule"/> to the originating <see cref="ValueValidator{T}"/>.
-        /// </summary>
-        /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TProperty">The property <see cref="Type"/>.</typeparam>
-        /// <param name="rule">The <see cref="IPropertyRule{TEntity, TProperty}"/> being extended.</param>
-        /// <returns>The <paramref name="rule"/> cast to a <see cref="ValueValidator{T}"/>; otherwise, throws an <see cref="InvalidCastException"/>.</returns>
-        public static ValueValidator<TProperty> AsValueValidator<TEntity, TProperty>(this IPropertyRule<TEntity, TProperty> rule) where TEntity : class
-            => rule is ValueValidator<TProperty> vv ? vv : throw new InvalidCastException("The rule is not an instance of ValueValidator<TProperty>.");
-
-        /// <summary>
-        /// Cast the <paramref name="rule"/> to the originating <see cref="ValidatorBase{TEntity}"/>.
-        /// </summary>
-        /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
-        /// <typeparam name="TProperty">The property <see cref="Type"/>.</typeparam>
-        /// <param name="rule">The <see cref="IPropertyRule{TEntity, TProperty}"/> being extended.</param>
-        /// <returns>The <paramref name="rule"/> cast to a <see cref="ValidatorBase{TEntity}"/>; otherwise, throws an <see cref="InvalidCastException"/>.</returns>
-        public static ValidatorBase<TEntity> AsValidator<TEntity, TProperty>(this IPropertyRule<TEntity, TProperty> rule) where TEntity : class
-            => rule is ValidatorBase<TEntity> vb ? vb : throw new InvalidCastException("The rule is not an instance of ValidatorBase<TEntity>.");
 
         #endregion
 
@@ -1642,20 +1656,6 @@ namespace CoreEx.Validation
             return multiValidator;
         }
 
-        /// <summary>
-        /// Adds a <see cref="IPropertyRule{TEntity, TProperty}"/> to the <see cref="MultiValidator"/>. 
-        /// </summary>
-        /// <typeparam name="T">The value <see cref="Type"/>.</typeparam>
-        /// <param name="multiValidator">The <see cref="MultiValidator"/>.</param>
-        /// <param name="validator">The <see cref="PropertyRuleBase{TEntity, TProperty}"/> <see cref="ValueValidator{T}"/>.</param>
-        /// <returns>The (this) <see cref="MultiValidator"/>.</returns>
-        public static MultiValidator Add<T>(this MultiValidator multiValidator, IPropertyRule<ValidationValue<T>, T> validator)
-        {
-            validator.ThrowIfNull(nameof(validator));
-            multiValidator.ThrowIfNull(nameof(multiValidator)).Validators.Add(validator.ValidateAsync);
-            return multiValidator;
-        }
-
         #endregion
 
         #region Result
@@ -1667,18 +1667,19 @@ namespace CoreEx.Validation
         /// <param name="result">The <see cref="Result{T}"/>.</param>
         /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
-        /// <param name="validator">The <see cref="IPropertyRule{TEntity, TProperty}"/> configuration function.</param>
+        /// <param name="validator">The <see cref="ValueValidatorConfiguration{T}"/> function.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="Result{T}"/>.</returns>
         /// <remarks>Where <see cref="IValidationResult.HasErrors"/> the corresponding <see cref="IResult.Error"/> will be updated with the <see cref="IValidationResult.ToException"/>.</remarks>
-        public static async Task<Result<TEntity>> ValidateAsync<TEntity>(this Result<TEntity> result, Func<IPropertyRule<ValidationValue<TEntity?>, TEntity?>, IPropertyRule<ValidationValue<TEntity?>, TEntity?>> validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default)
+        public static async Task<Result<TEntity>> ValidateAsync<TEntity>(this Result<TEntity> result, Action<ValueValidatorConfiguration<TEntity>>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default)
         {
             validator.ThrowIfNull(nameof(validator));
 
             return await result.ThenAsync(async v =>
             {
-                var vi = validator(v.Validate(name, text)) ?? throw new InvalidOperationException($"The {nameof(validator)} function must return a non-null instance to perform the requested validation.");
-                var vr = await vi.ValidateAsync(cancellationToken).ConfigureAwait(false);
+                var vv = v.Validate(name, text);
+                vv.Configure(c => validator(c));
+                var vr = await vv.ValidateAsync(cancellationToken).ConfigureAwait(false);
                 return vr.ToResult<TEntity>();
             });
         }
@@ -1690,18 +1691,19 @@ namespace CoreEx.Validation
         /// <param name="result">The <see cref="Result{T}"/>.</param>
         /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
-        /// <param name="validator">The <see cref="IPropertyRule{TEntity, TProperty}"/> configuration function.</param>
+        /// <param name="validator">The <see cref="ValueValidatorConfiguration{T}"/> function.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="Result{T}"/>.</returns>
         /// <remarks>Where <see cref="IValidationResult.HasErrors"/> the corresponding <see cref="IResult.Error"/> will be updated with the <see cref="IValidationResult.ToException"/>.</remarks>
-        public static async Task<Result<TEntity>> ValidateAsync<TEntity>(this Task<Result<TEntity>> result, Func<IPropertyRule<ValidationValue<TEntity?>, TEntity?>, IPropertyRule<ValidationValue<TEntity?>, TEntity?>> validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default)
+        public static async Task<Result<TEntity>> ValidateAsync<TEntity>(this Task<Result<TEntity>> result, Action<ValueValidatorConfiguration<TEntity>>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default)
         {
             validator.ThrowIfNull(nameof(validator));
 
             return await result.ThenAsync(async v =>
             {
-                var vi = validator(v.Validate(name, text)) ?? throw new InvalidOperationException($"The {nameof(validator)} function must return a non-null instance to perform the requested validation.");
-                var vr = await vi.ValidateAsync(cancellationToken).ConfigureAwait(false);
+                var vv = v.Validate(name, text);
+                vv.Configure(c => validator(c));
+                var vr = await vv.ValidateAsync(cancellationToken).ConfigureAwait(false);
                 return vr.ToResult<TEntity>();
             });
         }
@@ -1714,13 +1716,13 @@ namespace CoreEx.Validation
         /// <typeparam name="T">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
         /// <param name="result">The <see cref="IResult"/>.</param>
         /// <param name="value">The value to validate.</param>
-        /// <param name="validator">The <see cref="IPropertyRule{TEntity, TProperty}"/> configuration function.</param>
+        /// <param name="validator">The <see cref="ValueValidatorConfiguration{T}"/>.</param>
         /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
         /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T>, IPropertyRule>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Action<ValueValidatorConfiguration<T>>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #else
         /// <summary>
         /// Executes the <paramref name="validator"/> for the specified <paramref name="value"/> where the <paramref name="result"/> is <see cref="Result.IsSuccess"/>.
@@ -1729,20 +1731,21 @@ namespace CoreEx.Validation
         /// <typeparam name="T">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
         /// <param name="result">The <see cref="IResult"/>.</param>
         /// <param name="value">The value to validate.</param>
-        /// <param name="validator">The <see cref="IPropertyRule{TEntity, TProperty}"/> configuration function.</param>
+        /// <param name="validator">The <see cref="ValueValidatorConfiguration{T}"/>.</param>
         /// <param name="name">The value name (defaults to <paramref name="value"/> name using the <see cref="CallerArgumentExpressionAttribute"/>).</param>
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
         /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Func<IPropertyRule<ValidationValue<T?>, T>, IPropertyRule>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this TResult result, T value, Action<ValueValidatorConfiguration<T>>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #endif
         {
             if (validator is null || result.IsFailure)
                 return result;
 
-            var vi = validator(value.Validate(name, text)) ?? throw new InvalidOperationException($"The {nameof(validator)} function must return a non-null instance to perform the requested validation.");
-            var vr = await vi.ValidateAsync(cancellationToken).ConfigureAwait(false);
+            var vv = value.Validate(name, text);
+            vv.Configure(c => validator(c));
+            var vr = await vv.ValidateAsync(cancellationToken).ConfigureAwait(false);
             return vr.HasErrors ? (TResult)result.ToFailure(vr.ToException()!) : result;           
         }
 
@@ -1754,13 +1757,13 @@ namespace CoreEx.Validation
         /// <typeparam name="T">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
         /// <param name="result">The <see cref="IResult"/>.</param>
         /// <param name="value">The value to validate.</param>
-        /// <param name="validator">The <see cref="IPropertyRule{TEntity, TProperty}"/> configuration function.</param>
+        /// <param name="validator">The <see cref="ValueValidatorConfiguration{T}"/>.</param>
         /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
         /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T>, IPropertyRule>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Action<ValueValidatorConfiguration<T>>? validator, string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #else
         /// <summary>
         /// Executes the <paramref name="validator"/> for the specified <paramref name="value"/> where the <paramref name="result"/> is <see cref="Result.IsSuccess"/>.
@@ -1769,21 +1772,22 @@ namespace CoreEx.Validation
         /// <typeparam name="T">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
         /// <param name="result">The <see cref="IResult"/>.</param>
         /// <param name="value">The value to validate.</param>
-        /// <param name="validator">The <see cref="IPropertyRule{TEntity, TProperty}"/> configuration function.</param>
+        /// <param name="validator">The <see cref="ValueValidatorConfiguration{T}"/>.</param>
         /// <param name="name">The value name (defaults to <paramref name="value"/> name using the <see cref="CallerArgumentExpressionAttribute"/>).</param>
         /// <param name="text">The <see cref="LText"/> to use for the <see cref="IValidationResult"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The resulting <see cref="IResult"/>.</returns>
         /// <remarks>Validation only occurs where the <paramref name="validator"/> is not <c>null</c>; otherwise, continues as expected.</remarks>
-        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Func<IPropertyRule<ValidationValue<T?>, T>, IPropertyRule>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
+        public static async Task<TResult> ValidatesAsync<TResult, T>(this Task<TResult> result, T value, Action<ValueValidatorConfiguration<T>>? validator, [CallerArgumentExpression(nameof(value))] string? name = default, LText? text = default, CancellationToken cancellationToken = default) where TResult : IResult
 #endif
         {
             var r = await result.ConfigureAwait(false);
             if (validator is null || r.IsFailure)
                 return r;
 
-            var vi = validator(value.Validate(name, text)) ?? throw new InvalidOperationException($"The {nameof(validator)} function must return a non-null instance to perform the requested validation.");
-            var vr = await vi.ValidateAsync(cancellationToken).ConfigureAwait(false);
+            var vv = value.Validate(name, text);
+            vv.Configure(c => validator(c));
+            var vr = await vv.ValidateAsync(cancellationToken).ConfigureAwait(false);
             return vr.HasErrors ? (TResult)r.ToFailure(vr.ToException()!) : r;
         }
 

--- a/src/CoreEx.Validation/ValueValidationConfiguration.cs
+++ b/src/CoreEx.Validation/ValueValidationConfiguration.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Localization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CoreEx.Validation
+{
+    /// <summary>
+    /// Enables the ability to configure the <see cref="ValueValidator{T}"/>.
+    /// </summary>
+    public class ValueValidatorConfiguration<T> : PropertyRuleBase<ValidationValue<T>, T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueValidatorConfiguration{T}"/> class.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as <see cref="Text.SentenceCase.ToSentenceCase(string)"/>).</param>
+        /// <param name="jsonName">The JSON property name (defaults to <paramref name="name"/>).</param>
+        internal ValueValidatorConfiguration(string name, LText? text = null, string? jsonName = null) : base(name, text, jsonName) { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="validationValue">The <see cref="ValidationValue{T}"/>.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
+        /// <returns>The <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
+        internal Task<ValueValidatorResult<ValidationValue<T>, T>> ValidateAsync(ValidationValue<T> validationValue, CancellationToken cancellationToken)
+        {
+            return ValidationInvoker.Current.InvokeAsync(this, async (_, cancellationToken) =>
+            {
+                var ctx = new PropertyContext<ValidationValue<T>, T>(new ValidationContext<ValidationValue<T>>(validationValue, new ValidationArgs()), validationValue.Value, Name, JsonName, Text);
+                await InvokeAsync(ctx, cancellationToken).ConfigureAwait(false);
+                return new ValueValidatorResult<ValidationValue<T>, T>(ctx);
+            }, cancellationToken);
+        }
+    }
+}

--- a/src/CoreEx/Abstractions/IServiceCollectionExtensions.cs
+++ b/src/CoreEx/Abstractions/IServiceCollectionExtensions.cs
@@ -168,26 +168,40 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddEventPublisher<TEventPublisher>(this IServiceCollection services) where TEventPublisher : class, IEventPublisher => CheckServices(services).AddScoped<IEventPublisher, TEventPublisher>();
 
         /// <summary>
-        /// Adds the <see cref="LoggerEventSender"/> as the <see cref="IEventSender"/> singleton service.
+        /// Adds the <see cref="LoggerEventSender"/> as the <see cref="IEventSender"/> scoped service.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
         public static IServiceCollection AddLoggerEventSender(this IServiceCollection services) => CheckServices(services).AddEventSender<LoggerEventSender>();
 
         /// <summary>
-        /// Adds the <see cref="NullEventSender"/> as the <see cref="IEventSender"/> singleton service.
+        /// Adds the <see cref="NullEventSender"/> as the <see cref="IEventSender"/> scoped service.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
         public static IServiceCollection AddNullEventSender(this IServiceCollection services) => CheckServices(services).AddEventSender<NullEventSender>();
 
         /// <summary>
-        /// Adds the <typeparamref name="TEventSender"/> as the <see cref="IEventSender"/> singleton service.
+        /// Adds the <typeparamref name="TEventSender"/> as the <see cref="IEventSender"/> scoped service.
         /// </summary>
         /// <typeparam name="TEventSender">The <see cref="IEventSender"/> <see cref="Type"/>.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
-        public static IServiceCollection AddEventSender<TEventSender>(this IServiceCollection services) where TEventSender : class, IEventSender => CheckServices(services).AddSingleton<IEventSender, TEventSender>();
+        public static IServiceCollection AddEventSender<TEventSender>(this IServiceCollection services) where TEventSender : class, IEventSender => CheckServices(services).AddScoped<IEventSender, TEventSender>();
+
+        /// <summary>
+        /// Adds the <typeparamref name="TEventSender"/> as the <see cref="IEventSender"/> scoped service.
+        /// </summary>
+        /// <typeparam name="TEventSender">The <see cref="IEventSender"/> <see cref="Type"/>.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <param name="configure">The action to enable the <see cref="IEventSender"/> to be further configured.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection AddEventSender<TEventSender>(this IServiceCollection services, Action<IServiceProvider, TEventSender> configure) where TEventSender : class, IEventSender => CheckServices(services).AddScoped<IEventSender>(sp =>
+        {
+            var sender = ActivatorUtilities.CreateInstance<TEventSender>(sp);
+            configure(sp, sender);
+            return sender;
+        });
 
         /// <summary>
         /// Adds the <see cref="EventSubscriberOrchestrator"/> as a singleton service.

--- a/src/CoreEx/CoreEx.csproj
+++ b/src/CoreEx/CoreEx.csproj
@@ -15,7 +15,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
@@ -28,7 +28,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.18" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
@@ -41,7 +41,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.28" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.29" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />

--- a/src/CoreEx/Events/IEventSender.cs
+++ b/src/CoreEx/Events/IEventSender.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,5 +20,10 @@ namespace CoreEx.Events
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The <see cref="Task"/>.</returns>
         Task SendAsync(IEnumerable<EventSendData> events, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Occurs after a successful <see cref="SendAsync"/>.
+        /// </summary>
+        event EventHandler? AfterSend;
     }
 }

--- a/src/CoreEx/Events/InMemorySender.cs
+++ b/src/CoreEx/Events/InMemorySender.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,6 +20,7 @@ namespace CoreEx.Events
         public Task SendAsync(IEnumerable<EventSendData> events, CancellationToken cancellationToken = default)
         {
             events.ForEach(_queue.Enqueue);
+            AfterSend?.Invoke(this, EventArgs.Empty);
             return Task.CompletedTask;
         }
 
@@ -31,5 +33,8 @@ namespace CoreEx.Events
         /// Resets (clears) the in-memory state.
         /// </summary>
         public void Reset() => _queue.Clear();
+
+        /// <inheritdoc/>
+        public event EventHandler? AfterSend;
     }
 }

--- a/src/CoreEx/Events/LoggerEventSender.cs
+++ b/src/CoreEx/Events/LoggerEventSender.cs
@@ -40,7 +40,11 @@ namespace CoreEx.Events
                 i++;
             }
 
+            AfterSend?.Invoke(this, EventArgs.Empty);
             return Task.CompletedTask;
         }
+
+        /// <inheritdoc/>
+        public event EventHandler? AfterSend;
     }
 }

--- a/src/CoreEx/Events/NullEventSender.cs
+++ b/src/CoreEx/Events/NullEventSender.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +13,13 @@ namespace CoreEx.Events
     public class NullEventSender : IEventSender
     {
         /// <inheritdoc/>
-        public Task SendAsync(IEnumerable<EventSendData> events, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task SendAsync(IEnumerable<EventSendData> events, CancellationToken cancellationToken = default)
+        {
+            AfterSend?.Invoke(this, EventArgs.Empty);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public event EventHandler? AfterSend;
     }
 }

--- a/src/CoreEx/Validation/Validation.cs
+++ b/src/CoreEx/Validation/Validation.cs
@@ -34,26 +34,11 @@ namespace CoreEx.Validation
         public static LText ValueTextDefault { get; set; } = "Value";
 
         /// <summary>
-        /// Validates the value asynchronously using the specified <paramref name="validator"/>.
-        /// </summary>
-        /// <typeparam name="T">The underlying value <see cref="Type"/>.</typeparam>
-        /// <param name="value">The value to validate.</param>
-        /// <param name="validator">The corresponding <see cref="IValidator{T}"/>.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        /// <returns>The validated value.</returns>
-        /// <exception cref="ValidationException">Thrown where a validation error(s) occurs.</exception>
-        public static async Task<T?> ValidateValueAsync<T>(this T value, IValidator<T> validator, CancellationToken cancellationToken = default) where T : class
-        {
-            (await (validator.ThrowIfNull(nameof(validator))).ValidateAsync(value, cancellationToken).ConfigureAwait(false)).ThrowOnError();
-            return value;
-        }
-
-        /// <summary>
         /// Validates (requires) that the <paramref name="value"/> is non-default and continues; otherwise, will throw a <see cref="ValidationException"/>.
         /// </summary>
         /// <typeparam name="T">The <paramref name="value"/> <see cref="Type"/>.</typeparam>
         /// <param name="value">The value to validate.</param>
-        /// <param name="name">The value name (defaults to <see cref="ValueNameDefault"/>).</param>
+        /// <param name="name">The value name.</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>The value where non-default.</returns>
         /// <exception cref="ValidationException">Thrown where the value is default.</exception>
@@ -84,7 +69,6 @@ namespace CoreEx.Validation
 
             return result;
         }
-
 
 #if NETSTANDARD2_1
         /// <summary>

--- a/tests/CoreEx.Test/Framework/FluentValidation/ServiceCollectionTest.cs
+++ b/tests/CoreEx.Test/Framework/FluentValidation/ServiceCollectionTest.cs
@@ -98,10 +98,10 @@ namespace CoreEx.Test.Framework.FluentValidation
 
             var sp = sc.BuildServiceProvider();
 
-            var rs = await new Product().Validate().Mandatory().Interop(FluentValidator.Create<ProductValidator>(sp).Wrap()).ValidateAsync();
+            var rs = await new Product().Validate().Configure(c => c.Mandatory().Interop(FluentValidator.Create<ProductValidator>(sp).Wrap())).ValidateAsync();
             Assert.That(rs.HasErrors, Is.True);
 
-            rs = await new Product { Id = "XXX", Name = "Blah", Price = 1.5m }.Validate().Mandatory().Interop(FluentValidator.Create<ProductValidator>(sp).Wrap()).ValidateAsync();
+            rs = await new Product { Id = "XXX", Name = "Blah", Price = 1.5m }.Validate(c => c.Mandatory().Interop(FluentValidator.Create<ProductValidator>(sp).Wrap())).ValidateAsync();
             Assert.That(rs.HasErrors, Is.False);
         }
 
@@ -113,10 +113,10 @@ namespace CoreEx.Test.Framework.FluentValidation
 
             var sp = sc.BuildServiceProvider();
 
-            var rs = await new Product().Validate().Mandatory().Interop(FluentValidator.Create<ProductValidator>(sp).Wrap()).ValidateAsync();
+            var rs = await new Product().Validate().Configure(c => c.Mandatory().Interop(FluentValidator.Create<ProductValidator>(sp).Wrap())).ValidateAsync();
             Assert.That(rs.HasErrors, Is.True);
 
-            rs = await new Product { Id = "XXX", Name = "Blah", Price = 1.5m }.Validate().Mandatory().Interop(() => FluentValidator.Create<ProductValidator>(sp).Wrap()).ValidateAsync();
+            rs = await new Product { Id = "XXX", Name = "Blah", Price = 1.5m }.Validate().Configure(c => c.Mandatory().Interop(() => FluentValidator.Create<ProductValidator>(sp).Wrap())).ValidateAsync();
             Assert.That(rs.HasErrors, Is.False);
         }
     }

--- a/tests/CoreEx.Test/Framework/RefData/ReferenceDataTest.cs
+++ b/tests/CoreEx.Test/Framework/RefData/ReferenceDataTest.cs
@@ -933,14 +933,14 @@ namespace CoreEx.Test.Framework.RefData
             var sw = Stopwatch.StartNew();
             await ReferenceDataOrchestrator.Current.PrefetchAsync(new string[] { "RefData", "RefDataEx" }).ConfigureAwait(false);
             sw.Stop();
-            Assert.That(sw.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(500));
+            Assert.That(sw.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(480));
 
             sw = Stopwatch.StartNew();
             var c = await ReferenceDataOrchestrator.Current.GetByTypeAsync<RefData>();
             sw.Stop();
             Assert.Multiple(() =>
             {
-                Assert.That(sw.ElapsedMilliseconds, Is.LessThan(500));
+                Assert.That(sw.ElapsedMilliseconds, Is.LessThan(520));
                 Assert.That(c, Is.Not.Null);
                 Assert.That(c!.ContainsCode("A"), Is.True);
             });
@@ -950,7 +950,7 @@ namespace CoreEx.Test.Framework.RefData
             sw.Stop();
             Assert.Multiple(() =>
             {
-                Assert.That(sw.ElapsedMilliseconds, Is.LessThan(500));
+                Assert.That(sw.ElapsedMilliseconds, Is.LessThan(520));
                 Assert.That(c, Is.Not.Null);
                 Assert.That(c!.ContainsId("BB"), Is.True);
             });

--- a/tests/CoreEx.Test/Framework/Results/ValidationExtensionsTest.cs
+++ b/tests/CoreEx.Test/Framework/Results/ValidationExtensionsTest.cs
@@ -78,7 +78,6 @@ namespace CoreEx.Test.Framework.Results
         [Test]
         public async Task Validation_Success_Other_Value()
         {
-            1.Validate().Mandatory().CompareValue(CompareOperator.LessThanEqual, 10);
             var r = await Result.Go().ValidatesAsync(1, v => v.Mandatory().CompareValue(CompareOperator.LessThanEqual, 10));
             Assert.That(r.IsSuccess, Is.True);
         }
@@ -95,9 +94,6 @@ namespace CoreEx.Test.Framework.Results
         public async Task Validation_Success_Other_String()
         {
             string? email = "a@b";
-
-            IPropertyRule<ValidationValue<string?>, string> x = email.Validate().Email();
-
             var r = await Result.Go().ValidatesAsync(email, v => v.Email());
             Assert.That(r.IsSuccess, Is.True);
         }
@@ -106,9 +102,6 @@ namespace CoreEx.Test.Framework.Results
         public async Task Validation_Success_Other_String2()
         {
             string email = "a@b";
-
-            email.Validate().Email();
-
             var r = await Result.Go(email).ValidatesAsync(email, v => v.Email());
             Assert.That(r.IsSuccess, Is.True);
         }
@@ -124,7 +117,7 @@ namespace CoreEx.Test.Framework.Results
                 return Result.Go(value)
                     .Required()
                     .Then(v => v.Id = id)
-                    .ThenAsync(v => v.Validate().Entity(_personValidator).ValidateAsync());
+                    .ThenAsync(v => v.Validate().Configure(c => c.Entity(_personValidator)).ValidateAsync());
             });
 
             Assert.That(r.IsSuccess, Is.True);
@@ -134,7 +127,7 @@ namespace CoreEx.Test.Framework.Results
         public async Task Validation_MultiValidator_Success()
         {
             var value = new Person { Name = "Tom", Age = 18 };
-            var r = await Result.Go().ValidateAsync(() => MultiValidator.Create().Add(value.Validate().Mandatory().Entity(_personValidator)));
+            var r = await Result.Go().ValidateAsync(() => MultiValidator.Create().Add(value.Validate().Configure(c => c.Mandatory().Entity(_personValidator))));
             Assert.That(r.IsSuccess, Is.True);
         }
 
@@ -142,7 +135,7 @@ namespace CoreEx.Test.Framework.Results
         public async Task Validation_MultiValidator_Failure()
         {
             var value = new Person { Name = "Tom" };
-            var r = await Result.Go().ValidateAsync(() => MultiValidator.Create().Add(value.Validate().Mandatory().Entity(_personValidator)));
+            var r = await Result.Go().ValidateAsync(() => MultiValidator.Create().Add(value.Validate().Configure(c => c.Mandatory().Entity(_personValidator))));
             Assert.That(r.Error, Is.Not.Null.And.Message.EqualTo("A data validation error occurred. [value.Age: Age must be greater than 0.]"));
         }
 
@@ -150,7 +143,7 @@ namespace CoreEx.Test.Framework.Results
         public async Task Validation_MultiValidator_Value_Success()
         {
             var value = new Person { Name = "Tom", Age = 18 };
-            var r = await Result.Go(value).ValidateAsync(p => MultiValidator.Create().Add(p.Validate().Mandatory().Entity(_personValidator)));
+            var r = await Result.Go(value).ValidateAsync(p => MultiValidator.Create().Add(p.Validate().Configure(c => c.Mandatory().Entity(_personValidator))));
             Assert.That(r.IsSuccess, Is.True);
         }
 
@@ -158,7 +151,7 @@ namespace CoreEx.Test.Framework.Results
         public async Task Validation_MultiValidator_Value_Failure()
         {
             var value = new Person { Name = "Tom" };
-            var r = await Result.Go(value).ValidateAsync(_ => MultiValidator.Create().Add(value.Validate().Mandatory().Entity(_personValidator)));
+            var r = await Result.Go(value).ValidateAsync(_ => MultiValidator.Create().Add(value.Validate().Configure(c => c.Mandatory().Entity(_personValidator))));
             Assert.That(r.Error, Is.Not.Null.And.Message.EqualTo("A data validation error occurred. [value.Age: Age must be greater than 0.]"));
         }
 

--- a/tests/CoreEx.Test/Framework/Validation/Clauses/DependsOnClauseTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Clauses/DependsOnClauseTest.cs
@@ -18,7 +18,7 @@ namespace CoreEx.Test.Framework.Validation.Clauses
                 .HasProperty(x => x.CountA, p => p.Between(1, 10).DependsOn(x => x.Text));
 
             var td = new TestData { Text = null, CountA = 88 };
-            var v1 = await td.Validate("value").Entity(v).ValidateAsync();
+            var v1 = await td.Validate("value").Configure(c => c.Entity(v)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -27,7 +27,7 @@ namespace CoreEx.Test.Framework.Validation.Clauses
             });
 
             td = new TestData { Text = "xxx", CountA = 88 };
-            v1 = await td.Validate("value").Entity(v).ValidateAsync();
+            v1 = await td.Validate("value").Configure(c => c.Entity(v)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -36,7 +36,7 @@ namespace CoreEx.Test.Framework.Validation.Clauses
             });
 
             td = new TestData { Text = "xxx", CountA = 5 };
-            v1 = await td.Validate("value").Entity(v).ValidateAsync();
+            v1 = await td.Validate("value").Configure(c => c.Entity(v)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
     }

--- a/tests/CoreEx.Test/Framework/Validation/Clauses/WhenClauseTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Clauses/WhenClauseTest.cs
@@ -13,22 +13,22 @@ namespace CoreEx.Test.Framework.Validation.Clauses
         [Test]
         public async Task When()
         {
-            var v1 = await 1.Validate().Between(2, 10).When(true).ValidateAsync();
+            var v1 = await 1.Validate(c => c.Between(2, 10).When(true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await 1.Validate().Between(2, 10).When(false).ValidateAsync();
+            v1 = await 1.Validate(c => c.Between(2, 10).When(false)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate().Between(2, 10).When(() => true).ValidateAsync();
+            v1 = await 1.Validate(c => c.Between(2, 10).When(() => true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await 1.Validate().Between(2, 10).When(() => false).ValidateAsync();
+            v1 = await 1.Validate(c => c.Between(2, 10).When(() => false)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate().Between(2, 10).When(x => x.Value == 1).ValidateAsync();
+            v1 = await 1.Validate(c => c.Between(2, 10).When(x => x.Value == 1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await 1.Validate().Between(2, 10).When(x => x.Value != 1).ValidateAsync();
+            v1 = await 1.Validate(c => c.Between(2, 10).When(x => x.Value != 1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             var v = Validator.Create<TestData>()
@@ -36,21 +36,21 @@ namespace CoreEx.Test.Framework.Validation.Clauses
                 .HasProperty(x => x.CountA, p => p.Between(1, 10).When(x => x.Text == "xxx"));
 
             var td = new TestData { Text = "xxx", CountA = 88 };
-            var v2 = await td.Validate().Entity(v).ValidateAsync();
+            var v2 = await td.Validate().Configure(c => c.Entity(v)).ValidateAsync();
             Assert.That(v2.HasErrors, Is.True);
 
             td = new TestData { Text = "yyy", CountA = 88 };
-            v2 = await td.Validate().Entity(v).ValidateAsync();
+            v2 = await td.Validate().Configure(c => c.Entity(v)).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
         }
 
         [Test]
         public async Task WhenValue()
         {
-            var v1 = await 1.Validate().Between(2, 10).WhenValue(v => v == 1).ValidateAsync();
+            var v1 = await 1.Validate(c => c.Between(2, 10).WhenValue(v => v == 1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await 1.Validate().Between(2, 10).WhenValue(v => v == 2).ValidateAsync();
+            v1 = await 1.Validate(c => c.Between(2, 10).WhenValue(v => v == 2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             var v = Validator.Create<TestData>()
@@ -58,21 +58,21 @@ namespace CoreEx.Test.Framework.Validation.Clauses
                 .HasProperty(x => x.CountA, p => p.Between(1, 10).WhenValue(v => v == 88));
 
             var td = new TestData { Text = "xxx", CountA = 88 };
-            var v2 = await td.Validate().Entity(v).ValidateAsync();
+            var v2 = await td.Validate().Configure(c => c.Entity(v)).ValidateAsync();
             Assert.That(v2.HasErrors, Is.True);
 
             td = new TestData { Text = "xxx", CountA = 99 };
-            v2 = await td.Validate().Entity(v).ValidateAsync();
+            v2 = await td.Validate().Configure(c => c.Entity(v)).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
         }
 
         [Test]
         public async Task WhenHasValue()
         {
-            var v1 = await 1.Validate().Immutable().WhenHasValue().ValidateAsync();
+            var v1 = await 1.Validate(c => c.Immutable().WhenHasValue()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await 0.Validate().Immutable().WhenHasValue().ValidateAsync();
+            v1 = await 0.Validate(c => c.Immutable().WhenHasValue()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
@@ -81,10 +81,10 @@ namespace CoreEx.Test.Framework.Validation.Clauses
         {
             ExecutionContext.Current.OperationType = OperationType.Update;
 
-            var v1 = await 1.Validate().Immutable().WhenOperation(OperationType.Update).ValidateAsync();
+            var v1 = await 1.Validate(c => c.Immutable().WhenOperation(OperationType.Update)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await 1.Validate().Immutable().WhenOperation(OperationType.Create).ValidateAsync();
+            v1 = await 1.Validate(c => c.Immutable().WhenOperation(OperationType.Create)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
@@ -93,10 +93,10 @@ namespace CoreEx.Test.Framework.Validation.Clauses
         {
             ExecutionContext.Current.OperationType = OperationType.Update;
 
-            var v1 = await 1.Validate().Immutable().WhenNotOperation(OperationType.Create).ValidateAsync();
+            var v1 = await 1.Validate(c => c.Immutable().WhenNotOperation(OperationType.Create)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await 1.Validate().Immutable().WhenNotOperation(OperationType.Update).ValidateAsync();
+            v1 = await 1.Validate(c => c.Immutable().WhenNotOperation(OperationType.Update)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
     }

--- a/tests/CoreEx.Test/Framework/Validation/CommonValidatorTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/CommonValidatorTest.cs
@@ -13,13 +13,13 @@ namespace CoreEx.Test.Framework.Validation
         [OneTimeSetUp]
         public void OneTimeSetUp() => CoreEx.Localization.TextProvider.SetTextProvider(new ValidationTextProvider());
 
-        private static readonly CommonValidator<string> _cv = Validator.CreateFor<string>(v => v.String(5).Must(x => x.Value != "XXXXX"));
+        private static readonly CommonValidator<string?> _cv = Validator.CreateFor<string?>(v => v.String(5).Must(x => x.Value != "XXXXX"));
         private static readonly CommonValidator<int?> _cv2 = Validator.CreateFor<int?>(v => v.Mandatory().CompareValue(CompareOperator.NotEqual, 1));
 
         [Test]
         public async Task Validate()
         {
-            var r = await _cv.ValidateAsync("XXXXXX");
+            var r = await "XXXXXX".Validate(_cv, null).ValidateAsync();
             Assert.That(r, Is.Not.Null);
             Assert.Multiple(() =>
             {
@@ -30,7 +30,7 @@ namespace CoreEx.Test.Framework.Validation
                 Assert.That(r.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            r = await _cv.ValidateAsync("XXXXX", "Name");
+            r = await "XXXXX".Validate(_cv, "Name").ValidateAsync();
             Assert.That(r, Is.Not.Null);
             Assert.Multiple(() =>
             {
@@ -41,7 +41,7 @@ namespace CoreEx.Test.Framework.Validation
                 Assert.That(r.Messages[0].Property, Is.EqualTo("Name"));
             });
 
-            r = await _cv.ValidateAsync("XXX", "Name");
+            r = await "XXX".Validate(_cv, "Name").ValidateAsync();
             Assert.That(r, Is.Not.Null);
             Assert.That(r.HasErrors, Is.False);
         }
@@ -89,7 +89,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Validate_Nullable()
         {
             int? v = 1;
-            var r = await _cv2.ValidateAsync(v);
+            var r = await v.Validate(_cv2, null).ValidateAsync();
             Assert.That(r, Is.Not.Null);
             Assert.Multiple(() =>
             {
@@ -122,8 +122,8 @@ namespace CoreEx.Test.Framework.Validation
         [Test]
         public async Task Common_FailureResult_ViaAdditional()
         {
-            var cv = Validator.CreateFor<string>(v => v.String(5)).AdditionalAsync((c, _) => Task.FromResult(Result.NotFoundError()));
-            var r = await cv.ValidateAsync("abc");
+            var cv = Validator.CreateFor<string?>(v => v.String(5)).AdditionalAsync((c, _) => Task.FromResult(Result.NotFoundError()));
+            var r = await "abc".Validate(cv).ValidateAsync();
 
             Assert.That(r, Is.Not.Null);
             Assert.Multiple(() =>
@@ -139,7 +139,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Common_FailureResult_ViaCustom()
         {
             var cv = CommonValidator.Create<string>(v => v.String(5).Custom(ctx => Result.NotFoundError()));
-            var r = await cv.ValidateAsync("abc");
+            var r = await "abc".Validate(cv).ValidateAsync();
 
             Assert.That(r, Is.Not.Null);
             Assert.Multiple(() =>
@@ -173,7 +173,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task CreateFor()
         {
             var cv = Validator.CreateFor<string>().Configure(v => v.MaximumLength(5));
-            var r = await cv.ValidateAsync("abcdef");
+            var r = await "abcdef".Validate(cv, null).ValidateAsync();
 
             Assert.That(r, Is.Not.Null);
             Assert.Multiple(() =>
@@ -208,7 +208,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Inherited_Basic()
         {
             var iv = new IntValidator();
-            var vr = await iv.ValidateAsync(8);
+            var vr = await 8.Validate(iv, null).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(vr.HasErrors, Is.True);
@@ -222,13 +222,13 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Inherited_Basic2()
         {
             var iv = new IntValidator();
-            var vr = await iv.ValidateAsync(28);
+            var vr = await 28.Validate(iv, "length").ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(vr.HasErrors, Is.True);
                 Assert.That(vr.Messages!, Has.Count.EqualTo(1));
                 Assert.That(vr.Messages![0].Text, Is.EqualTo("Count must be less than or equal to 20."));
-                Assert.That(vr.Messages[0].Property, Is.EqualTo("value"));
+                Assert.That(vr.Messages[0].Property, Is.EqualTo("length"));
             });
         }
 
@@ -236,7 +236,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Inherited_OnValidate()
         {
             var iv = new IntValidator();
-            var vr = await iv.ValidateAsync(11);
+            var vr = await 11.Validate(iv, null).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(vr.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/MultiValidatorTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/MultiValidatorTest.cs
@@ -20,7 +20,7 @@ namespace CoreEx.Test.Framework.Validation
 
             var r = await MultiValidator.Create()
                 .Add(v1, new TestData { CountB = 0 })
-                .Add(1.Validate("value").Between(10, 20))
+                .Add(1.Validate("value").Configure(c => c.Between(10, 20)))
                 .ValidateAsync().ConfigureAwait(false);
             
             Assert.That(r, Is.Not.Null);
@@ -52,8 +52,8 @@ namespace CoreEx.Test.Framework.Validation
                 .HasProperty(x => x.CountB, p => p.Mandatory().CompareValue(CompareOperator.GreaterThan, 10));
 
             var r = await MultiValidator.Create()
-                .Add(new TestData { CountB = 0 }.Validate("value").Entity(v1))
-                .Add(1.Validate("id").Between(10, 20))
+                .Add(new TestData { CountB = 0 }.Validate("value").Configure(c => c.Entity(v1)))
+                .Add(1.Validate("id").Configure(c => c.Between(10, 20)))
                 .ValidateAsync().ConfigureAwait(false);
 
             Assert.That(r, Is.Not.Null);
@@ -87,8 +87,8 @@ namespace CoreEx.Test.Framework.Validation
                 .HasProperty(x => x.CountB, p => p.Mandatory().CompareValue(CompareOperator.GreaterThan, 10));
 
             var r = await MultiValidator.Create()
-                .Add(new TestData { Text = "XXXXXXXXXX", CountB = 11 }.Validate("value").Entity(v1))
-                .Add(15.Validate("id").Between(10, 20))
+                .Add(new TestData { Text = "XXXXXXXXXX", CountB = 11 }.Validate("value").Configure(c => c.Entity(v1)))
+                .Add(15.Validate("id").Configure(c => c.Between(10, 20)))
                 .ValidateAsync().ConfigureAwait(false);
 
             Assert.That(r, Is.Not.Null);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/BetweenRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/BetweenRuleTest.cs
@@ -14,13 +14,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate()
         {
-            var v1 = await 1.Validate("value").Between(1, 10).ValidateAsync();
+            var v1 = await 1.Validate("value").Configure(c => c.Between(1, 10)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 5.Validate("value").Between(1, 10).ValidateAsync();
+            v1 = await 5.Validate("value").Configure(c => c.Between(1, 10)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").Between(2, 10).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.Between(2, 10)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -30,10 +30,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 10.Validate("value").Between(1, 10).ValidateAsync();
+            v1 = await 10.Validate("value").Configure(c => c.Between(1, 10)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 11.Validate("value").Between(1, 10, "One", "Ten").ValidateAsync();
+            v1 = await 11.Validate("value").Configure(c => c.Between(1, 10, "One", "Ten")).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -43,13 +43,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 2.Validate("value").Between(1, 10, exclusiveBetween: true).ValidateAsync();
+            v1 = await 2.Validate("value").Configure(c => c.Between(1, 10, exclusiveBetween: true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 5.Validate("value").Between(1, 10, exclusiveBetween: true).ValidateAsync();
+            v1 = await 5.Validate("value").Configure(c => c.Between(1, 10, exclusiveBetween: true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").Between(1, 10, exclusiveBetween: true).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.Between(1, 10, exclusiveBetween: true)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -59,10 +59,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 9.Validate("value").Between(1, 10, exclusiveBetween: true).ValidateAsync();
+            v1 = await 9.Validate("value").Configure(c => c.Between(1, 10, exclusiveBetween: true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 10.Validate("value").Between(1, 10, "One", "Ten", exclusiveBetween: true).ValidateAsync();
+            v1 = await 10.Validate("value").Configure(c => c.Between(1, 10, "One", "Ten", exclusiveBetween: true)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -77,7 +77,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         public async Task Validate_Nullable()
         {
             int? v = null;
-            var v1 = await v.Validate("value").Between(1, 10).ValidateAsync();
+            var v1 = await v.Validate("value").Configure(c => c.Between(1, 10)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -88,15 +88,15 @@ namespace CoreEx.Test.Framework.Validation.Rules
             });
 
             v = 1;
-            v1 = await v.Validate("value").Between(1, 10).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(1, 10)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             v = 5;
-            v1 = await v.Validate("value").Between(1, 10).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(1, 10)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             v = 1;
-            v1 = await v.Validate("value").Between(2, 10).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(2, 10)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -107,11 +107,11 @@ namespace CoreEx.Test.Framework.Validation.Rules
             });
 
             v = 10;
-            v1 = await v.Validate("value").Between(1, 10).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(1, 10)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             v = 11;
-            v1 = await v.Validate("value").Between(1, 10, "One", "Ten").ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(1, 10, "One", "Ten")).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -122,15 +122,15 @@ namespace CoreEx.Test.Framework.Validation.Rules
             });
 
             v = 2;
-            v1 = await v.Validate("value").Between(1, 10, exclusiveBetween: true).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(1, 10, exclusiveBetween: true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             v = 5;
-            v1 = await v.Validate("value").Between(1, 10, exclusiveBetween: true).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(1, 10, exclusiveBetween: true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             v = 1;
-            v1 = await v.Validate("value").Between(1, 10, exclusiveBetween: true).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(1, 10, exclusiveBetween: true)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -141,11 +141,11 @@ namespace CoreEx.Test.Framework.Validation.Rules
             });
 
             v = 9;
-            v1 = await v.Validate("value").Between(1, 10, exclusiveBetween: true).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(1, 10, exclusiveBetween: true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             v = 10;
-            v1 = await v.Validate("value").Between(1, 10, "One", "Ten", exclusiveBetween: true).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.Between(1, 10, "One", "Ten", exclusiveBetween: true)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -159,7 +159,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_InclusiveBetween()
         {
-            var v1 = await 1.Validate("value").InclusiveBetween(2, 10).ValidateAsync();
+            var v1 = await 1.Validate("value").Configure(c => c.InclusiveBetween(2, 10)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -169,14 +169,14 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 10.Validate("value").InclusiveBetween(1, 10).ValidateAsync();
+            v1 = await 10.Validate("value").Configure(c => c.InclusiveBetween(1, 10)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task Validate_ExclusiveBetween()
         {
-            var v1 = await 2.Validate("value").ExclusiveBetween(2, 10).ValidateAsync();
+            var v1 = await 2.Validate("value").Configure(c => c.ExclusiveBetween(2, 10)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -186,7 +186,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 9.Validate("value").ExclusiveBetween(1, 10).ValidateAsync();
+            v1 = await 9.Validate("value").Configure(c => c.ExclusiveBetween(1, 10)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
     }

--- a/tests/CoreEx.Test/Framework/Validation/Rules/CollectionRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/CollectionRuleTest.cs
@@ -18,7 +18,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Errors()
         {
-            var v1 = await new int[] { 1 }.Validate("value").Collection(2).ValidateAsync();
+            var v1 = await new int[] { 1 }.Validate("value").Configure(c => c.Collection(2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -28,10 +28,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await new int[] { 1 }.Validate("value").Collection(1).ValidateAsync();
+            v1 = await new int[] { 1 }.Validate("value").Configure(c => c.Collection(1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new int[] { 1, 2, 3 }.Validate("value").Collection(maxCount: 2).ValidateAsync();
+            v1 = await new int[] { 1, 2, 3 }.Validate("value").Configure(c => c.Collection(maxCount: 2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -41,13 +41,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await new int[] { 1, 2 }.Validate("value").Collection(maxCount: 2).ValidateAsync();
+            v1 = await new int[] { 1, 2 }.Validate("value").Configure(c => c.Collection(maxCount: 2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await ((int[]?)null).Validate("value").Collection(1).ValidateAsync();
+            v1 = await ((int[]?)null).Validate("value").Configure(c => c.Collection(1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await Array.Empty<int>().Validate("value").Collection(1).ValidateAsync();
+            v1 = await Array.Empty<int>().Validate("value").Configure(c => c.Collection(1)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -57,14 +57,14 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await new int[] { 1, 2, 3 }.Validate("value").Collection().ValidateAsync();
+            v1 = await new int[] { 1, 2, 3 }.Validate("value").Configure(c => c.Collection()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task Validate_MinCount()
         {
-            var v1 = await new List<int> { 1 }.Validate("value").Collection(2).ValidateAsync();
+            var v1 = await new List<int> { 1 }.Validate("value").Configure(c => c.Collection(2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -80,10 +80,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         {
             var iv = Validator.Create<TestItem>().HasProperty(x => x.Id, p => p.Mandatory());
 
-            var v1 = await Array.Empty<TestItem>().Validate("value").Collection(item: CollectionRuleItem.Create(iv)).ValidateAsync();
+            var v1 = await Array.Empty<TestItem>().Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new TestItem[] { new() }.Validate("value").Collection(item: CollectionRuleItem.Create(iv)).ValidateAsync();
+            v1 = await new TestItem[] { new() }.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -99,10 +99,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         {
             var iv = Validator.CreateFor<int>(r => r.Text("Number").CompareValue(CompareOperator.LessThanEqual, 5));
 
-            var v1 = await new int[] { 1, 2, 3, 4, 5 }.Validate("value").Collection(item: CollectionRuleItem.Create(iv)).ValidateAsync();
+            var v1 = await new int[] { 1, 2, 3, 4, 5 }.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new int[] { 6, 2, 3, 4, 5 }.Validate("value").Collection(item: CollectionRuleItem.Create(iv)).ValidateAsync();
+            v1 = await new int[] { 6, 2, 3, 4, 5 }.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -118,10 +118,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         {
             var iv = Validator.CreateFor<int>(r => r.Text("Number").LessThanOrEqualTo(5));
 
-            var v1 = await new int[] { 1, 2, 3, 4, 5 }.Validate("value").Collection(iv).ValidateAsync();
+            var v1 = await new int[] { 1, 2, 3, 4, 5 }.Validate("value").Configure(c => c.Collection(iv)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new int[] { 6, 2, 3, 4, 5 }.Validate("value").Collection(iv).ValidateAsync();
+            v1 = await new int[] { 6, 2, 3, 4, 5 }.Validate("value").Configure(c => c.Collection(iv)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -135,10 +135,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Item_Null()
         {
-            var v1 = await new List<TestItem?> { new() }.Validate("value").Collection().ValidateAsync();
+            var v1 = await new List<TestItem?> { new() }.Validate("value").Configure(c => c.Collection()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new List<TestItem?>() { null }.Validate("value").Collection().ValidateAsync();
+            v1 = await new List<TestItem?>() { null }.Validate("value").Configure(c => c.Collection()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -148,7 +148,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await new List<TestItem?> { null }.Validate("value").Collection(allowNullItems: true).ValidateAsync();
+            v1 = await new List<TestItem?> { null }.Validate("value").Configure(c => c.Collection(allowNullItems: true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
@@ -157,16 +157,16 @@ namespace CoreEx.Test.Framework.Validation.Rules
         {
             var iv = Validator.Create<TestItem>().HasProperty(x => x.Id, p => p.Mandatory());
 
-            var v1 = await Array.Empty<TestItem>().Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(x => x.Id)).ValidateAsync();
+            var v1 = await Array.Empty<TestItem>().Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(x => x.Id))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             var tis = new TestItem[] { new() { Id = "ABC", Text = "Abc" }, new() { Id = "DEF", Text = "Def" }, new() { Id = "GHI", Text = "Ghi" } };
 
-            v1 = await tis.Validate("value").Collection(item:  CollectionRuleItem.Create(iv).DuplicateCheck(x => x.Id)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(x => x.Id))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             tis[2].Id = "ABC";
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(x => x.Id)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(x => x.Id))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -182,16 +182,16 @@ namespace CoreEx.Test.Framework.Validation.Rules
         {
             var iv = Validator.Create<TestItem2>().HasProperty(x => x.Part1, p => p.Mandatory()).HasProperty(x => x.Part2, p => p.Mandatory());
 
-            var v1 = await Array.Empty<TestItem2>().Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck()).ValidateAsync();
+            var v1 = await Array.Empty<TestItem2>().Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck())).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             var tis = new TestItem2[] { new() { Part1 = "ABC", Part2 = 1, Text = "Abc" }, new() { Part1 = "DEF", Part2 = 1, Text = "Def" }, new() { Part1 = "GHI", Part2 = 1, Text = "Ghi" } };
 
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck()).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck())).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             tis[2].Part1 = "ABC";
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck()).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck())).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -207,16 +207,16 @@ namespace CoreEx.Test.Framework.Validation.Rules
         {
             var iv = Validator.Create<TestItem>().HasProperty(x => x.Id, p => p.Mandatory());
 
-            var v1 = await Array.Empty<TestItem>().Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(true)).ValidateAsync();
+            var v1 = await Array.Empty<TestItem>().Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(true))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             var tis = new TestItem[] { new() { Id = "ABC", Text = "Abc" }, new() { Id = "DEF", Text = "Def" }, new() { Id = "GHI", Text = "Ghi" } };
 
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(true)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(true))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             tis[2].Id = "ABC";
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(true)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create(iv).DuplicateCheck(true))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -230,16 +230,16 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Item_Duplicates_Identifier2()
         {
-            var v1 = await Array.Empty<TestItem3>().Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
+            var v1 = await Array.Empty<TestItem3>().Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             var tis = new TestItem3[] { new() { Id = 1.ToGuid() }, new() { Id = 2.ToGuid() }, new() { Id = 3.ToGuid() } };
 
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             tis[2].Id = 1.ToGuid();
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -250,23 +250,23 @@ namespace CoreEx.Test.Framework.Validation.Rules
             });
 
             tis[2].Id = Guid.Empty;
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task Validate_Item_Duplicates_IgnoreInitial()
         {
-            var v1 = await Array.Empty<TestItem3>().Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
+            var v1 = await Array.Empty<TestItem3>().Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             var tis = new TestItem3[] { new() { Id = Guid.Empty }, new() { Id = 2.ToGuid() }, new() { Id = Guid.Empty } };
 
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             tis[2].Id = 2.ToGuid();
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -277,17 +277,17 @@ namespace CoreEx.Test.Framework.Validation.Rules
             });
 
             tis[2].Id = Guid.Empty;
-            v1 = await tis.Validate("value").Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true)).ValidateAsync();
+            v1 = await tis.Validate("value").Configure(c => c.Collection(item: CollectionRuleItem.Create<TestItem3>().DuplicateCheck(true))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task Validate_Ints_MinCount()
         {
-            var v1 = await new int[] { 1, 2, 3, 4 }.Validate(name: "Array").MinimumCount(4).ValidateAsync();
+            var v1 = await new int[] { 1, 2, 3, 4 }.Validate(name: "Array").Configure(c => c.MinimumCount(4)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new int[] { 1, 2, 3, 4 }.Validate(name: "Array").MinimumCount(5).ValidateAsync();
+            v1 = await new int[] { 1, 2, 3, 4 }.Validate(name: "Array").Configure(c => c.MinimumCount(5)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -301,10 +301,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Ints2_MaxCount()
         {
-            var v1 = await new int[] { 1, 2, 3, 4 }.Validate(name: "Array").MaximumCount(5).ValidateAsync();
+            var v1 = await new int[] { 1, 2, 3, 4 }.Validate(name: "Array").Configure(c => c.MaximumCount(5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new int[] { 1, 2, 3, 4 }.Validate(name: "Array").MaximumCount(3).ValidateAsync();
+            v1 = await new int[] { 1, 2, 3, 4 }.Validate(name: "Array").Configure(c => c.MaximumCount(3)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/CompareValueRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/CompareValueRuleTest.cs
@@ -14,10 +14,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate()
         {
-            var v1 = await 1.Validate("value").CompareValue(CompareOperator.Equal, 1).ValidateAsync();
+            var v1 = await 1.Validate("value").Configure(c => c.CompareValue(CompareOperator.Equal, 1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").CompareValue(CompareOperator.Equal, 2).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.CompareValue(CompareOperator.Equal, 2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -27,10 +27,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 1.Validate("value").CompareValue(CompareOperator.GreaterThan, 0).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.CompareValue(CompareOperator.GreaterThan, 0)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").CompareValue(CompareOperator.GreaterThan, 2, "Two").ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.CompareValue(CompareOperator.GreaterThan, 2, "Two")).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -45,10 +45,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         public async Task Validate_Nullable()
         {
             int? v = 1;
-            var v1 = await v.Validate("value").CompareValue(CompareOperator.Equal, 1).ValidateAsync();
+            var v1 = await v.Validate("value").Configure(c => c.CompareValue(CompareOperator.Equal, 1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await v.Validate("value").CompareValue(CompareOperator.Equal, 2).ValidateAsync();
+            v1 = await v.Validate("value").Configure(c => c.CompareValue(CompareOperator.Equal, 2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -62,10 +62,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Equal()
         {
-            var v1 = await 1.Validate("value").Equal(1).ValidateAsync();
+            var v1 = await 1.Validate("value").Configure(c => c.Equal(1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").Equal(2).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.Equal(2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -79,10 +79,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_NotEqual()
         {
-            var v1 = await 1.Validate("value").NotEqual(2).ValidateAsync();
+            var v1 = await 1.Validate("value").Configure(c => c.NotEqual(2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").NotEqual(1).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.NotEqual(1)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -96,10 +96,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_LessThan()
         {
-            var v1 = await 1.Validate("value").LessThan(2).ValidateAsync();
+            var v1 = await 1.Validate("value").Configure(c => c.LessThan(2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").LessThan(1).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.LessThan(1)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -113,10 +113,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_LessThanOrEqualTo()
         {
-            var v1 = await 1.Validate("value").LessThanOrEqualTo(1).ValidateAsync();
+            var v1 = await 1.Validate("value").Configure(c => c.LessThanOrEqualTo(1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 2.Validate("value").LessThanOrEqualTo(1).ValidateAsync();
+            v1 = await 2.Validate("value").Configure(c => c.LessThanOrEqualTo(1)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -130,10 +130,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_GreaterThan()
         {
-            var v1 = await 2.Validate("value").GreaterThan(1).ValidateAsync();
+            var v1 = await 2.Validate("value").Configure(c => c.GreaterThan(1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").GreaterThan(2).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.GreaterThan(2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -147,10 +147,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_GreaterThanOrEqualTo()
         {
-            var v1 = await 2.Validate("value").GreaterThanOrEqualTo(2).ValidateAsync();
+            var v1 = await 2.Validate("value").Configure(c => c.GreaterThanOrEqualTo(2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").GreaterThanOrEqualTo(2).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.GreaterThanOrEqualTo(2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/CompareValuesRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/CompareValuesRuleTest.cs
@@ -14,10 +14,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate()
         {
-            var v1 = await 1.Validate("value").CompareValues(new int[] { 1, 2 }).ValidateAsync();
+            var v1 = await 1.Validate("value").Configure(c => c.CompareValues(new int[] { 1, 2 })).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 1.Validate("value").CompareValues(new int[] { 2, 3 }).ValidateAsync();
+            v1 = await 1.Validate("value").Configure(c => c.CompareValues(new int[] { 2, 3 })).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -31,10 +31,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_String()
         {
-            var v1 = await "A".Validate("value").CompareValues(new string[] { "A", "B" }).ValidateAsync();
+            var v1 = await "A".Validate("value").Configure(c => c.CompareValues(new string[] { "A", "B" })).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "C".Validate("value").CompareValues(new string[] { "A", "B" }).ValidateAsync();
+            v1 = await "C".Validate("value").Configure(c => c.CompareValues(new string[] { "A", "B" })).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -44,7 +44,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await "a".Validate("value").CompareValues(new string[] { "A", "B" }, true).ValidateAsync();
+            v1 = await "a".Validate("value").Configure(c => c.CompareValues(new string[] { "A", "B" }, true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 

--- a/tests/CoreEx.Test/Framework/Validation/Rules/CustomRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/CustomRuleTest.cs
@@ -15,7 +15,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate()
         {
-            var v1 = await "Abc".Validate("value").Custom(x => { x.CreateErrorMessage("Test"); return Result.Success; }).ValidateAsync();
+            var v1 = await "Abc".Validate("value").Configure(c => c.Custom(x => { x.CreateErrorMessage("Test"); return Result.Success; })).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/DecimalRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/DecimalRuleTest.cs
@@ -15,10 +15,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_AllowNegatives()
         {
-            var v1 = await (123).Validate("value").Numeric().ValidateAsync();
+            var v1 = await (123).Validate("value").Configure(c => c.Numeric()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (-123).Validate("value").Numeric().ValidateAsync();
+            v1 = await (-123).Validate("value").Configure(c => c.Numeric()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -28,13 +28,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await (-123).Validate("value").Numeric(true).ValidateAsync();
+            v1 = await (-123).Validate("value").Configure(c => c.Numeric(true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            var v2 = await (123m).Validate("value").Numeric().ValidateAsync();
+            var v2 = await (123m).Validate("value").Configure(c => c.Numeric()).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
 
-            v2 = await (-123m).Validate("value").Numeric().ValidateAsync();
+            v2 = await (-123m).Validate("value").Configure(c => c.Numeric()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v2.HasErrors, Is.True);
@@ -44,20 +44,20 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v2.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v2 = await (-123m).Validate("value").Numeric(true).ValidateAsync();
+            v2 = await (-123m).Validate("value").Configure(c => c.Numeric(true)).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
         }
 
         [Test]
         public async Task Validate_MaxDigits()
         {
-            var v1 = await (123).Validate("value").Numeric(maxDigits: 5).ValidateAsync();
+            var v1 = await (123).Validate("value").Configure(c => c.Numeric(maxDigits: 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (12345).Validate("value").Numeric(maxDigits: 5).ValidateAsync();
+            v1 = await (12345).Validate("value").Configure(c => c.Numeric(maxDigits: 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (123456).Validate("value").Numeric(maxDigits: 5).ValidateAsync();
+            v1 = await (123456).Validate("value").Configure(c => c.Numeric(maxDigits: 5)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -67,13 +67,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            var v2 = await (12.34m).Validate("value").Numeric(maxDigits: 5).ValidateAsync();
+            var v2 = await (12.34m).Validate("value").Configure(c => c.Numeric(maxDigits: 5)).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
 
-            v2 = await (12.345m).Validate("value").Numeric(maxDigits: 5).ValidateAsync();
+            v2 = await (12.345m).Validate("value").Configure(c => c.Numeric(maxDigits: 5)).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
 
-            v2 = await (1.23456m).Validate("value").Numeric(maxDigits: 5).ValidateAsync();
+            v2 = await (1.23456m).Validate("value").Configure(c => c.Numeric(maxDigits: 5)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v2.HasErrors, Is.True);
@@ -87,13 +87,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_DecimalPlaces()
         {
-            var v1 = await (12.3m).Validate("value").Numeric(decimalPlaces: 2).ValidateAsync();
+            var v1 = await (12.3m).Validate("value").Configure(c => c.Numeric(decimalPlaces: 2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (123.400m).Validate("value").Numeric(decimalPlaces: 2).ValidateAsync();
+            v1 = await (123.400m).Validate("value").Configure(c => c.Numeric(decimalPlaces: 2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (0.123m).Validate("value").Numeric(decimalPlaces: 2).ValidateAsync();
+            v1 = await (0.123m).Validate("value").Configure(c => c.Numeric(decimalPlaces: 2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -107,13 +107,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_MaxDigits_And_DecimalPlaces()
         {
-            var v1 = await (12.3m).Validate("value").Numeric(maxDigits: 5, decimalPlaces: 2).ValidateAsync();
+            var v1 = await (12.3m).Validate("value").Configure(c => c.Numeric(maxDigits: 5, decimalPlaces: 2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (123.400m).Validate("value").Numeric(maxDigits: 5, decimalPlaces: 2).ValidateAsync();
+            v1 = await (123.400m).Validate("value").Configure(c => c.Numeric(maxDigits: 5, decimalPlaces: 2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (0.123m).Validate("value").Numeric(maxDigits: 5, decimalPlaces: 2).ValidateAsync();
+            v1 = await (0.123m).Validate("value").Configure(c => c.Numeric(maxDigits: 5, decimalPlaces: 2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -123,7 +123,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await (1234.0m).Validate("value").Numeric(maxDigits: 5, decimalPlaces: 2).ValidateAsync();
+            v1 = await (1234.0m).Validate("value").Configure(c => c.Numeric(maxDigits: 5, decimalPlaces: 2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -137,13 +137,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_PrecisionScale()
         {
-            var v1 = await (12.3m).Validate("value").PrecisionScale(precision: 5, scale: 2).ValidateAsync();
+            var v1 = await (12.3m).Validate("value").Configure(c => c.PrecisionScale(precision: 5, scale: 2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (123.400m).Validate("value").PrecisionScale(precision: 5, scale: 2).ValidateAsync();
+            v1 = await (123.400m).Validate("value").Configure(c => c.PrecisionScale(precision: 5, scale: 2)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (0.123m).Validate("value").PrecisionScale(precision: 5, scale: 2).ValidateAsync();
+            v1 = await (0.123m).Validate("value").Configure(c => c.PrecisionScale(precision: 5, scale: 2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -153,7 +153,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await (1234.0m).Validate("value").PrecisionScale(precision: 5, scale: 2).ValidateAsync();
+            v1 = await (1234.0m).Validate("value").Configure(c => c.PrecisionScale(precision: 5, scale: 2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/DictionaryRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/DictionaryRuleTest.cs
@@ -17,7 +17,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate()
         {
-            var v1 = await new Dictionary<string, string> { { "k1", "v1" } }.Validate("Dict").Dictionary(2).ValidateAsync();
+            var v1 = await new Dictionary<string, string> { { "k1", "v1" } }.Validate("Dict").Configure(c => c.Dictionary(2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -27,10 +27,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("Dict"));
             });
 
-            v1 = await new Dictionary<string, string> { { "k1", "v1" } }.Validate("Dict").Dictionary(1).ValidateAsync();
+            v1 = await new Dictionary<string, string> { { "k1", "v1" } }.Validate("Dict").Configure(c => c.Dictionary(1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" }, { "k3", "v3" } }.Validate("Dict").Dictionary(maxCount: 2).ValidateAsync();
+            v1 = await new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" }, { "k3", "v3" } }.Validate("Dict").Configure(c => c.Dictionary(maxCount: 2)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -40,13 +40,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("Dict"));
             });
 
-            v1 = await new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" }, { "k3", "v3" } }.Validate("Dict").Dictionary(maxCount: 3).ValidateAsync();
+            v1 = await new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" }, { "k3", "v3" } }.Validate("Dict").Configure(c => c.Dictionary(maxCount: 3)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await ((Dictionary<string, string>?)null).Validate().Collection(1).ValidateAsync();
+            v1 = await ((Dictionary<string, string>?)null).Validate().Configure(c => c.Collection(1)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new Dictionary<string, string> { }.Validate("Dict").Dictionary(1).ValidateAsync();
+            v1 = await new Dictionary<string, string> { }.Validate("Dict").Configure(c => c.Dictionary(1)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -62,10 +62,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         {
             var iv = Validator.Create<TestItem>().HasProperty(x => x.Id, p => p.Mandatory());
 
-            var v1 = await new Dictionary<string, TestItem>().Validate("Dict").Dictionary(item: DictionaryRuleItem.Create<string, TestItem>(value: iv)).ValidateAsync();
+            var v1 = await new Dictionary<string, TestItem>().Validate("Dict").Configure(c => c.Dictionary(item: DictionaryRuleItem.Create<string, TestItem>(value: iv))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new Dictionary<string, TestItem> { { "k1", new TestItem() } }.Validate("Dict").Dictionary(item: DictionaryRuleItem.Create<string, TestItem>(value: iv)).ValidateAsync();
+            v1 = await new Dictionary<string, TestItem> { { "k1", new TestItem() } }.Validate("Dict").Configure(c => c.Dictionary(item: DictionaryRuleItem.Create<string, TestItem>(value: iv))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -79,10 +79,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Null_Value()
         {
-            var v1 = await new Dictionary<string, TestItem?> { { "k1", new TestItem() } }.Validate("Dict").Dictionary().ValidateAsync();
+            var v1 = await new Dictionary<string, TestItem?> { { "k1", new TestItem() } }.Validate("Dict").Configure(c => c.Dictionary()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new Dictionary<string, TestItem?> { { "k1", null } }.Validate("Dict").Dictionary().ValidateAsync();
+            v1 = await new Dictionary<string, TestItem?> { { "k1", null } }.Validate("Dict").Configure(c => c.Dictionary()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -92,17 +92,17 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("Dict"));
             });
 
-            v1 = await new Dictionary<string, TestItem?> { { "k1", null } }.Validate("Dict").Dictionary(allowNullValues: true).ValidateAsync();
+            v1 = await new Dictionary<string, TestItem?> { { "k1", null } }.Validate("Dict").Configure(c => c.Dictionary(allowNullValues: true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task Validate_Ints()
         {
-            var v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 }, { "k3", 3 }, { "k4", 4 } }.Validate("Dict").Dictionary(maxCount: 4).ValidateAsync();
+            var v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 }, { "k3", 3 }, { "k4", 4 } }.Validate("Dict").Configure(c => c.Dictionary(maxCount: 4)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 }, { "k3", 3 }, { "k4", 4} }.Validate("Dict").Dictionary(maxCount: 3).ValidateAsync();
+            v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 }, { "k3", 3 }, { "k4", 4 } }.Validate("Dict").Configure(c => c.Dictionary(maxCount: 3)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -118,10 +118,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         {
             var kv = Validator.CreateFor<string>(r => r.Text("Key").Mandatory().String(2));
 
-            var v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 } }.Validate("Dict").Dictionary(item: DictionaryRuleItem.Create<string, int>(kv)).ValidateAsync();
+            var v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 } }.Validate("Dict").Configure(c => c.Dictionary(item: DictionaryRuleItem.Create<string, int>(kv))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2x", 2 } }.Validate("Dict").Dictionary(kv, Validator.Null<int>()).ValidateAsync();
+            v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2x", 2 } }.Validate("Dict").Configure(c => c.Dictionary(kv, Validator.Null<int>())).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -138,10 +138,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
             var kv = Validator.CreateFor<string>(r => r.Text("Key").Mandatory().String(2));
             var vv = Validator.CreateFor<int>(r => r.Mandatory().CompareValue(CompareOperator.LessThanEqual, 10));
 
-            var v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 } }.Validate("Dict").Dictionary(item: DictionaryRuleItem.Create(kv, vv)).ValidateAsync();
+            var v1 = await new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 } }.Validate("Dict").Configure(c => c.Dictionary(item: DictionaryRuleItem.Create(kv, vv))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await new Dictionary<string, int> { { "k1", 11 }, { "k2x", 2 } }.Validate("Dict").Dictionary(kv, vv).ValidateAsync();
+            v1 = await new Dictionary<string, int> { { "k1", 11 }, { "k2x", 2 } }.Validate("Dict").Configure(c => c.Dictionary(kv, vv)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/DuplicateRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/DuplicateRuleTest.cs
@@ -14,10 +14,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Value()
         {
-            var v1 = await 123.Validate("value").Duplicate(x => false).ValidateAsync();
+            var v1 = await 123.Validate("value").Configure(c => c.Duplicate(x => false)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
             
-            v1 = await 123.Validate("value").Duplicate(x => true).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Duplicate(x => true)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -27,10 +27,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").Duplicate(() => false).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Duplicate(() => false)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 123.Validate("value").Duplicate(() => true).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Duplicate(() => true)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/EmailRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/EmailRuleTest.cs
@@ -13,56 +13,56 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Email()
         {
-            var v1 = await ((string?)null).Validate().Email().ValidateAsync();
+            var v1 = await ((string?)null).Validate().Configure(c => c.Email()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "blah@.com".Validate().Email().ValidateAsync();
+            v1 = await "blah@.com".Validate().Configure(c => c.Email()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "blah.com".Validate().Email().ValidateAsync();
+            v1 = await "blah.com".Validate().Configure(c => c.Email()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await "@blah.com".Validate().Email().ValidateAsync();
+            v1 = await "@blah.com".Validate().Configure(c => c.Email()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await "blah@".Validate().Email().ValidateAsync();
+            v1 = await "blah@".Validate().Configure(c => c.Email()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await $"mynameis@{new string('x', 250)}.com".Validate().Email().ValidateAsync();
+            v1 = await $"mynameis@{new string('x', 250)}.com".Validate().Configure(c => c.Email()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await $"mynameis@{new string('x', 250)}.com".Validate().Email(null).ValidateAsync();
+            v1 = await $"mynameis@{new string('x', 250)}.com".Validate().Configure(c => c.Email(null)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await $"mynameis@{new string('x', 500)}.com".Validate().Email(null).ValidateAsync();
+            v1 = await $"mynameis@{new string('x', 500)}.com".Validate().Configure(c => c.Email(null)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task EmailAddress()
         {
-            var v1 = await ((string?)null).Validate().EmailAddress().ValidateAsync();
+            var v1 = await ((string?)null).Validate().Configure(c => c.EmailAddress()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "blah@.com".Validate().EmailAddress().ValidateAsync();
+            v1 = await "blah@.com".Validate().Configure(c => c.EmailAddress()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "blah.com".Validate().EmailAddress().ValidateAsync();
+            v1 = await "blah.com".Validate().Configure(c => c.EmailAddress()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await "@blah.com".Validate().EmailAddress().ValidateAsync();
+            v1 = await "@blah.com".Validate().Configure(c => c.EmailAddress()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await "blah@".Validate().EmailAddress().ValidateAsync();
+            v1 = await "blah@".Validate().Configure(c => c.EmailAddress()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await $"mynameis@{new string('x', 250)}.com".Validate().EmailAddress().ValidateAsync();
+            v1 = await $"mynameis@{new string('x', 250)}.com".Validate().Configure(c => c.EmailAddress()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True);
 
-            v1 = await $"mynameis@{new string('x', 250)}.com".Validate().EmailAddress(null).ValidateAsync();
+            v1 = await $"mynameis@{new string('x', 250)}.com".Validate().Configure(c => c.EmailAddress(null)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await $"mynameis@{new string('x', 500)}.com".Validate().EmailAddress(null).ValidateAsync();
+            v1 = await $"mynameis@{new string('x', 500)}.com".Validate().Configure(c => c.EmailAddress(null)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
     }

--- a/tests/CoreEx.Test/Framework/Validation/Rules/EntityRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/EntityRuleTest.cs
@@ -19,7 +19,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         public async Task Validate()
         {
             var te = new TestEntity { Item = new TestItem() };
-            var v1 = await te.Validate("entity", "EnTiTy").Entity(_tev).ValidateAsync();
+            var v1 = await te.Validate("entity", "EnTiTy").Configure(c => c.Entity(_tev)).ValidateAsync();
 
             Assert.Multiple(() =>
             {

--- a/tests/CoreEx.Test/Framework/Validation/Rules/EnumRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/EnumRuleTest.cs
@@ -14,10 +14,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate()
         {
-            var v1 = await ((AbcOption)1).Validate("value").Enum().ValidateAsync();
+            var v1 = await ((AbcOption)1).Validate("value").Configure(c => c.Enum()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await ((AbcOption)88).Validate("value").Enum().ValidateAsync();
+            v1 = await ((AbcOption)88).Validate("value").Configure(c => c.Enum()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/EnumValueRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/EnumValueRuleTest.cs
@@ -14,10 +14,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate()
         {
-            var v1 = await "A".Validate("value").Enum().As<AbcOption>().ValidateAsync();
+            var v1 = await "A".Validate("value").Configure(c => c.Enum().As<AbcOption>()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "a".Validate("value").Enum().As<AbcOption>().ValidateAsync();
+            v1 = await "a".Validate("value").Configure(c => c.Enum().As<AbcOption>()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -27,10 +27,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await "a".Validate("value").Enum().As<AbcOption>(true).ValidateAsync();
+            v1 = await "a".Validate("value").Configure(c => c.Enum().As<AbcOption>(true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "X".Validate("value").Enum().As<AbcOption>().ValidateAsync();
+            v1 = await "X".Validate("value").Configure(c => c.Enum().As<AbcOption>()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -40,14 +40,14 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await ((string?)null).Validate("value").Enum().As<AbcOption>().ValidateAsync();
+            v1 = await ((string?)null).Validate("value").Configure(c => c.Enum().As<AbcOption>()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task ValidateAndOverride()
         {
-            var v1 = await "someoptionwithcasing".Validate("value").Enum().As<CaseOption>(true, false).ValidateAsync();
+            var v1 = await "someoptionwithcasing".Validate("value").Configure(c => c.Enum().As<CaseOption>(true, false)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.False);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/ExistsRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/ExistsRuleTest.cs
@@ -15,10 +15,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Value()
         {
-            var v1 = await 123.Validate("value").Exists(x => true).ValidateAsync();
+            var v1 = await 123.Validate("value").Configure(c => c.Exists(x => true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
             
-            v1 = await 123.Validate("value").Exists(x => false).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Exists(x => false)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -28,10 +28,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").Exists(true).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Exists(true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 123.Validate("value").Exists(false).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Exists(false)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -41,10 +41,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").ExistsAsync((_, __) => Task.FromResult(true)).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.ExistsAsync((_, __) => Task.FromResult(true))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 123.Validate("value").ExistsAsync((_, __) => Task.FromResult(false)).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.ExistsAsync((_, __) => Task.FromResult(false))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -54,10 +54,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").ValueExistsAsync((_, __) => Task.FromResult<object?>(new object())).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.ValueExistsAsync((_, __) => Task.FromResult<object?>(new object()))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 123.Validate("value").ValueExistsAsync((_, __) => Task.FromResult((object?)null)).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.ValueExistsAsync((_, __) => Task.FromResult((object?)null))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -67,10 +67,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").AgentExistsAsync((_, __) => CoreEx.Http.HttpResult.CreateAsync(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK), __)).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.AgentExistsAsync((_, __) => CoreEx.Http.HttpResult.CreateAsync(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK), __))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 123.Validate("value").AgentExistsAsync((_, __) => CoreEx.Http.HttpResult.CreateAsync(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound), __)).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.AgentExistsAsync((_, __) => CoreEx.Http.HttpResult.CreateAsync(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound), __))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -80,10 +80,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").AgentExistsAsync((_, __) => CoreEx.Http.HttpResult.CreateAsync<int>(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK), cancellationToken: __)).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.AgentExistsAsync((_, __) => CoreEx.Http.HttpResult.CreateAsync<int>(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.OK), cancellationToken: __))).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 123.Validate("value").AgentExistsAsync((_, __) => CoreEx.Http.HttpResult.CreateAsync<int>(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound), cancellationToken: __)).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.AgentExistsAsync((_, __) => CoreEx.Http.HttpResult.CreateAsync<int>(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.NotFound), cancellationToken: __))).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -93,7 +93,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").ValueExistsAsync(async (_, __) => await GetBlahAsync()).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.ValueExistsAsync(async (_, __) => await GetBlahAsync())).ValidateAsync();
             Assert.That(v1.HasErrors, Is.True); // Result.Success is not a valid value
         }
 

--- a/tests/CoreEx.Test/Framework/Validation/Rules/ImmutableRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/ImmutableRuleTest.cs
@@ -14,10 +14,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Value()
         {
-            var v1 = await 123.Validate("value").Immutable(x => true).ValidateAsync();
+            var v1 = await 123.Validate("value").Configure(c => c.Immutable(x => true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
             
-            v1 = await 123.Validate("value").Immutable(x => false).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Immutable(x => false)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -27,10 +27,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").Immutable(() => true).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Immutable(() => true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 123.Validate("value").Immutable(() => false).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Immutable(() => false)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/MandatoryRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/MandatoryRuleTest.cs
@@ -14,10 +14,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_String()
         {
-            var v1 = await "XXX".Validate("value").Mandatory().ValidateAsync();
+            var v1 = await "XXX".Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await ((string?)null).Validate("value").Mandatory().ValidateAsync();
+            v1 = await ((string?)null).Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -27,7 +27,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await (string.Empty).Validate("value").Mandatory().ValidateAsync();
+            v1 = await (string.Empty).Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -41,10 +41,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Int32()
         {
-            var v1 = await (123).Validate("value").Mandatory().ValidateAsync();
+            var v1 = await (123).Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (0).Validate("value").Mandatory().ValidateAsync();
+            v1 = await (0).Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -54,13 +54,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            var v2 = await ((int?)123).Validate("value").Mandatory().ValidateAsync();
+            var v2 = await ((int?)123).Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
 
-            v2 = await ((int?)0).Validate("value").Mandatory().ValidateAsync();
+            v2 = await ((int?)0).Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
 
-            v2 = await ((int?)null).Validate("value").Mandatory().ValidateAsync();
+            v2 = await ((int?)null).Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v2.HasErrors, Is.True);
@@ -80,11 +80,11 @@ namespace CoreEx.Test.Framework.Validation.Rules
         public async Task Validate_Entity()
         {
             Foo? foo = new();
-            var v1 = await foo.Validate("value").Mandatory().ValidateAsync();
+            var v1 = await foo.Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
             foo = null;
-            v1 = await foo.Validate("value").Mandatory().ValidateAsync();
+            v1 = await foo.Validate("value").Configure(c => c.Mandatory()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -98,10 +98,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_NotEmpty_String()
         {
-            var v1 = await "XXX".Validate("value").NotEmpty().ValidateAsync();
+            var v1 = await "XXX".Validate("value").Configure(c => c.NotEmpty()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await ((string?)null).Validate("value").NotEmpty().ValidateAsync();
+            v1 = await ((string?)null).Validate("value").Configure(c => c.NotEmpty()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -111,7 +111,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await (string.Empty).Validate("value").NotEmpty().ValidateAsync();
+            v1 = await (string.Empty).Validate("value").Configure(c => c.NotEmpty()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -125,10 +125,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_NotEmpty_Int32()
         {
-            var v1 = await (123).Validate("value").NotEmpty().ValidateAsync();
+            var v1 = await (123).Validate("value").Configure(c => c.NotEmpty()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (0).Validate("value").NotEmpty().ValidateAsync();
+            v1 = await (0).Validate("value").Configure(c => c.NotEmpty()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -138,13 +138,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            var v2 = await ((int?)123).Validate("value").NotEmpty().ValidateAsync();
+            var v2 = await ((int?)123).Validate("value").Configure(c => c.NotEmpty()).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
 
-            v2 = await ((int?)0).Validate("value").NotEmpty().ValidateAsync();
+            v2 = await ((int?)0).Validate("value").Configure(c => c.NotEmpty()).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
 
-            v2 = await ((int?)null).Validate("value").NotEmpty().ValidateAsync();
+            v2 = await ((int?)null).Validate("value").Configure(c => c.NotEmpty()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v2.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/MustRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/MustRuleTest.cs
@@ -14,10 +14,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_Value()
         {
-            var v1 = await 123.Validate("value").Must(x => true).ValidateAsync();
+            var v1 = await 123.Validate("value").Configure(c => c.Must(x => true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
             
-            v1 = await 123.Validate("value").Must(x => false).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Must(x => false)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -27,10 +27,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await 123.Validate("value").Must(() => true).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Must(() => true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await 123.Validate("value").Must(() => false).ValidateAsync();
+            v1 = await 123.Validate("value").Configure(c => c.Must(() => false)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/NoneRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/NoneRuleTest.cs
@@ -14,7 +14,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_String()
         {
-            var v1 = await "XXX".Validate("value").None().ValidateAsync();
+            var v1 = await "XXX".Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -24,20 +24,20 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await ((string?)null).Validate("value").None().ValidateAsync();
+            v1 = await ((string?)null).Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (string.Empty).Validate("value").None().ValidateAsync();
+            v1 = await (string.Empty).Validate("value").Configure(c => c.Validate()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "  ".Validate("value").None().ValidateAsync();
+            v1 = await "  ".Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task Validate_Int32()
         {
-            var v1 = await (123).Validate("value").None().ValidateAsync();
+            var v1 = await (123).Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -47,16 +47,16 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await (0).Validate("value").None().ValidateAsync();
+            v1 = await (0).Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            var v2 = await ((int?)123).Validate("value").None().ValidateAsync();
+            var v2 = await ((int?)123).Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.That(v2.HasErrors, Is.True);
 
-            v2 = await ((int?)0).Validate("value").None().ValidateAsync();
+            v2 = await ((int?)0).Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.That(v2.HasErrors, Is.True);
 
-            v2 = await ((int?)null).Validate("value").None().ValidateAsync();
+            v2 = await ((int?)null).Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
         }
 
@@ -69,7 +69,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         public async Task Validate_Entity()
         {
             Foo? foo = new();
-            var v1 = await foo.Validate("value").None().ValidateAsync();
+            var v1 = await foo.Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -80,7 +80,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
             });
 
             foo = null;
-            v1 = await foo.Validate("value").None().ValidateAsync();
+            v1 = await foo.Validate("value").Configure(c => c.None()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
     }

--- a/tests/CoreEx.Test/Framework/Validation/Rules/NumericRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/NumericRuleTest.cs
@@ -14,10 +14,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_AllowNegatives()
         {
-            var v1 = await (123f).Validate("value").Numeric().ValidateAsync();
+            var v1 = await (123f).Validate("value").Configure(c => c.Numeric()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await (-123f).Validate("value").Numeric().ValidateAsync();
+            v1 = await (-123f).Validate("value").Configure(c => c.Numeric()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -27,13 +27,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await (-123f).Validate("value").Numeric(true).ValidateAsync();
+            v1 = await (-123f).Validate("value").Configure(c => c.Numeric(true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            var v2 = await (123d).Validate("value").Numeric().ValidateAsync();
+            var v2 = await (123d).Validate("value").Configure(c => c.Numeric()).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
 
-            v2 = await (-123d).Validate("value").Numeric().ValidateAsync();
+            v2 = await (-123d).Validate("value").Configure(c => c.Numeric()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v2.HasErrors, Is.True);
@@ -43,7 +43,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v2.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v2 = await (-123d).Validate("value").Numeric(true).ValidateAsync();
+            v2 = await (-123d).Validate("value").Configure(c => c.Numeric(true)).ValidateAsync();
             Assert.That(v2.HasErrors, Is.False);
         }
     }

--- a/tests/CoreEx.Test/Framework/Validation/Rules/OverrideRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/OverrideRuleTest.cs
@@ -13,7 +13,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public void Validate_Value()
         {
-            Assert.ThrowsAsync<InvalidOperationException>(async () => await 123.Validate().Override(456).ValidateAsync());
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await 123.Validate().Configure(c => c.Override(456)).ValidateAsync());
         }
     }
 }

--- a/tests/CoreEx.Test/Framework/Validation/Rules/ReferenceDataRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/ReferenceDataRuleTest.cs
@@ -31,10 +31,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
             using var scope = sp.CreateScope();
             var ec = scope.ServiceProvider.GetService<ExecutionContext>();
 
-            var v1 = await ((RefDataEx)"Aaa").Validate("value").IsValid().ValidateAsync();
+            var v1 = await ((RefDataEx)"Aaa").Validate("value").Configure(c => c.IsValid()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await ((RefDataEx)"Abc").Validate("value").IsValid().ValidateAsync();
+            v1 = await ((RefDataEx)"Abc").Validate("value").Configure(c => c.IsValid()).ValidateAsync();
 
             Assert.Multiple(() =>
             {
@@ -62,10 +62,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
             using var scope = sp.CreateScope();
             var ec = scope.ServiceProvider.GetService<ExecutionContext>();
 
-            var v1 = await "Aaa".Validate("value").RefDataCode().As<RefDataEx>().ValidateAsync();
+            var v1 = await "Aaa".Validate("value").Configure(c => c.RefDataCode().As<RefDataEx>()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "Abc".Validate("value").RefDataCode().As<RefDataEx>().ValidateAsync();
+            v1 = await "Abc".Validate("value").Configure(c => c.RefDataCode().As<RefDataEx>()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -93,7 +93,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
             var ec = scope.ServiceProvider.GetService<ExecutionContext>();
 
             var sids = new ReferenceDataCodeList<RefDataEx>("Aaa", "Abc");
-            var v1 = await sids.Validate("value").AreValid().ValidateAsync();
+            var v1 = await sids.Validate("value").Configure(c => c.AreValid()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -104,7 +104,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
             });
 
             sids = new ReferenceDataCodeList<RefDataEx>("Aaa", "Aaa");
-            v1 = await sids.Validate("value").AreValid().ValidateAsync();
+            v1 = await sids.Validate("value").Configure(c => c.AreValid()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -114,10 +114,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await sids.Validate("value").AreValid(allowDuplicates: true).ValidateAsync();
+            v1 = await sids.Validate("value").Configure(c => c.AreValid(allowDuplicates: true)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await sids.Validate("value").AreValid(true, 5).ValidateAsync();
+            v1 = await sids.Validate("value").Configure(c => c.AreValid(true, 5)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -127,7 +127,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await sids.Validate("value").AreValid(true, maxCount: 1).ValidateAsync();
+            v1 = await sids.Validate("value").Configure(c => c.AreValid(true, maxCount: 1)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/StringRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/StringRuleTest.cs
@@ -15,13 +15,13 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task Validate_MinLength()
         {
-            var v1 = await "Abc".Validate("value").String(2, 5).ValidateAsync();
+            var v1 = await "Abc".Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "Ab".Validate("value").String(2, 5).ValidateAsync();
+            v1 = await "Ab".Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "A".Validate("value").String(2, 5).ValidateAsync();
+            v1 = await "A".Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -31,23 +31,23 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await string.Empty.Validate("value").String(2, 5).ValidateAsync();
+            v1 = await string.Empty.Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await ((string?)null).Validate("value").String(2, 5).ValidateAsync();
+            v1 = await ((string?)null).Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task Validate_MaxLength()
         {
-            var v1 = await "Abc".Validate("value").String(2, 5).ValidateAsync();
+            var v1 = await "Abc".Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "Abcde".Validate("value").String(2, 5).ValidateAsync();
+            v1 = await "Abcde".Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "Abcdef".Validate("value").String(2, 5).ValidateAsync();
+            v1 = await "Abcdef".Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -57,10 +57,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await string.Empty.Validate("value").String(2, 5).ValidateAsync();
+            v1 = await string.Empty.Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await ((string?)null).Validate("value").String(2, 5).ValidateAsync();
+            v1 = await ((string?)null).Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
@@ -68,10 +68,10 @@ namespace CoreEx.Test.Framework.Validation.Rules
         public async Task Validate_Regex()
         {
             var r = new Regex("[a-zA-Z]$");
-            var v1 = await "Abc".Validate("value").String(r).ValidateAsync();
+            var v1 = await "Abc".Validate("value").Configure(c => c.String(r)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "123".Validate("value").String(r).ValidateAsync();
+            v1 = await "123".Validate("value").Configure(c => c.String(r)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -81,20 +81,20 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await string.Empty.Validate("value").String(2, 5).ValidateAsync();
+            v1 = await string.Empty.Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await ((string?)null).Validate("value").String(2, 5).ValidateAsync();
+            v1 = await ((string?)null).Validate("value").Configure(c => c.String(2, 5)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
         }
 
         [Test]
         public async Task Validate_ExactLength()
         {
-            var v1 = await "Abc".Validate("value").String(3, 3).ValidateAsync();
+            var v1 = await "Abc".Validate("value").Configure(c => c.String(3, 3)).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "A".Validate("value").String(3, 3).ValidateAsync();
+            v1 = await "A".Validate("value").Configure(c => c.String(3, 3)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);
@@ -104,7 +104,7 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.Messages[0].Property, Is.EqualTo("value"));
             });
 
-            v1 = await "AAAA".Validate("value").Length(3).ValidateAsync();
+            v1 = await "AAAA".Validate("value").Configure(c => c.Length(3)).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/Rules/WildcardRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/WildcardRuleTest.cs
@@ -14,22 +14,22 @@ namespace CoreEx.Test.Framework.Validation.Rules
         [Test]
         public async Task ValidateWildcard()
         {
-            var v1 = await "xxxx".Validate("value").Wildcard().ValidateAsync();
+            var v1 = await "xxxx".Validate("value").Configure(c => c.Wildcard()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "*xxxx".Validate("value").Wildcard().ValidateAsync();
+            v1 = await "*xxxx".Validate("value").Configure(c => c.Wildcard()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "xxxx*".Validate("value").Wildcard().ValidateAsync();
+            v1 = await "xxxx*".Validate("value").Configure(c => c.Wildcard()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "*xxxx*".Validate("value").Wildcard().ValidateAsync();
+            v1 = await "*xxxx*".Validate("value").Configure(c => c.Wildcard()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "x*x".Validate("value").Wildcard().ValidateAsync();
+            v1 = await "x*x".Validate("value").Configure(c => c.Wildcard()).ValidateAsync();
             Assert.That(v1.HasErrors, Is.False);
 
-            v1 = await "x?x".Validate("value").Wildcard().ValidateAsync();
+            v1 = await "x?x".Validate("value").Configure(c => c.Wildcard()).ValidateAsync();
             Assert.Multiple(() =>
             {
                 Assert.That(v1.HasErrors, Is.True);

--- a/tests/CoreEx.Test/Framework/Validation/ValidatorTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/ValidatorTest.cs
@@ -492,7 +492,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxc = Validator.CreateForCollection<List<TestItem>>(minCount: 1, maxCount: 2, item: CollectionRuleItem.Create(new TestItemValidator()));
             var tc = new List<TestItem> { new() { Id = "A", Text = "aaa" }, new() { Id = "B", Text = "bbb" }, new() { Id = "C", Text = "ccc" } };
 
-            var r = await vxc.ValidateAsync(tc);
+            var r = await tc.Validate(vxc, null).ValidateAsync();
 
             Assert.Multiple(() =>
             {
@@ -516,7 +516,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxc = Validator.CreateForCollection<List<TestItem>, TestItem>(new TestItemValidator(), minCount: 3);
             var tc = new List<TestItem> { new() { Id = "A", Text = "A" }, new() { Id = "B", Text = "B" } };
 
-            var r = await vxc.ValidateAsync(tc);
+            var r = await tc.Validate(vxc, null).ValidateAsync();
 
             Assert.Multiple(() =>
             {
@@ -531,10 +531,10 @@ namespace CoreEx.Test.Framework.Validation
         [Test]
         public async Task Coll_Validator_MinCount2()
         {
-            var vxc = Validator.CreateFor<List<TestItem>>().Collection(new TestItemValidator(), minCount: 3).AsCommonValidator();
+            var vxc = Validator.CreateFor<List<TestItem>>().Configure(c => c.Collection(new TestItemValidator(), minCount: 3));
             var tc = new List<TestItem> { new() { Id = "A", Text = "A" }, new() { Id = "B", Text = "B" } };
 
-            var r = await vxc.ValidateAsync(tc);
+            var r = await tc.Validate(vxc, null).ValidateAsync();
 
             Assert.Multiple(() =>
             {
@@ -552,7 +552,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxc = Validator.CreateForCollection<List<TestItem>>(item: CollectionRuleItem.Create(new TestItemValidator()).DuplicateCheck(x => x.Id));
             var tc = new List<TestItem> { new() { Id = "A", Text = "A" }, new() { Id = "A", Text = "A" } };
 
-            var r = await vxc.ValidateAsync(tc);
+            var r = await tc.Validate(vxc, null).ValidateAsync();
 
             Assert.Multiple(() =>
             {
@@ -570,7 +570,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxc = Validator.CreateForCollection<List<TestItem>>(minCount: 1, maxCount: 2, item: CollectionRuleItem.Create(new TestItemValidator()).DuplicateCheck(x => x.Id));
             var tc = new List<TestItem> { new() { Id = "A", Text = "A" }, new() { Id = "B", Text = "B" } };
 
-            var r = await vxc.ValidateAsync(tc);
+            var r = await tc.Validate(vxc, null).ValidateAsync();
 
             Assert.That(r.HasErrors, Is.False);
         }
@@ -581,7 +581,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxc = Validator.CreateForCollection<List<int>>(minCount: 1, maxCount: 5);
             var ic = new List<int> { 1, 2, 3, 4, 5 };
 
-            var r = await vxc.ValidateAsync(ic);
+            var r = await ic.Validate(vxc, null).ValidateAsync();
 
             Assert.That(r.HasErrors, Is.False);
         }
@@ -592,7 +592,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxc = Validator.CreateFor<List<int>>(v => v.Collection(1, 3));
             var ic = new List<int> { 1, 2, 3, 4, 5 };
 
-            var r = await vxc.ValidateAsync(ic);
+            var r = await ic.Validate(vxc, null).ValidateAsync();
 
             Assert.Multiple(() =>
             {
@@ -610,7 +610,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxd = Validator.CreateForDictionary<Dictionary<string, TestItem>>(minCount: 1, maxCount: 2, item: DictionaryRuleItem.Create<string, TestItem>(value: new TestItemValidator()));
             var tc = new Dictionary<string, TestItem> { { "k1", new TestItem { Id = "A", Text = "aaa" } }, { "k2", new TestItem { Id = "B", Text = "bbb" } }, { "k3", new TestItem { Id = "C", Text = "ccc" } } };
 
-            var r = await vxd.ValidateAsync(tc);
+            var r = await tc.Validate(vxd, null).ValidateAsync();
 
             Assert.Multiple(() =>
             {
@@ -634,7 +634,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxd = Validator.CreateForDictionary<Dictionary<string, TestItem>>(minCount: 3, item: DictionaryRuleItem.Create<string, TestItem>(value: new TestItemValidator()));
             var tc = new Dictionary<string, TestItem> { { "k1", new TestItem { Id = "A", Text = "A" } }, { "k2", new TestItem { Id = "B", Text = "B" } } };
 
-            var r = await vxd.ValidateAsync(tc);
+            var r = await tc.Validate(vxd, null).ValidateAsync();
 
             Assert.Multiple(() =>
             {
@@ -652,7 +652,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxd = Validator.CreateForDictionary<Dictionary<string, TestItem>, string, TestItem>(new TestItemValidator(), minCount: 2);
             var tc = new Dictionary<string, TestItem> { { "k1", new TestItem { Id = "A", Text = "A" } }, { "k2", new TestItem { Id = "B", Text = "B" } } };
 
-            var r = await vxd.ValidateAsync(tc);
+            var r = await tc.Validate(vxd, null).ValidateAsync();
 
             Assert.That(r.HasErrors, Is.False);
         }
@@ -663,7 +663,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxd = Validator.CreateForDictionary<Dictionary<string, int>>(minCount: 1, maxCount: 5);
             var id = new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 }, { "k3", 3 }, { "k4", 4 }, { "k5", 5 } };
 
-            var r = await vxd.ValidateAsync(id);
+            var r = await id.Validate(vxd, null).ValidateAsync();
 
             Assert.That(r.HasErrors, Is.False);
         }
@@ -674,7 +674,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxd = Validator.CreateForDictionary<Dictionary<string, int>>(minCount: 1, maxCount: 3);
             var id = new Dictionary<string, int> { { "k1", 1 }, { "k2", 2 }, { "k3", 3 }, { "k4", 4 }, { "k5", 5 } };
 
-            var r = await vxd.ValidateAsync(id);
+            var r = await id.Validate(vxd, null).ValidateAsync();
 
             Assert.Multiple(() =>
             {
@@ -693,7 +693,7 @@ namespace CoreEx.Test.Framework.Validation
             var vxd = Validator.CreateForDictionary<Dictionary<string, TestItem>, string, TestItem>(kv, new TestItemValidator(), minCount: 2);
             var tc = new Dictionary<string, TestItem> { { "k1", new TestItem { Id = "A", Text = "A" } }, { "k2x", new TestItem { Id = "B", Text = "B" } } };
 
-            var r = await vxd.ValidateAsync(tc);
+            var r = await tc.Validate(vxd, null).ValidateAsync();
 
             Assert.Multiple(() =>
             {

--- a/tests/CoreEx.Test/Framework/Validation/ValueValidatorTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/ValueValidatorTest.cs
@@ -15,7 +15,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Run_With_NotNull()
         {
             string name = "George";
-            var r = await name.Validate().Mandatory().String(50).ValidateAsync();
+            var r = await name.Validate().Configure(c => c.Mandatory().String(50)).ValidateAsync();
             Assert.That(r, Is.Not.Null);
             Assert.That(r.HasErrors, Is.False);
         }
@@ -24,7 +24,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Run_With_Null()
         {
             string? name = null;
-            var r = await name.Validate().Mandatory().String(50).ValidateAsync();
+            var r = await name.Validate().Configure(c => c.Mandatory().String(50)).ValidateAsync();
             Assert.That(r, Is.Not.Null);
             Assert.Multiple(() =>
             {
@@ -38,7 +38,7 @@ namespace CoreEx.Test.Framework.Validation
         public async Task Validate_With_FailureResult()
         {
             string name = "Bill";
-            var r = await name.Validate().Mandatory().Custom(ctx => Result.Go().When(() => ctx.Value == "Bill", () => Result.NotFoundError())).String(5).ValidateAsync();
+            var r = await name.Validate().Configure(c => c.Mandatory().Custom(ctx => Result.Go().When(() => ctx.Value == "Bill", () => Result.NotFoundError())).String(5)).ValidateAsync();
             Assert.That(r, Is.Not.Null);
             Assert.Multiple(() =>
             {

--- a/tests/CoreEx.Test2/Framework/Validation/ValidationExtensionsTest.cs
+++ b/tests/CoreEx.Test2/Framework/Validation/ValidationExtensionsTest.cs
@@ -28,7 +28,6 @@ namespace CoreEx.Test2.Framework.Validation
             {
                 var v2 = v;
                 var v3 = v.Email();
-                return v3;
             });
         }
     }

--- a/tests/CoreEx.TestFunction/CoreEx.TestFunction.csproj
+++ b/tests/CoreEx.TestFunction/CoreEx.TestFunction.csproj
@@ -6,12 +6,12 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\CoreEx.AspNetCore\CoreEx.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\CoreEx.AutoMapper\CoreEx.AutoMapper.csproj" />
     <ProjectReference Include="..\..\src\CoreEx.Azure\CoreEx.Azure.csproj" />
     <ProjectReference Include="..\..\src\CoreEx.FluentValidation\CoreEx.FluentValidation.csproj" />
     <ProjectReference Include="..\..\src\CoreEx.Newtonsoft\CoreEx.Newtonsoft.csproj" />

--- a/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
+++ b/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.2.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.17.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\CoreEx.AspNetCore\CoreEx.AspNetCore.csproj" />


### PR DESCRIPTION
- *Fixed*: Removed `Azure.Identity` dependency as no longer required; related to `https://github.com/advisories/GHSA-wvxc-855f-jvrv`.
- *Fixed*: Removed `AspNetCore.HealthChecks.SqlServer` dependency as no longer required.
- *Fixed:* Updated all dependencies to latest versions.
- *Fixed*: `CoreEx.AutoMapper` updated to leverage latest major version (`13.0.1`); as such `netstandard` no longer supported.
- *Fixed*: The `TimerHostedServiceBase` was incorrectly resetting the `LastException` on sleep versus wake. 
- *Fixed*: The `AddEventSender` dependency injection extension methods now correctly register as _Scoped_.
- *Fixed*: The `Logger.LogInformation` invocations refactored to `Logger.LogDebug` where applicable to reduce noise in the logs.
- *Fixed*: The `IPropertyRule.ValidateAsync` method removed as it was not required and could lead to incorrect usage.
- *Fixed:* The `ValueValidator` now only supports a `Configure` method to enable `IPropertyRule`-based configuration (versus directly).
- *Fixed:* The `CommonValidator.ValidateAsync` is now internal as this was not intended and could lead to incorrect usage.
- *Enhancement*: Added `AfterSend` event to `IEventSender` to enable post-send processing.
- *Enhancement*: Added `EventOutboxHostedService.OneOffTrigger` method to enable a _one-off_ trigger interval to be specified for the registered (DI) instance.
