### PR TITLE
v3.18.0

### DIFF
--- a/src/CoreEx.Validation/Rules/ReferenceDataSidListRule.cs
+++ b/src/CoreEx.Validation/Rules/ReferenceDataSidListRule.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using CoreEx.RefData;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -12,7 +11,7 @@ namespace CoreEx.Validation.Rules
     /// <summary>
     /// Provides validation for a <see cref="IReferenceDataCodeList"/> including <see cref="MinCount"/>, <see cref="MaxCount"/>, per item <see cref="IReferenceData.IsValid"/>, and whether to <see cref="AllowDuplicates"/>.
     /// </summary>
-    public class ReferenceDataSidListRule<TEntity, TProperty> : ValueRuleBase<TEntity, TProperty?> where TEntity : class where TProperty : IReferenceDataCodeList
+    public class ReferenceDataSidListRule<TEntity, TProperty> : ValueRuleBase<TEntity, TProperty> where TEntity : class where TProperty : IReferenceDataCodeList?
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ReferenceDataSidListRule{TEntity, TProperty}"/> class.
@@ -35,7 +34,7 @@ namespace CoreEx.Validation.Rules
         public bool AllowDuplicates { get; set; } = false;
 
         /// <inheritdoc/>
-        protected override Task ValidateAsync(PropertyContext<TEntity, TProperty?> context, CancellationToken cancellationToken = default)
+        protected override Task ValidateAsync(PropertyContext<TEntity, TProperty> context, CancellationToken cancellationToken = default)
         {
             if (context.Value!.HasInvalidItems)
             {

--- a/src/CoreEx.Validation/ValidationExtensions.cs
+++ b/src/CoreEx.Validation/ValidationExtensions.cs
@@ -1280,7 +1280,7 @@ namespace CoreEx.Validation
         /// <param name="maxCount">The maximum count.</param>
         /// <param name="errorText">The error message format text <see cref="LText"/> (overrides the default).</param>
         /// <returns>A <see cref="IPropertyRule{TEntity, TProperty}"/>.</returns>
-        public static IPropertyRule<TEntity, TProperty?> AreValid<TEntity, TProperty>(this IPropertyRule<TEntity, TProperty?> rule, bool allowDuplicates = false, int minCount = 0, int? maxCount = null, LText? errorText = null) where TEntity : class where TProperty : IReferenceDataCodeList
+        public static IPropertyRule<TEntity, TProperty> AreValid<TEntity, TProperty>(this IPropertyRule<TEntity, TProperty> rule, bool allowDuplicates = false, int minCount = 0, int? maxCount = null, LText? errorText = null) where TEntity : class where TProperty : IReferenceDataCodeList?
             => rule.ThrowIfNull(nameof(rule)).AddRule(new ReferenceDataSidListRule<TEntity, TProperty> { AllowDuplicates = allowDuplicates, MinCount = minCount, MaxCount = maxCount, ErrorText = errorText });
 
         /// <summary>
@@ -1577,7 +1577,7 @@ namespace CoreEx.Validation
         /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
-        public static ValueValidator<T> Validate<T>(this T value, string? name = null, LText? text = null) => new(value, name, text);
+        public static ValueValidator<T> Validate<T>(this T? value, string? name = null, LText? text = null) => new(value, name, text);
 
         /// <summary>
         /// Enables (sets up) validation for a value.
@@ -1588,7 +1588,7 @@ namespace CoreEx.Validation
         /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
-        public static ValueValidator<T> Validate<T>(this T value, Action<ValueValidatorConfiguration<T>> configure, string? name = null, LText? text = null) 
+        public static ValueValidator<T> Validate<T>(this T? value, Action<ValueValidatorConfiguration<T>> configure, string? name = null, LText? text = null) 
             => new ValueValidator<T>(value, name, text).Configure(configure);
 
         /// <summary>
@@ -1600,7 +1600,7 @@ namespace CoreEx.Validation
         /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
-        public static ValueValidator<T> Validate<T>(this T value, CommonValidator<T> validator, string? name = null, LText? text = null)
+        public static ValueValidator<T> Validate<T>(this T? value, CommonValidator<T> validator, string? name = null, LText? text = null)
             => new ValueValidator<T>(value, name, text).Configure(c => c.Common(validator));
 #else
         /// <summary>
@@ -1611,7 +1611,7 @@ namespace CoreEx.Validation
         /// <param name="name">The value name (defaults to <paramref name="value"/> name using the <see cref="CallerArgumentExpressionAttribute"/>).</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
-        public static ValueValidator<T> Validate<T>(this T value, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null) => new(value, name, text);
+        public static ValueValidator<T> Validate<T>(this T? value, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null) => new(value, name, text);
 
         /// <summary>
         /// Enables (sets up) validation for a value.
@@ -1622,7 +1622,7 @@ namespace CoreEx.Validation
         /// <param name="name">The value name (defaults to <paramref name="value"/> name using the <see cref="CallerArgumentExpressionAttribute"/>).</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
-        public static ValueValidator<T> Validate<T>(this T value, Action<ValueValidatorConfiguration<T>> configure, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null) 
+        public static ValueValidator<T> Validate<T>(this T? value, Action<ValueValidatorConfiguration<T>> configure, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null) 
             => new ValueValidator<T>(value, name, text).Configure(configure);
 
         /// <summary>
@@ -1634,7 +1634,7 @@ namespace CoreEx.Validation
         /// <param name="name">The value name (defaults to <paramref name="value"/> name using the <see cref="CallerArgumentExpressionAttribute"/>).</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>A <see cref="ValueValidator{T}"/>.</returns>
-        public static ValueValidator<T> Validate<T>(this T value, CommonValidator<T> validator, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null)
+        public static ValueValidator<T> Validate<T>(this T? value, CommonValidator<T> validator, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null)
             => new ValueValidator<T>(value, name, text).Configure(c => c.Common(validator));
 #endif
 
@@ -1649,7 +1649,7 @@ namespace CoreEx.Validation
         /// <param name="multiValidator">The <see cref="MultiValidator"/>.</param>
         /// <param name="validator">The <see cref="ValueValidator{T}"/>.</param>
         /// <returns>The (this) <see cref="MultiValidator"/>.</returns>
-        public static MultiValidator Add<T>(this MultiValidator multiValidator, ValueValidator<T?> validator)
+        public static MultiValidator Add<T>(this MultiValidator multiValidator, ValueValidator<T> validator)
         {
             validator.ThrowIfNull(nameof(validator));
             multiValidator.ThrowIfNull(nameof(multiValidator)).Validators.Add(async ct => await validator.ValidateAsync(ct).ConfigureAwait(false));

--- a/src/CoreEx.Validation/ValueValidator.cs
+++ b/src/CoreEx.Validation/ValueValidator.cs
@@ -22,7 +22,7 @@ namespace CoreEx.Validation
         /// <param name="value">The value to validate.</param>
         /// <param name="name">The value name (defaults to <see cref="Validation.ValueNameDefault"/>).</param>
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
-        internal ValueValidator(T value, string? name = null, LText? text = null)
+        internal ValueValidator(T? value, string? name = null, LText? text = null)
         {
             _configuration = new ValueValidatorConfiguration<T>(string.IsNullOrEmpty(name) ? Validation.ValueNameDefault : name, text);
             _validationValue = new ValidationValue<T>(null, value);

--- a/tests/CoreEx.Test/Framework/Validation/CommonValidatorTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/CommonValidatorTest.cs
@@ -186,6 +186,44 @@ namespace CoreEx.Test.Framework.Validation
             });
         }
 
+        [Test]
+        public async Task CommonExtensionMethod()
+        {
+            await CommonExtensionMethod(null, false);
+            await CommonExtensionMethod("12345", false);
+            await CommonExtensionMethod("1234567", true);
+        }
+
+        private async Task CommonExtensionMethod(string? accountId, bool expectErrors)
+        {
+            var r = await accountId.Validate().Configure(cv => cv.Common(Validators.String5)).ValidateAsync();
+            Assert.That(r.HasErrors, Is.EqualTo(expectErrors));
+        }
+
+        [Test]
+        public async Task CommonEntity()
+        {
+            var pv = new PersonValidator();
+            var r = await pv.ValidateAsync(new Person());
+            Assert.That(r.HasErrors, Is.False);
+
+            r = await pv.ValidateAsync(new Person { Name = "12345" });
+            Assert.That(r.HasErrors, Is.False);
+
+            r = await pv.ValidateAsync(new Person { Name = "12345678" });
+            Assert.That(r.HasErrors, Is.True);
+        }
+
+        public static class Validators
+        {
+            public static CommonValidator<string> String5 => CommonValidator.Create<string>(c => c.String(5));
+        }
+
+        public class PersonValidator : Validator<Person>
+        {
+            public PersonValidator() => HasProperty(x => x.Name, p => p.Common(Validators.String5));
+        }
+
         public class Person
         {
             public string? Name { get; set; }


### PR DESCRIPTION
- *Fixed*: Removed `Azure.Identity` dependency as no longer required; related to `https://github.com/advisories/GHSA-wvxc-855f-jvrv`.
- *Fixed*: Removed `AspNetCore.HealthChecks.SqlServer` dependency as no longer required.
- *Fixed:* Updated all dependencies to latest versions.
- *Fixed*: `CoreEx.AutoMapper` updated to leverage latest major version (`13.0.1`); as such `netstandard` no longer supported.
- *Fixed*: The `TimerHostedServiceBase` was incorrectly resetting the `LastException` on sleep versus wake. 
- *Fixed*: The `AddEventSender` dependency injection extension methods now correctly register as _Scoped_.
- *Fixed*: The `Logger.LogInformation` invocations refactored to `Logger.LogDebug` where applicable to reduce noise in the logs.
- *Fixed*: The `IPropertyRule.ValidateAsync` method removed as it was not required and could lead to incorrect usage.
- *Fixed:* The `ValueValidator` now only supports a `Configure` method to enable `IPropertyRule`-based configuration (versus directly).
- *Fixed:* The `CommonValidator.ValidateAsync` is now internal as this was not intended and could lead to incorrect usage.
- *Enhancement*: Added `AfterSend` event to `IEventSender` to enable post-send processing.
- *Enhancement*: Added `EventOutboxHostedService.OneOffTrigger` method to enable a _one-off_ trigger interval to be specified for the registered (DI) instance.