### PR TITLE
v3.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v3.21.1
+- *Fixed:* `Mapper.MapSameTypeWithSourceValue` added (defaults to `true`) to map the source value to the destination value where the types are the same; previously this would result in an exception unless added explicitly. The `Mapper.SameTypeMapper` enables.
+- *Fixed:* `ReferenceDataOrchestrator.GetAllTypesInNamespace` added to get all the `IReferenceData` types in the specified namespace. Needed for the likes of the `CosmosDbBatch.ImportValueBatchAsync` where a list of types is required.
+
 ## v3.21.0
 - *Enhancement*: `CoreEx.Cosmos` improvements:
   - Added `CosmosDbArgs` to `CosmosDbContainerBase` to allow per container configuration where required.

--- a/Common.targets
+++ b/Common.targets
@@ -27,7 +27,7 @@
     <IsPackable>true</IsPackable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.21.0</Version>
+		<Version>3.21.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx.Cosmos/CosmosDbQueryBase.cs
+++ b/src/CoreEx.Cosmos/CosmosDbQueryBase.cs
@@ -16,26 +16,17 @@ namespace CoreEx.Cosmos
     /// <typeparam name="T">The resultant <see cref="Type"/>.</typeparam>
     /// <typeparam name="TModel">The cosmos model <see cref="Type"/>.</typeparam>
     /// <typeparam name="TSelf">The <see cref="Type"/> itself.</typeparam>
-    public abstract class CosmosDbQueryBase<T, TModel, TSelf> where T : class, new() where TModel : class, new() where TSelf : CosmosDbQueryBase<T, TModel, TSelf>
+    public abstract class CosmosDbQueryBase<T, TModel, TSelf>(ICosmosDbContainer container, CosmosDbArgs dbArgs) where T : class, new() where TModel : class, new() where TSelf : CosmosDbQueryBase<T, TModel, TSelf>
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CosmosDbQueryBase{T, TModel, TSelf}"/> class.
-        /// </summary>
-        protected CosmosDbQueryBase(ICosmosDbContainer container, CosmosDbArgs dbArgs)
-        {
-            Container = container.ThrowIfNull(nameof(container));
-            QueryArgs = dbArgs;
-        }
-
         /// <summary>
         /// Gets the <see cref="ICosmosDbContainer"/>.
         /// </summary>
-        public ICosmosDbContainer Container { get; }
+        public ICosmosDbContainer Container { get; } = container.ThrowIfNull(nameof(container));
 
         /// <summary>
         /// Gets the <see cref="CosmosDbArgs"/>.
         /// </summary>
-        public CosmosDbArgs QueryArgs;
+        public CosmosDbArgs QueryArgs = dbArgs;
 
         /// <summary>
         /// Gets the <see cref="PagingResult"/>.

--- a/src/CoreEx/CoreEx.csproj
+++ b/src/CoreEx/CoreEx.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="System.Memory.Data" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">

--- a/src/CoreEx/RefData/ReferenceDataOrchestrator.cs
+++ b/src/CoreEx/RefData/ReferenceDataOrchestrator.cs
@@ -669,5 +669,13 @@ namespace CoreEx.RefData
             ((IReferenceData)rdx).SetInvalid();
             return rdx;
         }
+
+        /// <summary>
+        /// Gets all the <see cref="IReferenceData"/> types in the same namespace as <typeparamref name="TNamespace"/>.
+        /// </summary>
+        /// <typeparam name="TNamespace">The <see cref="Type"/> to infer the namespace.</typeparam>
+        /// <returns>The <see cref="Type"/> list.</returns>
+        public static IEnumerable<Type> GetAllTypesInNamespace<TNamespace>() => typeof(TNamespace).Assembly.GetTypes().Where(t => t.Namespace == typeof(TNamespace).Namespace && t.IsClass && !t.IsAbstract && typeof(IReferenceData).IsAssignableFrom(t));
+
     }
 }

--- a/tests/CoreEx.Test/Framework/Mapping/MapperTest.cs
+++ b/tests/CoreEx.Test/Framework/Mapping/MapperTest.cs
@@ -913,8 +913,11 @@ namespace CoreEx.Test.Framework.Mapping
         {
             var m = new Mapper();
             var r = m.TryGetMapper<PersonA, PersonA>(out var sm);
-            Assert.That(r, Is.True);
-            Assert.That(sm, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(r, Is.True);
+                Assert.That(sm, Is.Not.Null);
+            });
 
             var p = new PersonA { Id = 88, Name = "blah" };
             var d = sm!.Map(p);
@@ -925,11 +928,18 @@ namespace CoreEx.Test.Framework.Mapping
         [Test]
         public void MapWithSameType_NotAllowed()
         {
-            var m = new Mapper();
-            m.MapSameTypeWithSourceValue = false;
+            var m = new Mapper
+            {
+                MapSameTypeWithSourceValue = false
+            };
+
             var r = m.TryGetMapper<PersonA, PersonA>(out var sm);
-            Assert.That(r, Is.False);
-            Assert.That(sm, Is.Null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(r, Is.False);
+                Assert.That(sm, Is.Null);
+            });
         }
 
         public class PersonAMapper : Mapper<PersonA, PersonB>

--- a/tests/CoreEx.Test/Framework/Mapping/MapperTest.cs
+++ b/tests/CoreEx.Test/Framework/Mapping/MapperTest.cs
@@ -908,6 +908,30 @@ namespace CoreEx.Test.Framework.Mapping
             Assert.That(pa2.Id, Is.EqualTo(88));
         }
 
+        [Test]
+        public void MapWithSameType_Allowed()
+        {
+            var m = new Mapper();
+            var r = m.TryGetMapper<PersonA, PersonA>(out var sm);
+            Assert.That(r, Is.True);
+            Assert.That(sm, Is.Not.Null);
+
+            var p = new PersonA { Id = 88, Name = "blah" };
+            var d = sm!.Map(p);
+            Assert.That(d, Is.Not.Null);
+            Assert.That(d, Is.SameAs(p));
+        }
+
+        [Test]
+        public void MapWithSameType_NotAllowed()
+        {
+            var m = new Mapper();
+            m.MapSameTypeWithSourceValue = false;
+            var r = m.TryGetMapper<PersonA, PersonA>(out var sm);
+            Assert.That(r, Is.False);
+            Assert.That(sm, Is.Null);
+        }
+
         public class PersonAMapper : Mapper<PersonA, PersonB>
         {
             public PersonAMapper()

--- a/tests/CoreEx.Test/Framework/RefData/ReferenceDataTest.cs
+++ b/tests/CoreEx.Test/Framework/RefData/ReferenceDataTest.cs
@@ -1159,6 +1159,13 @@ namespace CoreEx.Test.Framework.RefData
                 Assert.That(td.RefData.IsValid, Is.True);
             });
         }
+
+        [Test]
+        public void GetAllTypesInNamespace()
+        {
+            var types = ReferenceDataOrchestrator.GetAllTypesInNamespace<RefData>().ToList();
+            Assert.That(types, Has.Count.EqualTo(5));
+        }
     }
 
     public class RefData : ReferenceDataBaseEx<int, RefData> 


### PR DESCRIPTION
- *Fixed:* `Mapper.MapSameTypeWithSourceValue` added (defaults to `true`) to map the source value to the destination value where the types are the same; previously this would result in an exception unless added explicitly. The `Mapper.SameTypeMapper` enables.
- *Fixed:* `ReferenceDataOrchestrator.GetAllTypesInNamespace` added to get all the `IReferenceData` types in the specified namespace. Needed for the likes of the `CosmosDbBatch.ImportValueBatchAsync` where a list of types is required.