### PR TITLE
v3.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.23.3
+- *Fixed:* Added `Result<T>.Adjusts` as wrapper for `ObjectExtensions.Adjust` to simplify support and resolve issue where the compiler sees the adjustment otherwise as a implicit cast resulting in an errant outcome.
+
 ## v3.23.2
 - *Fixed:* `DatabaseExtendedExtensions.DeleteWithResultAsync` corrected to return a `Task<Result>`.`
 

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.23.2</Version>
+		<Version>3.23.3</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx/Results/ResultsExtensions.cs
+++ b/src/CoreEx/Results/ResultsExtensions.cs
@@ -84,6 +84,21 @@ namespace CoreEx.Results
             => result.IsSuccess && result.Value == null ? throw new ArgumentNullException(name ?? Validation.Validation.ValueNameDefault) : result;
 
         /// <summary>
+        /// Enables adjustment (changes) to a <see cref="Result{T}.Value"/> via an <paramref name="adjuster"/> action where the <paramref name="result"/> is <see cref="Result{T}.IsSuccess"/>
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Result{T}.Value"/> <see cref="Type"/>.</typeparam>
+        /// <param name="result">The <see cref="Result{T}"/>.</param>
+        /// <param name="adjuster">The adjusting action (invoked only where the underlying <see cref="Result{T}.Value"/> is not <c>null</c>).</param>
+        /// <returns>The resulting <see cref="Result{T}"/>.</returns>
+        public static Result<T> Adjusts<T>(this Result<T> result, Action<T> adjuster)
+        {
+            if (result.IsSuccess)
+                result.Value.Adjust(adjuster);
+
+            return result;
+        }
+
+        /// <summary>
         /// Checks whether the user has the required <paramref name="permission"/> (see <see cref="ExecutionContext.UserIsAuthorized(string)"/>).
         /// </summary>
         /// <typeparam name="TResult">The <see cref="Result"/> or <see cref="Result{T}"/> <see cref="Type"/>.</typeparam>

--- a/tests/CoreEx.Test/Framework/Results/ResultTTest.cs
+++ b/tests/CoreEx.Test/Framework/Results/ResultTTest.cs
@@ -226,5 +226,32 @@ namespace CoreEx.Test.Framework.Results
             var ir = (IResult)Result<int>.Fail("On no!");
             Assert.Throws<BusinessException>(() => _ = ir.Value);
         }
+
+        [Test]
+        public void Adjusts()
+        {
+            var r = Result<Person>.Ok(new Person());
+            Assert.Multiple(() =>
+            {
+                Assert.That(r.IsSuccess, Is.True);
+                Assert.That(r.Value.Id, Is.EqualTo(0));
+            });
+
+            var r2 = r.Adjusts(v => v.Id = 2);
+            Assert.Multiple(() =>
+            {
+                Assert.That(r2.IsSuccess, Is.True);
+                Assert.That(r2.Value.Id, Is.EqualTo(2));
+            });
+
+            r = Result<Person>.Fail(new BusinessException());
+            r2 = r.Adjusts(v => v.Id = 2);
+            Assert.That(r2.IsSuccess, Is.False);
+        }
+
+        public class Person
+        {
+            public int Id { get; set; }
+        }
     }
 }


### PR DESCRIPTION
- *Fixed:* Added `Result<T>.Adjusts` as wrapper for `ObjectExtensions.Adjust` to simplify support and resolve issue where the compiler sees the adjustment otherwise as a implicit cast resulting in an errant outcome.