### PR TITLE
v3.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.25.2
+- *Fixed:* `HttpRequestOptions.WithQuery` fixed to ensure any previously set `Include` and `Exclude` fields are not lost (results in a merge); i.e. only the `Filter` and `OrderBy` properties are explicitly overridden.
+
 ## v3.25.1
 - *Fixed:* Extend `QueryFilterFieldConfigBase` to include `AsNullable()` to specifiy whether the field supports `null`.
 - *Fixed:* Extend `QueryFilterFieldConfigBase` to include `WithResultWriter()` to specify a function to override the corresponding LINQ statement result writing.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.25.1</Version>
+		<Version>3.25.2</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx/Http/HttpRequestOptions.cs
+++ b/src/CoreEx/Http/HttpRequestOptions.cs
@@ -142,8 +142,18 @@ namespace CoreEx.Http
         /// </summary>
         /// <param name="query">The <see cref="QueryArgs"/>.</param>
         /// <returns>The current <see cref="HttpRequestOptions"/> instance to support fluent-style method-chaining.</returns>
+        /// <remarks>Any existing <see cref="Include(string[])"/> and/or <see cref="Exclude(string[])"/> fields will be integrated into the <paramref name="query"/>.</remarks>
         public HttpRequestOptions WithQuery(QueryArgs? query)
         {
+            if (Query is not null && query is not null)
+            {
+                if (Query.IncludeFields is not null)
+                    query.Include([.. Query.IncludeFields]);
+
+                if (Query.ExcludeFields is not null)
+                    query.Exclude([.. Query.ExcludeFields]);
+            }
+
             Query = query;
             return this;
         }

--- a/tests/CoreEx.Test/Framework/Http/HttpRequestOptionsTest.cs
+++ b/tests/CoreEx.Test/Framework/Http/HttpRequestOptionsTest.cs
@@ -157,5 +157,16 @@ namespace CoreEx.Test.Framework.Http
             hr.ApplyRequestOptions(ro);
             Assert.That(hr.RequestUri!.AbsoluteUri, Is.EqualTo("https://unittest/testing?fruit=banana&fruit=apple"));
         }
+
+        [Test]
+        public void QueryArgsQueryString()
+        {
+            var qa = QueryArgs.Create("name eq 'bob'");
+            var hr = new HttpRequestMessage(HttpMethod.Get, "https://unittest/testing");
+            var ro = new HttpRequestOptions() { IncludeInactive = true }.Include("name", "text");
+            ro = ro.WithQuery(qa);
+            hr.ApplyRequestOptions(ro);
+            Assert.That(hr.RequestUri!.AbsoluteUri, Is.EqualTo("https://unittest/testing?$filter=name+eq+%27bob%27&$fields=name,text&$inactive=true"));
+        }
     }
 }


### PR DESCRIPTION
- *Fixed:* `HttpRequestOptions.WithQuery` fixed to ensure any previously set `Include` and `Exclude` fields are not lost (results in a merge); i.e. only the `Filter` and `OrderBy` properties are explicitly overridden.