### PR TITLE
v3.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.23.2
+- *Fixed:* `DatabaseExtendedExtensions.DeleteWithResultAsync` corrected to return a `Task<Result>`.`
+
 ## v3.23.1
 - *Fixed:* Updated all dependencies to latest versions (specifically _UnitTestEx_).
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.23.1</Version>
+		<Version>3.23.2</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx.Database/Extended/DatabaseExtendedExtensions.cs
+++ b/src/CoreEx.Database/Extended/DatabaseExtendedExtensions.cs
@@ -405,7 +405,7 @@ namespace CoreEx.Database.Extended
         /// <param name="mapper">The <see cref="IDatabaseMapper{T}"/>.</param>
         /// <param name="key">The <see cref="CompositeKey"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
-        public static Task DeleteWithResultAsync(this DatabaseCommand command, IDatabaseMapper mapper, CompositeKey key, CancellationToken cancellationToken = default)
+        public static Task<Result> DeleteWithResultAsync(this DatabaseCommand command, IDatabaseMapper mapper, CompositeKey key, CancellationToken cancellationToken = default)
             => DeleteWithResultAsync(command, new DatabaseArgs(command.Database.DbArgs, mapper), key, cancellationToken);
 
         #endregion


### PR DESCRIPTION
- *Fixed:* `DatabaseExtendedExtensions.DeleteWithResultAsync` corrected to return a `Task<Result>`.`