### PR TITLE
v3.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 Represents the **NuGet** versions.
 
 ## v3.25.1
-- *Fixed:* Extend `QueryFilterFieldConfigBase` to include `IsNullable()` to specifiy whether the field supports `null`, and include `StatementWriter()` to specify a function to override the statement result writing.
+- *Fixed:* Extend `QueryFilterFieldConfigBase` to include `AsNullable()` to specifiy whether the field supports `null`.
+- *Fixed:* Extend `QueryFilterFieldConfigBase` to include `WithResultWriter()` to specify a function to override the corresponding LINQ statement result writing.
+- *Fixed:* Adjusted the fluent-style method-chaining interface to improve usability (and consistency).
 
 ## v3.25.0
 - *Enhancement:* Added new `CoreEx.Data` project/package to encapsulate all generic data-related capabilities, specifically the new `QueryFilterParser` and `QueryOrderByParser` classes. These enable a limited, explicitly supported, dynamic capability to `$filter` and `$orderby` an underlying query _similar_ to _OData_. This is **not** intended to be a replacement for the full capabilities of OData, GraphQL, etc. but to offer basic dynamic flexibility where needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.25.1
+- *Fixed:* Extend `QueryFilterFieldConfigBase` to include `IsNullable()` to specifiy whether the field supports `null`, and include `StatementWriter()` to specify a function to override the statement result writing.
+
 ## v3.25.0
 - *Enhancement:* Added new `CoreEx.Data` project/package to encapsulate all generic data-related capabilities, specifically the new `QueryFilterParser` and `QueryOrderByParser` classes. These enable a limited, explicitly supported, dynamic capability to `$filter` and `$orderby` an underlying query _similar_ to _OData_. This is **not** intended to be a replacement for the full capabilities of OData, GraphQL, etc. but to offer basic dynamic flexibility where needed.
   - Added `IQueryable<T>.Where()` and `IQueryable<T>.OrderBy` extension method that will use the aforementioned parsers configured within the new `QueryArgsConfig` and `QueryArgs` and apply leveraging `System.Linq.Dynamic.Core`.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.25.0</Version>
+		<Version>3.25.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/My.Hr/My.Hr.Business/Services/EmployeeService.cs
+++ b/samples/My.Hr/My.Hr.Business/Services/EmployeeService.cs
@@ -6,8 +6,8 @@ public class EmployeeService : IEmployeeService
 {
     private static readonly QueryArgsConfig _queryConfig = QueryArgsConfig.Create()
         .WithFilter(filter => filter
-            .AddField<string>("LastName", c => c.Operators(QueryFilterTokenKind.AllStringOperators).UseUpperCase())
-            .AddField<string>("FirstName", c => c.Operators(QueryFilterTokenKind.AllStringOperators).UseUpperCase())
+            .AddField<string>("LastName", c => c.WithOperators(QueryFilterOperator.AllStringOperators).WithUpperCase())
+            .AddField<string>("FirstName", c => c.WithOperators(QueryFilterOperator.AllStringOperators).WithUpperCase())
             .AddField<DateTime>("StartDate")
             .AddField<DateTime>("TerminationDate")
             .AddField<string>(nameof(Employee.Gender), c => c.WithValue(v =>

--- a/src/CoreEx.Data/Querying/Expressions/IQueryFilterFieldStatementExpression.cs
+++ b/src/CoreEx.Data/Querying/Expressions/IQueryFilterFieldStatementExpression.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+namespace CoreEx.Data.Querying.Expressions
+{
+    /// <summary>
+    /// Identifies a query filter statement expression.
+    /// </summary>
+    public interface IQueryFilterFieldStatementExpression 
+    {
+        /// <summary>
+        /// Gets the field <see cref="IQueryFilterFieldConfig"/>.
+        /// </summary>
+        IQueryFilterFieldConfig FieldConfig { get; }
+
+        /// <summary>
+        /// Gets the field <see cref="QueryFilterToken"/>.
+        /// </summary>
+        QueryFilterToken Field { get; }
+    }
+}

--- a/src/CoreEx.Data/Querying/Expressions/QueryFilterCloseParenthesisExpression.cs
+++ b/src/CoreEx.Data/Querying/Expressions/QueryFilterCloseParenthesisExpression.cs
@@ -17,8 +17,5 @@ namespace CoreEx.Data.Querying.Expressions
 
         /// <inheritdoc/>
         public override void WriteToResult(QueryFilterParserResult result) => result.FilterBuilder.Append(_syntax.ToLinq(Filter));
-
-        /// <inheritdoc/>
-        protected override IQueryFilterFieldConfig? GetFieldConfig() => null;
     }
 }

--- a/src/CoreEx.Data/Querying/Expressions/QueryFilterExpressionBase.cs
+++ b/src/CoreEx.Data/Querying/Expressions/QueryFilterExpressionBase.cs
@@ -66,12 +66,6 @@ namespace CoreEx.Data.Querying.Expressions
         protected abstract void AddToken(int index, QueryFilterToken token);
 
         /// <summary>
-        /// Gets the underlying <see cref="IQueryFilterFieldConfig"/> used in the expression.
-        /// </summary>
-        /// <returns>The field <see cref="IQueryFilterFieldConfig"/> where applicable; otherwise, <see langword="null"/>.</returns>
-        protected abstract IQueryFilterFieldConfig? GetFieldConfig();
-
-        /// <summary>
         /// Converts the query filter expression into the corresponding dynamic LINQ appending to the <paramref name="result"/>.
         /// </summary>
         /// <param name="result">The <see cref="QueryFilterParserResult"/>.</param>

--- a/src/CoreEx.Data/Querying/Expressions/QueryFilterLogicalExpression.cs
+++ b/src/CoreEx.Data/Querying/Expressions/QueryFilterLogicalExpression.cs
@@ -50,8 +50,5 @@ namespace CoreEx.Data.Querying.Expressions
             if (_not.Kind != QueryFilterTokenKind.Unspecified)
                 result.Append(_not.ToLinq(Filter));
         }
-
-        /// <inheritdoc/>
-        protected override IQueryFilterFieldConfig? GetFieldConfig() => null;
     }
 }

--- a/src/CoreEx.Data/Querying/Expressions/QueryFilterOpenParenthesisExpression.cs
+++ b/src/CoreEx.Data/Querying/Expressions/QueryFilterOpenParenthesisExpression.cs
@@ -17,8 +17,5 @@ namespace CoreEx.Data.Querying.Expressions
 
         /// <inheritdoc/>
         public override void WriteToResult(QueryFilterParserResult result) => result.Append(_syntax.ToLinq(Filter));
-
-        /// <inheritdoc/>
-        protected override IQueryFilterFieldConfig? GetFieldConfig() => null;
     }
 }

--- a/src/CoreEx.Data/Querying/Expressions/QueryFilterOperatorExpression.cs
+++ b/src/CoreEx.Data/Querying/Expressions/QueryFilterOperatorExpression.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using System;
 using System.Collections.Generic;
 
 namespace CoreEx.Data.Querying.Expressions
@@ -10,14 +11,15 @@ namespace CoreEx.Data.Querying.Expressions
     /// <param name="parser">The <see cref="QueryFilterParser"/>.</param>
     /// <param name="filter">The originating query filter.</param>
     /// <param name="field">The field <see cref="QueryFilterToken"/>.</param>
-    public sealed class QueryFilterOperatorExpression(QueryFilterParser parser, string filter, QueryFilterToken field) : QueryFilterExpressionBase(parser, filter, field)
+    public sealed class QueryFilterOperatorExpression(QueryFilterParser parser, string filter, QueryFilterToken field) : QueryFilterExpressionBase(parser, filter, field), IQueryFilterFieldStatementExpression
     {
+        private IQueryFilterFieldConfig? _fieldConfig;
         private bool _isComplete;
 
         /// <summary>
         /// Gets the field <see cref="IQueryFilterFieldConfig"/>.
         /// </summary>
-        public IQueryFilterFieldConfig? FieldConfig { get; private set; }
+        public IQueryFilterFieldConfig FieldConfig => _fieldConfig ?? throw new InvalidOperationException($"{nameof(FieldConfig)} must be set before it can be accessed.");
 
         /// <summary>
         /// Gets the field <see cref="QueryFilterToken"/>.
@@ -47,7 +49,7 @@ namespace CoreEx.Data.Querying.Expressions
             {
                 case 0:
                     Field = token;
-                    FieldConfig = Parser.GetFieldConfig(Field, Filter);
+                    _fieldConfig = Parser.GetFieldConfig(Field, Filter);
                     _isComplete = FieldConfig.IsTypeBoolean;
                     break;
 
@@ -55,7 +57,7 @@ namespace CoreEx.Data.Querying.Expressions
                     if (!QueryFilterTokenKind.AllStringOperators.HasFlag(token.Kind))
                         throw new QueryFilterParserException($"Field '{Field.GetRawToken(Filter).ToString()}' does not support '{token.GetRawToken(Filter).ToString()}' as an operator.");
 
-                    if (!FieldConfig!.SupportedKinds.HasFlag(token.Kind))
+                    if (!FieldConfig.SupportedKinds.HasFlag(token.Kind))
                         throw new QueryFilterParserException($"Field '{Field.GetRawToken(Filter).ToString()}' does not support the '{token.GetRawToken(Filter).ToString()}' operator.");
 
                     _isComplete = false;
@@ -74,7 +76,7 @@ namespace CoreEx.Data.Querying.Expressions
                     if (token.Kind == QueryFilterTokenKind.Null && !QueryFilterTokenKind.EqualityOperator.HasFlag(Operator.Kind))
                         throw new QueryFilterParserException($"Field '{Field.GetRawToken(Filter).ToString()}' constant must not be null for an '{Operator.GetRawToken(Filter).ToString()}' operator.");
 
-                    FieldConfig!.ValidateConstant(Field, token, Filter);
+                    FieldConfig.ValidateConstant(Field, token, Filter);
                     Constants.Add(token);
                     _isComplete = true;
                     break;
@@ -91,7 +93,7 @@ namespace CoreEx.Data.Querying.Expressions
                         if (token.Kind == QueryFilterTokenKind.Null)
                             throw new QueryFilterParserException($"Field '{Field.GetRawToken(Filter).ToString()}' constant must not be null for an '{Operator.GetRawToken(Filter).ToString()}' operator.");
 
-                        FieldConfig!.ValidateConstant(Field, token, Filter);
+                        FieldConfig.ValidateConstant(Field, token, Filter);
                         Constants.Add(token);
                     }
                     else
@@ -113,19 +115,24 @@ namespace CoreEx.Data.Querying.Expressions
             }
         }
 
+        /// <summary>
+        /// Gets the converted <see cref="Constants"/> value using the specified <paramref name="index"/>.
+        /// </summary>
+        /// <param name="index">The <see cref="Constants"/> index.</param>
+        /// <returns>The converted value.</returns>
+        public object GetConstantValue(int index) => Constants[index].GetConvertedValue(Operator, Field, FieldConfig, Filter);
+
         /// <inheritdoc/>
         public override void WriteToResult(QueryFilterParserResult result)
         {
-            result.Fields.Add(FieldConfig!.Field);
-
-            if (Operator.Kind != QueryFilterTokenKind.In && (Constants.Count == 0 || Constants[0].Kind != QueryFilterTokenKind.Null) && FieldConfig!.IsCheckForNotNull)
+            if (Operator.Kind != QueryFilterTokenKind.In && (Constants.Count == 0 || Constants[0].Kind != QueryFilterTokenKind.Null) && FieldConfig.IsCheckForNotNull)
             {
                 result.Append("(");
                 result.FilterBuilder.Append(FieldConfig.Model);
                 result.FilterBuilder.Append(" != null && ");
             }
 
-            result.Append(FieldConfig!.Model);
+            result.Append(FieldConfig.Model);
 
             if (Constants.Count > 0)
             {
@@ -144,7 +151,7 @@ namespace CoreEx.Data.Querying.Expressions
                         if (i > 0)
                             result.FilterBuilder.Append(", ");
 
-                        result.AppendValue(Constants[i].GetConvertedValue(Operator, Field, FieldConfig, Filter));
+                        result.AppendValue(GetConstantValue(i));
                     }
 
                     result.FilterBuilder.Append(')');
@@ -152,17 +159,14 @@ namespace CoreEx.Data.Querying.Expressions
                 else
                 {
                     if (Constants[0].Kind == QueryFilterTokenKind.Value || Constants[0].Kind == QueryFilterTokenKind.Literal)
-                        result.AppendValue(Constants[0].GetConvertedValue(Operator, Field, FieldConfig, Filter));
+                        result.AppendValue(GetConstantValue(0));
                     else
                         result.FilterBuilder.Append(Constants[0].ToLinq(Filter));
                 }
             }
 
-            if (Operator.Kind != QueryFilterTokenKind.In && (Constants.Count == 0 || Constants[0].Kind != QueryFilterTokenKind.Null) && FieldConfig!.IsCheckForNotNull)
+            if (Operator.Kind != QueryFilterTokenKind.In && (Constants.Count == 0 || Constants[0].Kind != QueryFilterTokenKind.Null) && FieldConfig.IsCheckForNotNull)
                 result.FilterBuilder.Append(')');
         }
-
-        /// <inheritdoc/>
-        protected override IQueryFilterFieldConfig? GetFieldConfig() => FieldConfig;
     }
 }

--- a/src/CoreEx.Data/Querying/Expressions/QueryFilterOperatorExpression.cs
+++ b/src/CoreEx.Data/Querying/Expressions/QueryFilterOperatorExpression.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace CoreEx.Data.Querying.Expressions
 {
     /// <summary>
-    /// Represents a query filter <see cref="QueryFilterTokenKind.Operator"/> expression.
+    /// Represents a query filter <see cref="QueryFilterTokenKind.ComparisonOperators"/> expression.
     /// </summary>
     /// <param name="parser">The <see cref="QueryFilterParser"/>.</param>
     /// <param name="filter">The originating query filter.</param>
@@ -40,7 +40,7 @@ namespace CoreEx.Data.Querying.Expressions
         public override bool IsComplete => _isComplete;
 
         /// <inheritdoc/>
-        public override bool CanAddToken(QueryFilterToken token) => !_isComplete || TokenCount == 1 && QueryFilterTokenKind.Operator.HasFlag(token.Kind);
+        public override bool CanAddToken(QueryFilterToken token) => !_isComplete || TokenCount == 1 && QueryFilterTokenKind.ComparisonOperators.HasFlag(token.Kind);
 
         /// <inheritdoc/>
         protected override void AddToken(int index, QueryFilterToken token)
@@ -57,7 +57,8 @@ namespace CoreEx.Data.Querying.Expressions
                     if (!QueryFilterTokenKind.AllStringOperators.HasFlag(token.Kind))
                         throw new QueryFilterParserException($"Field '{Field.GetRawToken(Filter).ToString()}' does not support '{token.GetRawToken(Filter).ToString()}' as an operator.");
 
-                    if (!FieldConfig.SupportedKinds.HasFlag(token.Kind))
+                    var op = (QueryFilterOperator)(int)token.Kind; 
+                    if (!FieldConfig.Operators.HasFlag(op))
                         throw new QueryFilterParserException($"Field '{Field.GetRawToken(Filter).ToString()}' does not support the '{token.GetRawToken(Filter).ToString()}' operator.");
 
                     _isComplete = false;
@@ -73,7 +74,7 @@ namespace CoreEx.Data.Querying.Expressions
                         break;
                     }
 
-                    if (token.Kind == QueryFilterTokenKind.Null && !QueryFilterTokenKind.EqualityOperator.HasFlag(Operator.Kind))
+                    if (token.Kind == QueryFilterTokenKind.Null && !QueryFilterTokenKind.EqualityOperators.HasFlag(Operator.Kind))
                         throw new QueryFilterParserException($"Field '{Field.GetRawToken(Filter).ToString()}' constant must not be null for an '{Operator.GetRawToken(Filter).ToString()}' operator.");
 
                     FieldConfig.ValidateConstant(Field, token, Filter);

--- a/src/CoreEx.Data/Querying/Expressions/QueryFilterStringFunctionExpression.cs
+++ b/src/CoreEx.Data/Querying/Expressions/QueryFilterStringFunctionExpression.cs
@@ -5,7 +5,7 @@ using System;
 namespace CoreEx.Data.Querying.Expressions
 {
     /// <summary>
-    /// Represents a query filter <see cref="QueryFilterTokenKind.StringFunction"/> expression.
+    /// Represents a query filter <see cref="QueryFilterTokenKind.StringFunctions"/> expression.
     /// </summary>
     /// <param name="parser">The <see cref="QueryFilterParser"/>.</param>
     /// <param name="filter">The originating query filter.</param>
@@ -60,7 +60,8 @@ namespace CoreEx.Data.Querying.Expressions
                     Field = token;
                     _fieldConfig = Parser.GetFieldConfig(Field, Filter);
 
-                    if (!FieldConfig.SupportedKinds.HasFlag(Function.Kind))
+                    var op = (QueryFilterOperator)(int)Function.Kind;
+                    if (!FieldConfig.Operators.HasFlag(op))
                         throw new QueryFilterParserException($"Field '{Field.GetRawToken(Filter).ToString()}' does not support the '{Function.GetRawToken(Filter).ToString()}' function.");
 
                     break;

--- a/src/CoreEx.Data/Querying/Expressions/QueryFilterToken.cs
+++ b/src/CoreEx.Data/Querying/Expressions/QueryFilterToken.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace CoreEx.Data.Querying
+namespace CoreEx.Data.Querying.Expressions
 {
     /// <summary>
     /// Represents a <see cref="QueryFilterParser"/> token.

--- a/src/CoreEx.Data/Querying/Expressions/QueryFilterTokenKind.cs
+++ b/src/CoreEx.Data/Querying/Expressions/QueryFilterTokenKind.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace CoreEx.Data.Querying
+namespace CoreEx.Data.Querying.Expressions
 {
     /// <summary>
     /// Provides the <see cref="QueryFilterToken"/> kind.
@@ -128,12 +128,12 @@ namespace CoreEx.Data.Querying
         /// <summary>
         /// An expression operator token.
         /// </summary>
-        Operator = Equal | NotEqual | GreaterThan | GreaterThanOrEqual | LessThan | LessThanOrEqual | In,
+        ComparisonOperators = Equal | NotEqual | GreaterThan | GreaterThanOrEqual | LessThan | LessThanOrEqual | In,
 
         /// <summary>
         /// An expression equality operator token.
         /// </summary>
-        EqualityOperator = Equal | NotEqual | In,
+        EqualityOperators = Equal | NotEqual | In,
 
         /// <summary>
         /// An expression constant token.
@@ -153,11 +153,11 @@ namespace CoreEx.Data.Querying
         /// <summary>
         /// A string oriented function-based operator.
         /// </summary>
-        StringFunction = StartsWith | EndsWith | Contains,
+        StringFunctions = StartsWith | EndsWith | Contains,
 
         /// <summary>
         /// All string oriented operators.
         /// </summary>
-        AllStringOperators = Operator | StringFunction
+        AllStringOperators = ComparisonOperators | StringFunctions
     }
 }

--- a/src/CoreEx.Data/Querying/IQueryFilterFieldConfig.cs
+++ b/src/CoreEx.Data/Querying/IQueryFilterFieldConfig.cs
@@ -54,6 +54,11 @@ namespace CoreEx.Data.Querying
         bool IsToUpper { get; }
 
         /// <summary>
+        /// Indicates whether the field can be <see langword="null"/> or not.
+        /// </summary>
+        bool IsNullable { get; }
+
+        /// <summary>
         /// Indicates whether a not-<see langword="null"/> check should also be performed before the comparion occurs.
         /// </summary>
         bool IsCheckForNotNull { get; }
@@ -80,5 +85,10 @@ namespace CoreEx.Data.Querying
         /// <param name="constant">The constant <see cref="QueryFilterToken"/>.</param>
         /// <param name="filter">The query filter.</param>
         void ValidateConstant(QueryFilterToken field, QueryFilterToken constant, string filter);
+
+        /// <summary>
+        /// Gets the <see cref="QueryFilterFieldResultWriter"/>.
+        /// </summary>
+        QueryFilterFieldResultWriter? ResultWriter { get; }
     }
 }

--- a/src/CoreEx.Data/Querying/IQueryFilterFieldConfig.cs
+++ b/src/CoreEx.Data/Querying/IQueryFilterFieldConfig.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Data.Querying.Expressions;
 using CoreEx.Mapping.Converters;
 using System;
+using System.Text;
 
 namespace CoreEx.Data.Querying
 {
@@ -44,8 +46,8 @@ namespace CoreEx.Data.Querying
         /// <summary>
         /// Gets the supported kinds.
         /// </summary>
-        /// <remarks>Where <see cref="IsTypeBoolean"/> defaults to both <see cref="QueryFilterTokenKind.Equal"/> and <see cref="QueryFilterTokenKind.NotEqual"/> only; otherwise, defaults to <see cref="QueryFilterTokenKind.Operator"/>.</remarks>
-        QueryFilterTokenKind SupportedKinds { get; }
+        /// <remarks>Where <see cref="IsTypeBoolean"/> defaults to both <see cref="QueryFilterOperator.Equal"/> and <see cref="QueryFilterOperator.NotEqual"/> only; otherwise, defaults to <see cref="QueryFilterOperator.ComparisonOperators"/>.</remarks>
+        QueryFilterOperator Operators { get; }
 
         /// <summary>
         /// Indicates whether the comparison should ignore case or not; will use <see cref="string.ToUpper()"/> when selected for comparisons.
@@ -69,6 +71,11 @@ namespace CoreEx.Data.Querying
         QueryStatement? DefaultStatement { get; }
 
         /// <summary>
+        /// Gets the additional help text.
+        /// </summary>
+        string? HelpText { get; }
+
+        /// <summary>
         /// Converts <paramref name="field"/> to the destination type using the <see cref="Converter"/> configurations where specified.
         /// </summary>
         /// <param name="operation">The operation <see cref="QueryFilterTokenKind"/> being performed on the <paramref name="field"/>.</param>
@@ -90,5 +97,12 @@ namespace CoreEx.Data.Querying
         /// Gets the <see cref="QueryFilterFieldResultWriter"/>.
         /// </summary>
         QueryFilterFieldResultWriter? ResultWriter { get; }
+
+        /// <summary>
+        /// Appends the field configuration to the <paramref name="stringBuilder"/>.
+        /// </summary>
+        /// <param name="stringBuilder">The <see cref="StringBuilder"/>.</param>
+        /// <returns>The <paramref name="stringBuilder"/>.</returns>
+        StringBuilder AppendToString(StringBuilder stringBuilder);
     }
 }

--- a/src/CoreEx.Data/Querying/QueryArgsConfig.cs
+++ b/src/CoreEx.Data/Querying/QueryArgsConfig.cs
@@ -22,7 +22,7 @@ namespace CoreEx.Data.Querying
         /// <summary>
         /// Gets the <see cref="QueryFilterParser"/>.
         /// </summary>
-        public QueryFilterParser FilterParser => _filterParser ??= new QueryFilterParser();
+        public QueryFilterParser FilterParser => _filterParser ??= new QueryFilterParser(this);
 
         /// <summary>
         /// Indicates whether there is a <see cref="FilterParser"/>.
@@ -32,7 +32,7 @@ namespace CoreEx.Data.Querying
         /// <summary>
         /// Gets the <see cref="QueryOrderByParser"/>.
         /// </summary>
-        public QueryOrderByParser OrderByParser => _orderByParser ??= new QueryOrderByParser();
+        public QueryOrderByParser OrderByParser => _orderByParser ??= new QueryOrderByParser(this);
 
         /// <summary>
         /// Indicates whether there is an <see cref="OrderByParser"/>.

--- a/src/CoreEx.Data/Querying/QueryFilterExtensions.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterExtensions.cs
@@ -75,7 +75,7 @@ namespace System.Linq
         {
             queryConfig.ThrowIfNull(nameof(queryConfig));
             if (!queryConfig.HasOrderByParser)
-                throw new QueryOrderByParserException("Capability is not currently supported.");
+                throw new QueryOrderByParserException("OrderBy statement is not currently supported.");
 
             var linq = queryConfig.OrderByParser.Parse(orderby.ThrowIfNullOrEmpty(nameof(orderby)));
             return query.OrderBy(linq);

--- a/src/CoreEx.Data/Querying/QueryFilterFieldConfigBase.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterFieldConfigBase.cs
@@ -87,6 +87,14 @@ namespace CoreEx.Data.Querying
         protected bool IsToUpper { get; set; } = false;
 
         /// <inheritdoc/>
+        bool IQueryFilterFieldConfig.IsNullable => IsNullable;
+
+        /// <summary>
+        /// Indicates whether the field can be <see langword="null"/> or not.
+        /// </summary>
+        protected bool IsNullable { get; set; } = false;
+
+        /// <inheritdoc/>
         bool IQueryFilterFieldConfig.IsCheckForNotNull => IsCheckForNotNull;
 
         /// <summary>
@@ -101,6 +109,14 @@ namespace CoreEx.Data.Querying
         /// Gets the default LINQ <see cref="QueryStatement"/> to be used where no filtering is specified.
         /// </summary>
         protected QueryStatement? DefaultStatement { get; set; }
+
+        /// <inheritdoc/>
+        QueryFilterFieldResultWriter? IQueryFilterFieldConfig.ResultWriter => ResultWriter;
+
+        /// <summary>
+        /// Gets the <see cref="QueryFilterFieldResultWriter"/>.
+        /// </summary>
+        protected QueryFilterFieldResultWriter? ResultWriter { get; set; }
 
         /// <inheritdoc/>
         object? IQueryFilterFieldConfig.ConvertToValue(QueryFilterToken operation, QueryFilterToken field, string filter) => ConvertToValue(operation, field, filter);
@@ -125,6 +141,9 @@ namespace CoreEx.Data.Querying
         {
             if (!QueryFilterTokenKind.Constant.HasFlag(constant.Kind))
                 throw new QueryFilterParserException($"Field '{field.GetRawToken(filter).ToString()}' constant '{constant.GetValueToken(filter)}' is not considered valid.");
+
+            if (constant.Kind == QueryFilterTokenKind.Null && !IsNullable)
+                throw new QueryFilterParserException($"Field '{field.GetRawToken(filter).ToString()}' constant '{constant.GetValueToken(filter)}' is not supported.");
 
             if (IsTypeString)
             {

--- a/src/CoreEx.Data/Querying/QueryFilterFieldConfigBase.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterFieldConfigBase.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Data.Querying.Expressions;
 using CoreEx.Mapping.Converters;
 using System;
+using System.Text;
 
 namespace CoreEx.Data.Querying
 {
@@ -33,22 +35,37 @@ namespace CoreEx.Data.Querying
             IsTypeBoolean = type == typeof(bool);
 
             if (IsTypeBoolean)
-                SupportedKinds = QueryFilterTokenKind.Equal | QueryFilterTokenKind.NotEqual;
+                Operators = QueryFilterOperator.Equal | QueryFilterOperator.NotEqual;
             else
-                SupportedKinds = QueryFilterTokenKind.Operator;
+                Operators = QueryFilterOperator.ComparisonOperators;
         }
 
         /// <inheritdoc/>
         QueryFilterParser IQueryFilterFieldConfig.Parser => _parser;
 
         /// <inheritdoc/>
-        Type IQueryFilterFieldConfig.Type => _type;
+        Type IQueryFilterFieldConfig.Type => Type;
+
+        /// <summary>
+        /// Gets the field type.
+        /// </summary>
+        protected Type Type => _type;
 
         /// <inheritdoc/>
-        string IQueryFilterFieldConfig.Field => _field;
+        string IQueryFilterFieldConfig.Field => Field;
+
+        /// <summary>
+        /// Gets the field name.
+        /// </summary>
+        protected string Field => _field;
 
         /// <inheritdoc/>
-        string? IQueryFilterFieldConfig.Model => _model ?? _field;
+        string? IQueryFilterFieldConfig.Model => Model;
+
+        /// <summary>
+        /// Gets the model name to be used for the dynamic LINQ expression.
+        /// </summary>
+        protected string? Model => _model ?? _field;
 
         /// <inheritdoc/>
         bool IQueryFilterFieldConfig.IsTypeString => IsTypeString;
@@ -69,13 +86,13 @@ namespace CoreEx.Data.Querying
         protected bool IsTypeBoolean { get; set; }
 
         /// <inheritdoc/>
-        QueryFilterTokenKind IQueryFilterFieldConfig.SupportedKinds => SupportedKinds;
+        QueryFilterOperator IQueryFilterFieldConfig.Operators => Operators;
 
         /// <summary>
-        /// Gets the supported kinds.
+        /// Gets the supported <see cref="QueryFilterOperator"/>(s).
         /// </summary>
-        /// <remarks>Where <see cref="IQueryFilterFieldConfig.IsTypeBoolean"/> defaults to both <see cref="QueryFilterTokenKind.Equal"/> and <see cref="QueryFilterTokenKind.NotEqual"/>; otherwise, defaults to <see cref="QueryFilterTokenKind.Operator"/>.</remarks>
-        protected QueryFilterTokenKind SupportedKinds { get; set; }
+        /// <remarks>Where <see cref="IQueryFilterFieldConfig.IsTypeBoolean"/> defaults to both <see cref="QueryFilterOperator.Equal"/> and <see cref="QueryFilterOperator.NotEqual"/>; otherwise, defaults to <see cref="QueryFilterOperator.ComparisonOperators"/>.</remarks>
+        protected QueryFilterOperator Operators { get; set; }
 
         /// <inheritdoc/>
         bool IQueryFilterFieldConfig.IsToUpper => IsToUpper;
@@ -106,7 +123,7 @@ namespace CoreEx.Data.Querying
         QueryStatement? IQueryFilterFieldConfig.DefaultStatement => DefaultStatement;
 
         /// <summary>
-        /// Gets the default LINQ <see cref="QueryStatement"/> to be used where no filtering is specified.
+        /// Gets or sets the default LINQ <see cref="QueryStatement"/> to be used where no filtering is specified.
         /// </summary>
         protected QueryStatement? DefaultStatement { get; set; }
 
@@ -114,9 +131,17 @@ namespace CoreEx.Data.Querying
         QueryFilterFieldResultWriter? IQueryFilterFieldConfig.ResultWriter => ResultWriter;
 
         /// <summary>
-        /// Gets the <see cref="QueryFilterFieldResultWriter"/>.
+        /// Gets or sets the <see cref="QueryFilterFieldResultWriter"/>.
         /// </summary>
         protected QueryFilterFieldResultWriter? ResultWriter { get; set; }
+
+        /// <inheritdoc/>
+        string? IQueryFilterFieldConfig.HelpText => HelpText;
+
+        /// <summary>
+        /// Gets or sets the additional help text.
+        /// </summary>
+        protected string? HelpText { get; set; }
 
         /// <inheritdoc/>
         object? IQueryFilterFieldConfig.ConvertToValue(QueryFilterToken operation, QueryFilterToken field, string filter) => ConvertToValue(operation, field, filter);
@@ -161,5 +186,76 @@ namespace CoreEx.Data.Querying
                     throw new QueryFilterParserException($"Field '{field.GetRawToken(filter).ToString()}' constant '{constant.GetValueToken(filter)}' must not be specified as a {QueryFilterTokenKind.Literal} where the underlying type is not a string.");
             }
         }
+
+        /// <inheritdoc/>
+        public override string ToString() => AppendToString(new StringBuilder()).ToString();
+
+        /// <summary>
+        /// Appends the field configuration to the <paramref name="stringBuilder"/>.
+        /// </summary>
+        /// <param name="stringBuilder">The <see cref="StringBuilder"/>.</param>
+        /// <returns>The <paramref name="stringBuilder"/>.</returns>
+        public virtual StringBuilder AppendToString(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append(_field);
+            stringBuilder.Append(" (Type: ").Append(_type.Name);
+            stringBuilder.Append(", Null: ").Append(IsNullable ? "true" : "false");
+            stringBuilder.Append(", Operators: ");
+
+            AppendOperatorsToString(stringBuilder);
+
+            stringBuilder.Append(')');
+            if (!string.IsNullOrEmpty(HelpText))
+                stringBuilder.Append(" - ").Append(HelpText);
+
+            return stringBuilder;
+        }
+
+        /// <summary>
+        /// Appends the <see cref="Operators"/> to the <paramref name="stringBuilder"/>.
+        /// </summary>
+        /// <param name="stringBuilder">The <see cref="StringBuilder"/>.</param>
+        /// <returns>The <paramref name="stringBuilder"/>.</returns>
+        protected StringBuilder AppendOperatorsToString(StringBuilder stringBuilder)
+        {
+            var first = true;
+            foreach (var e in Enum.GetValues(typeof(QueryFilterOperator)))
+            {
+                if (Operators.HasFlag((QueryFilterOperator)e))
+                {
+                    var op = GetODataOperator((QueryFilterOperator)e);
+                    if (op is not null)
+                    {
+                        if (first)
+                            first = false;
+                        else
+                            stringBuilder.Append(", ");
+
+                        stringBuilder.Append(op);
+                    }
+                }
+            }
+
+            return stringBuilder;
+        }
+
+        /// <summary>
+        /// Gets the ODATA operator for the specified <paramref name="operator"/>
+        /// </summary>
+        /// <param name="operator">The <see cref="QueryFilterOperator"/>.</param>
+        protected static string? GetODataOperator(QueryFilterOperator @operator) => @operator switch
+        {
+            QueryFilterOperator.Equal => "EQ",
+            QueryFilterOperator.NotEqual => "NE",
+            QueryFilterOperator.GreaterThan => "GT",
+            QueryFilterOperator.GreaterThanOrEqual => "GE",
+            QueryFilterOperator.LessThan => "LT",
+            QueryFilterOperator.LessThanOrEqual => "LE",
+            QueryFilterOperator.In => "IN",
+            QueryFilterOperator.StartsWith => nameof(QueryFilterOperator.StartsWith),
+            QueryFilterOperator.EndsWith => nameof(QueryFilterOperator.EndsWith),
+            QueryFilterOperator.Contains => nameof(QueryFilterOperator.Contains),
+            _ => null
+        };
     }
 }

--- a/src/CoreEx.Data/Querying/QueryFilterFieldConfigBaseT.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterFieldConfigBaseT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Data.Querying.Expressions;
 using System;
 
 namespace CoreEx.Data.Querying
@@ -16,13 +17,25 @@ namespace CoreEx.Data.Querying
         : QueryFilterFieldConfigBase(parser, type, field, model) where TSelf : QueryFilterFieldConfigBase<TSelf>
     {
         /// <summary>
+        /// Indicates that the field can be <see langword="null"/>.
+        /// </summary>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        /// <remarks>Sets the <see cref="QueryFilterFieldConfigBase.IsNullable"/> to <see langword="true"/>.</remarks>
+        public TSelf Nullable()
+        {
+            IsNullable = true;
+            return (TSelf)this;
+        }
+
+        /// <summary>
         /// Indicates that a not-<see langword="null"/> check should also be performed before a comparion occurs.
         /// </summary>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
-        /// <remarks>Sets the <see cref="QueryFilterFieldConfigBase.IsCheckForNotNull"/> to <see langword="true"/>.</remarks>
+        /// <remarks>Sets the <see cref="QueryFilterFieldConfigBase.IsCheckForNotNull"/> and <see cref="QueryFilterFieldConfigBase.IsNullable"/> to <see langword="true"/>.</remarks>
         public TSelf AlsoCheckNotNull()
         {
             IsCheckForNotNull = true;
+            IsNullable = true;
             return (TSelf)this;
         }
 
@@ -30,12 +43,23 @@ namespace CoreEx.Data.Querying
         /// Sets (overrides) the default default LINQ statement to be used where no filtering is specified.
         /// </summary>
         /// <param name="statement">The LINQ <see cref="QueryStatement"/>.</param>
-        /// <returns></returns>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         /// <remarks>To avoid unnecessary parsing this should be specified as a valid dynamic LINQ statement.
         /// <para>This must be the required expression <b>only</b>. It will be appended as an <i>and</i> to the final LINQ statement.</para></remarks>
         public TSelf Default(QueryStatement? statement)
         {
             DefaultStatement = statement;
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Sets (overrides) the function that will be used to write the <see cref="IQueryFilterFieldStatementExpression"/> LINQ statement to the <see cref="QueryFilterParserResult.FilterBuilder"/>.
+        /// </summary>
+        /// <param name="resultWriter">The <see cref="QueryFilterFieldResultWriter"/>.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf StatementWriter(QueryFilterFieldResultWriter? resultWriter)
+        {
+            ResultWriter = resultWriter;
             return (TSelf)this;
         }
     }

--- a/src/CoreEx.Data/Querying/QueryFilterFieldConfigBaseT.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterFieldConfigBaseT.cs
@@ -21,7 +21,7 @@ namespace CoreEx.Data.Querying
         /// </summary>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         /// <remarks>Sets the <see cref="QueryFilterFieldConfigBase.IsNullable"/> to <see langword="true"/>.</remarks>
-        public TSelf Nullable()
+        public TSelf AsNullable()
         {
             IsNullable = true;
             return (TSelf)this;
@@ -46,7 +46,7 @@ namespace CoreEx.Data.Querying
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
         /// <remarks>To avoid unnecessary parsing this should be specified as a valid dynamic LINQ statement.
         /// <para>This must be the required expression <b>only</b>. It will be appended as an <i>and</i> to the final LINQ statement.</para></remarks>
-        public TSelf Default(QueryStatement? statement)
+        public TSelf WithDefault(QueryStatement? statement)
         {
             DefaultStatement = statement;
             return (TSelf)this;
@@ -57,9 +57,20 @@ namespace CoreEx.Data.Querying
         /// </summary>
         /// <param name="resultWriter">The <see cref="QueryFilterFieldResultWriter"/>.</param>
         /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
-        public TSelf StatementWriter(QueryFilterFieldResultWriter? resultWriter)
+        public TSelf WithResultWriter(QueryFilterFieldResultWriter? resultWriter)
         {
             ResultWriter = resultWriter;
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        /// Sets (overrides) the additional help text.
+        /// </summary>
+        /// <param name="text">The additional help text.</param>
+        /// <returns>The <typeparamref name="TSelf"/> to support fluent-style method-chaining.</returns>
+        public TSelf WithHelpText(string text)
+        {
+            HelpText = text.ThrowIfNullOrEmpty(nameof(text));
             return (TSelf)this;
         }
     }

--- a/src/CoreEx.Data/Querying/QueryFilterFieldConfigT.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterFieldConfigT.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Data.Querying.Expressions;
 using CoreEx.Mapping.Converters;
 using System;
 
@@ -18,17 +19,17 @@ namespace CoreEx.Data.Querying
         private Func<T, object>? _valueFunc;
 
         /// <summary>
-        /// Sets (overrides) the operator <see cref="QueryFilterFieldConfigBase.SupportedKinds"/>.
+        /// Sets (overrides) the operator <see cref="QueryFilterFieldConfigBase.Operators"/>.
         /// </summary>
-        /// <param name="kinds">The supported <see cref="QueryFilterTokenKind"/> flags.</param>
+        /// <param name="operators">The supported <see cref="QueryFilterOperator"/>(s).</param>
         /// <returns>The <see cref="QueryFilterFieldConfig{T}"/> to support fluent-style method-chaining.</returns>
-        /// <remarks>The default is <see cref="QueryFilterTokenKind.Operator"/>.</remarks>
-        public QueryFilterFieldConfig<T> Operators(QueryFilterTokenKind kinds)
+        /// <remarks>The default is <see cref="QueryFilterTokenKind.ComparisonOperators"/>.</remarks>
+        public QueryFilterFieldConfig<T> WithOperators(QueryFilterOperator operators)
         {
             if (((IQueryFilterFieldConfig)this).IsTypeBoolean)
-                throw new NotSupportedException($"{nameof(Operators)} is not supported where {nameof(IQueryFilterFieldConfig.IsTypeBoolean)}.");
+                throw new NotSupportedException($"{nameof(WithOperators)} is not supported where {nameof(IQueryFilterFieldConfig.IsTypeBoolean)}.");
 
-            SupportedKinds = kinds;
+            Operators = operators;
             return this;
         }
 
@@ -37,10 +38,10 @@ namespace CoreEx.Data.Querying
         /// </summary>
         /// <returns>The <see cref="QueryFilterFieldConfig{T}"/> to support fluent-style method-chaining.</returns>
         /// <remarks>Sets the <see cref="QueryFilterFieldConfigBase.IsToUpper"/> to <see langword="true"/>.</remarks>
-        public QueryFilterFieldConfig<T> UseUpperCase()
+        public QueryFilterFieldConfig<T> WithUpperCase()
         {
             if (!((IQueryFilterFieldConfig)this).IsTypeString)
-                throw new ArgumentException($"A {nameof(UseUpperCase)} can only be specified where the field type is a string.");
+                throw new ArgumentException($"A {nameof(WithUpperCase)} can only be specified where the field type is a string.");
 
             IsToUpper = true;
             return this;

--- a/src/CoreEx.Data/Querying/QueryFilterFieldResultWriter.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterFieldResultWriter.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using CoreEx.Data.Querying.Expressions;
+
+namespace CoreEx.Data.Querying
+{
+    /// <summary>
+    /// The <see cref="QueryFilterParserResult"/> writing function that will be used to write the <paramref name="expression"/> to the <see cref="QueryFilterParserResult.FilterBuilder"/>.
+    /// </summary>
+    /// <param name="expression">The <see cref="IQueryFilterFieldStatementExpression"/> expression.</param>
+    /// <param name="result">The <see cref="QueryFilterParserResult"/>.</param>
+    /// <returns><see langword="true"/> indicates that a LINQ statement has been written to the <see cref="QueryFilterParserResult.FilterBuilder"/> and that the standard writer should not be invoked;
+    /// otherwise, <see langword="false"/> indicates that the standard writer is to be invoked.</returns>
+    public delegate bool QueryFilterFieldResultWriter(IQueryFilterFieldStatementExpression expression, QueryFilterParserResult result);
+}

--- a/src/CoreEx.Data/Querying/QueryFilterNullFieldConfig.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterNullFieldConfig.cs
@@ -15,7 +15,11 @@ namespace CoreEx.Data.Querying
         /// <param name="parser">The owning <see cref="QueryFilterParser"/>.</param>
         /// <param name="field">The field name.</param>
         /// <param name="model">The model name (defaults to <paramref name="field"/>.</param>
-        public QueryFilterNullFieldConfig(QueryFilterParser parser, string field, string? model) : base(parser, typeof(object), field, model) => SupportedKinds = QueryFilterTokenKind.Equal | QueryFilterTokenKind.NotEqual;
+        public QueryFilterNullFieldConfig(QueryFilterParser parser, string field, string? model) : base(parser, typeof(object), field, model)
+        {
+            SupportedKinds = QueryFilterTokenKind.Equal | QueryFilterTokenKind.NotEqual;
+            IsNullable = true;
+        }
 
         /// <inheritdoc/>
         protected override object ConvertToValue(QueryFilterToken operation, QueryFilterToken field, string filter)

--- a/src/CoreEx.Data/Querying/QueryFilterNullFieldConfig.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterNullFieldConfig.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using System;
+using System.Data;
+using System.Text;
+using CoreEx.Data.Querying.Expressions;
 
 namespace CoreEx.Data.Querying
 {
@@ -17,12 +20,33 @@ namespace CoreEx.Data.Querying
         /// <param name="model">The model name (defaults to <paramref name="field"/>.</param>
         public QueryFilterNullFieldConfig(QueryFilterParser parser, string field, string? model) : base(parser, typeof(object), field, model)
         {
-            SupportedKinds = QueryFilterTokenKind.Equal | QueryFilterTokenKind.NotEqual;
+            Operators = QueryFilterOperator.Equal | QueryFilterOperator.NotEqual;
             IsNullable = true;
         }
 
         /// <inheritdoc/>
         protected override object ConvertToValue(QueryFilterToken operation, QueryFilterToken field, string filter)
             => throw new FormatException("Only null comparisons are supported.");
+
+        /// <summary>
+        /// Appends the field configuration to the <paramref name="stringBuilder"/>.
+        /// </summary>
+        /// <param name="stringBuilder">The <see cref="StringBuilder"/>.</param>
+        /// <returns>The <paramref name="stringBuilder"/>.</returns>
+        public override StringBuilder AppendToString(StringBuilder stringBuilder)
+        {
+            stringBuilder.Append(Field);
+            stringBuilder.Append(" (Type: <none>");
+            stringBuilder.Append(", Null: ").Append(IsNullable ? "true" : "false");
+            stringBuilder.Append(", Operators: ");
+
+            AppendOperatorsToString(stringBuilder);
+
+            stringBuilder.Append(')');
+            if (!string.IsNullOrEmpty(HelpText))
+                stringBuilder.Append(" - ").Append(HelpText);
+
+            return stringBuilder;
+        }
     }
 }

--- a/src/CoreEx.Data/Querying/QueryFilterOperator.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterOperator.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using CoreEx.Data.Querying.Expressions;
+
+namespace CoreEx.Data.Querying
+{
+    /// <summary>
+    /// Enables the <see cref="IQueryFilterFieldConfig.Operators"/>.
+    /// </summary>
+    /// <remarks>Values are the same as the <see cref="QueryFilterTokenKind"/> to simplify usage.</remarks>
+    [Flags]
+    public enum QueryFilterOperator
+    {
+        /// <summary>
+        /// The equal operator.
+        /// </summary>
+        Equal = 4,
+
+        /// <summary>
+        /// The not equal operator.
+        /// </summary>
+        NotEqual = 8,
+
+        /// <summary>
+        /// The less than operator.
+        /// </summary>
+        LessThan = 16,
+
+        /// <summary>
+        /// The less than or equal operator.
+        /// </summary>
+        LessThanOrEqual = 32,
+
+        /// <summary>
+        /// The greater than or equal operator.
+        /// </summary>
+        GreaterThanOrEqual = 64,
+
+        /// <summary>
+        /// The greater than operator.
+        /// </summary>
+        GreaterThan = 128,
+
+        /// <summary>
+        /// The logical IN operator.
+        /// </summary>
+        In = 256,
+
+        /// <summary>
+        /// The starts with function.
+        /// </summary>
+        StartsWith = 524288,
+
+        /// <summary>
+        /// The contains function.
+        /// </summary>
+        Contains = 1048576,
+
+        /// <summary>
+        /// The ends with function.
+        /// </summary>
+        EndsWith = 2097152,
+
+        /// <summary>
+        /// The <i>equality</i> operators.
+        /// </summary>
+        EqualityOperators = Equal | NotEqual | In,
+
+        /// <summary>
+        /// The <i>comparison</i> operators.
+        /// </summary>
+        ComparisonOperators = EqualityOperators | GreaterThan | GreaterThanOrEqual | LessThan | LessThanOrEqual,
+
+        /// <summary>
+        /// The string oriented function-based operators.
+        /// </summary>
+        StringFunctions = StartsWith | EndsWith | Contains,
+
+        /// <summary>
+        /// All string oriented operators and functions.
+        /// </summary>
+        AllStringOperators = ComparisonOperators | StringFunctions
+    }
+}

--- a/src/CoreEx.Data/Querying/QueryFilterParser.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterParser.cs
@@ -169,6 +169,13 @@ namespace CoreEx.Data.Querying
             // Append all the expressions to the resulting LINQ whilst parsing.
             foreach (var expression in GetExpressions(filter))
             {
+                if (expression is IQueryFilterFieldStatementExpression fse)
+                {
+                    result.Fields.Add(fse.FieldConfig.Field);
+                    if (fse.FieldConfig.ResultWriter is not null && fse.FieldConfig.ResultWriter.Invoke(fse, result))
+                        continue;
+                }
+
                 WriteToResult(expression, result);
             }
 

--- a/src/CoreEx.Data/Querying/QueryFilterReferenceDataFieldConfig.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterReferenceDataFieldConfig.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Data.Querying.Expressions;
 using CoreEx.Entities;
 using CoreEx.RefData;
 using System;
@@ -10,7 +11,7 @@ namespace CoreEx.Data.Querying
     /// Provides the <see cref="QueryFilterParser"/> <see cref="IReferenceData"/> field configuration.
     /// </summary>
     /// <typeparam name="TRef">The <see cref="IReferenceData"/> <see cref="Type"/>.</typeparam>
-    /// <remarks>This will automatically set the <see cref="QueryFilterFieldConfigBase.SupportedKinds"/> to be <see cref="QueryFilterTokenKind.EqualityOperator"/> only.</remarks>
+    /// <remarks>Defaults the <see cref="QueryFilterFieldConfigBase.Operators"/> to <see cref="QueryFilterOperator.EqualityOperators"/> only.</remarks>
     public class QueryFilterReferenceDataFieldConfig<TRef> : QueryFilterFieldConfigBase<QueryFilterFieldConfig<TRef>> where TRef : IReferenceData, new()
     {
         private bool _useIdentifier;
@@ -25,7 +26,7 @@ namespace CoreEx.Data.Querying
         /// <param name="model">The model name (defaults to <paramref name="field"/>.</param>
         public QueryFilterReferenceDataFieldConfig(QueryFilterParser parser, string field, string? model) : base(parser, typeof(TRef), field, model)
         {
-            SupportedKinds = QueryFilterTokenKind.EqualityOperator;
+            Operators = QueryFilterOperator.EqualityOperators;
             IsTypeString = true;
         }
 
@@ -33,7 +34,7 @@ namespace CoreEx.Data.Querying
         /// Indicates that the <see cref="IReferenceData"/> <see cref="IIdentifier.Id"/> is to be used as the value for the query (versus the originating filter value being the <see cref="IReferenceData.Code"/>).
         /// </summary>
         /// <returns>The <see cref="QueryFilterFieldConfig{T}"/> to support fluent-style method-chaining.</returns>
-        /// <remarks>This will automatically set the <see cref="QueryFilterFieldConfigBase.SupportedKinds"/> to be <see cref="QueryFilterTokenKind.EqualityOperator"/> only as other operators are nonsensical in this context.</remarks>
+        /// <remarks>This will automatically set the <see cref="QueryFilterFieldConfigBase.Operators"/> to be <see cref="QueryFilterOperator.EqualityOperators"/> only as other operators are nonsensical in this context.</remarks>
         public QueryFilterReferenceDataFieldConfig<TRef> UseIdentifier()
         {
             _useIdentifier = true;

--- a/src/CoreEx.Data/Querying/QueryOrderByFieldConfig.cs
+++ b/src/CoreEx.Data/Querying/QueryOrderByFieldConfig.cs
@@ -8,7 +8,7 @@ namespace CoreEx.Data.Querying
     /// <param name="parser">The owning <see cref="QueryOrderByParser"/>.</param>
     /// <param name="field">The field name.</param>
     /// <param name="model">The model name (defaults to <paramref name="field"/>.</param>
-    public class QueryOrderByFieldConfig(QueryOrderByParser parser, string field, string? model)
+    public sealed class QueryOrderByFieldConfig(QueryOrderByParser parser, string field, string? model)
     {
         private readonly string? _model = model;
 
@@ -32,17 +32,33 @@ namespace CoreEx.Data.Querying
         /// Gets the supported <see cref="QueryOrderByDirection"/>.
         /// </summary>
         /// <remarks>Defaults to <see cref="QueryOrderByDirection.Both"/>.</remarks>
-        public QueryOrderByDirection SupportedDirection { get; private set; } = QueryOrderByDirection.Both;
+        public QueryOrderByDirection Direction { get; private set; } = QueryOrderByDirection.Both;
 
         /// <summary>
-        /// Sets (overrides) the <see cref="SupportedDirection"/>.
+        /// Gets the additional help text.
+        /// </summary>
+        public string? HelpText { get; private set; }
+
+        /// <summary>
+        /// Sets (overrides) the <see cref="Direction"/>.
         /// </summary>
         /// <param name="supportedDirection">The <see cref="QueryOrderByDirection"/>.</param>
         /// <returns>The <see cref="QueryOrderByFieldConfig"/> to support fluent-style method-chaining.</returns>
         /// <remarks>The default is <see cref="QueryOrderByDirection.Both"/>.</remarks>
-        public QueryOrderByFieldConfig Supports(QueryOrderByDirection supportedDirection)
+        public QueryOrderByFieldConfig WithDirection(QueryOrderByDirection supportedDirection)
         {
-            SupportedDirection = supportedDirection;
+            Direction = supportedDirection;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets (overrides) the additional help text.
+        /// </summary>
+        /// <param name="text">The additional help text.</param>
+        /// <returns>The <see cref="QueryOrderByFieldConfig"/> to support fluent-style method-chaining.</returns>
+        public QueryOrderByFieldConfig WithHelpText(string text)
+        {
+            HelpText = text.ThrowIfNullOrEmpty(nameof(text));
             return this;
         }
     }

--- a/tests/CoreEx.Cosmos.Test/CosmosDbQueryTestcs.cs
+++ b/tests/CoreEx.Cosmos.Test/CosmosDbQueryTestcs.cs
@@ -1,4 +1,5 @@
 ﻿using CoreEx.Data.Querying;
+using CoreEx.Data.Querying.Expressions;
 using CoreEx.Entities;
 
 namespace CoreEx.Cosmos.Test
@@ -217,7 +218,7 @@ namespace CoreEx.Cosmos.Test
         {
             var qac = QueryArgsConfig.Create()
                 .WithFilter(f => f
-                    .AddField<string>("Name", "Value.Name", c => c.Operators(QueryFilterTokenKind.AllStringOperators).UseUpperCase())
+                    .AddField<string>("Name", "Value.Name", c => c.WithOperators(QueryFilterOperator.AllStringOperators).WithUpperCase())
                     .AddField<bool>("Birthday", "Value.Birthday"));
 
             var v = await _db.Persons3.ModelContainer.Query(q => q.Where(qac, QueryArgs.Create("endswith(name, 'Y')")).OrderBy(x => x.Id)).ToArrayAsync();


### PR DESCRIPTION
- *Fixed:* Extend `QueryFilterFieldConfigBase` to include `AsNullable()` to specifiy whether the field supports `null`.
- *Fixed:* Extend `QueryFilterFieldConfigBase` to include `WithResultWriter()` to specify a function to override the corresponding LINQ statement result writing.
- *Fixed:* Adjusted the fluent-style method-chaining interface to improve usability (and consistency).