### PR TITLE
v3.25.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.25.4
+- *Fixed*: Fixed the `InvalidOperationException` with a 'Sequence contains no elements' when performing validation with the `CompareValuesRule` that has the `OverrideValue` set. 
+
 ## v3.25.3
 - *Fixed:* Added function parameter support for `WithDefault()` to enable runtime execution of the default statement where required for the query filter capabilities.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Represents the **NuGet** versions.
 
 ## v3.25.4
 - *Fixed*: Fixed the `InvalidOperationException` with a 'Sequence contains no elements' when performing validation with the `CompareValuesRule` that has the `OverrideValue` set. 
-- *Fixed:* Updated all dependencies to latest versions
+- *Fixed:* Updated all dependencies to latest versions.
 
 ## v3.25.3
 - *Fixed:* Added function parameter support for `WithDefault()` to enable runtime execution of the default statement where required for the query filter capabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Represents the **NuGet** versions.
 
 ## v3.25.4
 - *Fixed*: Fixed the `InvalidOperationException` with a 'Sequence contains no elements' when performing validation with the `CompareValuesRule` that has the `OverrideValue` set. 
+- *Fixed:* Updated all dependencies to latest versions
 
 ## v3.25.3
 - *Fixed:* Added function parameter support for `WithDefault()` to enable runtime execution of the default statement where required for the query filter capabilities.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.25.3</Version>
+		<Version>3.25.4</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx.AspNetCore/CoreEx.AspNetCore.csproj
+++ b/src/CoreEx.AspNetCore/CoreEx.AspNetCore.csproj
@@ -13,7 +13,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Azure/CoreEx.Azure.csproj
+++ b/src/CoreEx.Azure/CoreEx.Azure.csproj
@@ -14,12 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.20.0" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.16.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.16.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.3.0" />
   </ItemGroup>
 

--- a/src/CoreEx.Azure/ServiceBus/IServiceCollectionExtensions.cs
+++ b/src/CoreEx.Azure/ServiceBus/IServiceCollectionExtensions.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddAzureServiceBusSender(this IServiceCollection services, Action<IServiceProvider, ServiceBusSender>? configure = null) => services.AddScoped<IEventSender>(sp =>
         {
             var sbs = new ServiceBusSender(sp.GetRequiredService<Asb.ServiceBusClient>(), sp.GetRequiredService<SettingsBase>(), sp.GetRequiredService<ILogger<ServiceBusSender>>());
-            var sbp = new ServiceBusPurger(sp.GetRequiredService<Asb.ServiceBusClient>(), sp.GetRequiredService<SettingsBase>(), sp.GetRequiredService<ILogger<ServiceBusPurger>>());
             configure?.Invoke(sp, sbs);
             return sbs;
         });

--- a/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
+++ b/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.42.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Database.Postgres/CoreEx.Database.Postgres.csproj
+++ b/src/CoreEx.Database.Postgres/CoreEx.Database.Postgres.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="Npgsql" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Database.SqlServer/CoreEx.Database.SqlServer.csproj
+++ b/src/CoreEx.Database.SqlServer/CoreEx.Database.SqlServer.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Dataverse/CoreEx.Dataverse.csproj
+++ b/src/CoreEx.Dataverse/CoreEx.Dataverse.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.1.27" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.1.32" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.EntityFrameworkCore/CoreEx.EntityFrameworkCore.csproj
+++ b/src/CoreEx.EntityFrameworkCore/CoreEx.EntityFrameworkCore.csproj
@@ -13,7 +13,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.32" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.33" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.FluentValidation/CoreEx.FluentValidation.csproj
+++ b/src/CoreEx.FluentValidation/CoreEx.FluentValidation.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.9.2" />
+    <PackageReference Include="FluentValidation" Version="11.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Newtonsoft/CoreEx.Newtonsoft.csproj
+++ b/src/CoreEx.Newtonsoft/CoreEx.Newtonsoft.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CloudNative.CloudEvents.NewtonsoftJson" Version="2.7.1" />
+    <PackageReference Include="CloudNative.CloudEvents.NewtonsoftJson" Version="2.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/CoreEx.Validation/Rules/CompareValuesRule.cs
+++ b/src/CoreEx.Validation/Rules/CompareValuesRule.cs
@@ -43,7 +43,7 @@ namespace CoreEx.Validation.Rules
         public IEqualityComparer<TProperty?> EqualityComparer { get; set; } = EqualityComparer<TProperty?>.Default;
 
         /// <summary>
-        /// Indicates whether to override the underlying property value with the corresponding <see cref="Enum"/> name.
+        /// Indicates whether to override the underlying property value with the corresponding matched value.
         /// </summary>
         public bool OverrideValue { get; set; }
 
@@ -52,13 +52,11 @@ namespace CoreEx.Validation.Rules
         {
             context.ThrowIfNull(nameof(context));
 
-            // Perform the comparison.
+            // Perform the comparison, and override where selected.
             var values = _compareToValues != null ? _compareToValues! : await _compareToValuesFunctionAsync!(context.Parent.Value!, cancellationToken).ConfigureAwait(false);
             if (!values.Where(x => EqualityComparer.Equals(x, context.Value)).Any())
                 context.CreateErrorMessage(ErrorText ?? ValidatorStrings.InvalidFormat);
-
-            // Override where selected.
-            if (OverrideValue)
+            else if (OverrideValue)
                 context.OverrideValue(values.Where(x => EqualityComparer.Equals(x, context.Value)).First());
         }
     }

--- a/src/CoreEx.Validation/Rules/EmailRule.cs
+++ b/src/CoreEx.Validation/Rules/EmailRule.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace CoreEx.Validation.Rules
 {
     /// <summary>
-    /// Provides <see cref="string"/> validation for an <b>e-mail</b>.
+    /// Provides <see cref="string"/> validation for an <b>e-mail</b> using the <see cref="EmailAddressAttribute"/> to perform the underlying validation.
     /// </summary>
     /// <typeparam name="TEntity">The entity <see cref="System.Type"/>.</typeparam>
     public class EmailRule<TEntity> : ValueRuleBase<TEntity, string> where TEntity : class

--- a/src/CoreEx.Validation/Rules/EnumValueRule.cs
+++ b/src/CoreEx.Validation/Rules/EnumValueRule.cs
@@ -34,8 +34,7 @@ namespace CoreEx.Validation.Rules
         {
             if (!Enum.TryParse<TEnum>(context.Value!, IgnoreCase, out var val))
                 context.CreateErrorMessage(ErrorText ?? ValidatorStrings.InvalidFormat);
-
-            if (IgnoreCase && OverrideValue)
+            else if (IgnoreCase && OverrideValue)
                 context.OverrideValue(val.ToString());
 
             return Task.CompletedTask;

--- a/src/CoreEx.Validation/ValidationExtensions.cs
+++ b/src/CoreEx.Validation/ValidationExtensions.cs
@@ -926,8 +926,8 @@ namespace CoreEx.Validation
         /// <param name="maxLength">The maximum string length for the e-mail address; defaults to 254.</param>
         /// <param name="errorText">The error message format text <see cref="LText"/> (overrides the default).</param>
         /// <returns>A <see cref="IPropertyRule{TEntity, String}"/>.</returns>
-        /// <remarks>The maximum length for an email address is '<c>254</c>' as per this <see href="https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address#:~:text=%20The%20length%20limits%20are%20as%20follows%3A%20,i.e.%2C%20example.com%20--%20254%20characters%20maximum.%20More%20">article</see>,
-        /// hence the default.</remarks>
+        /// <remarks>The maximum length for an email address is '<c>254</c>' or '<c>256</c>' or '<c>320</c>' as per this <see href="https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address#:~:text=%20The%20length%20limits%20are%20as%20follows%3A%20,i.e.%2C%20example.com%20--%20254%20characters%20maximum.%20More%20">article</see>,
+        /// in the absense of a definitive answer '<c>254</c>' has been chosen as the default. As it appears there is no real correct answer, simply adjust accordingly.</remarks>
         public static IPropertyRule<TEntity, string> Email<TEntity>(this IPropertyRule<TEntity, string> rule, int? maxLength = 254, LText? errorText = null) where TEntity : class
             => rule.ThrowIfNull(nameof(rule)).AddRule(new EmailRule<TEntity> { MaxLength = maxLength, ErrorText = errorText });
 
@@ -939,8 +939,8 @@ namespace CoreEx.Validation
         /// <param name="maxLength">The maximum string length for the e-mail address; defaults to 254.</param>
         /// <param name="errorText">The error message format text <see cref="LText"/> (overrides the default).</param>
         /// <returns>A <see cref="IPropertyRule{TEntity, String}"/>.</returns>
-        /// <remarks>The maximum length for an email address is '<c>254</c>' as per this <see href="https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address#:~:text=%20The%20length%20limits%20are%20as%20follows%3A%20,i.e.%2C%20example.com%20--%20254%20characters%20maximum.%20More%20">article</see>,
-        /// hence the default.</remarks>
+        /// <remarks>The maximum length for an email address is '<c>254</c>' or '<c>256</c>' or '<c>320</c>' as per this <see href="https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address#:~:text=%20The%20length%20limits%20are%20as%20follows%3A%20,i.e.%2C%20example.com%20--%20254%20characters%20maximum.%20More%20">article</see>,
+        /// in the absense of a definitive answer '<c>254</c>' has been chosen as the default. As it appears there is no real correct answer, simply adjust accordingly.</remarks>
         public static IPropertyRule<TEntity, string> EmailAddress<TEntity>(this IPropertyRule<TEntity, string> rule, int? maxLength = 254, LText? errorText = null) where TEntity : class
             => rule.ThrowIfNull(nameof(rule)).AddRule(new EmailRule<TEntity> { MaxLength = maxLength, ErrorText = errorText });
 

--- a/src/CoreEx/CoreEx.csproj
+++ b/src/CoreEx/CoreEx.csproj
@@ -15,7 +15,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
@@ -41,14 +41,14 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.32" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.33" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Include="System.Memory.Data" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.9" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
@@ -61,13 +61,13 @@
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Include="System.Memory.Data" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.9" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.7.1" />
+    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="YamlDotNet" Version="16.0.0" />
+    <PackageReference Include="YamlDotNet" Version="16.1.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/CoreEx/Validation/Validation.cs
+++ b/src/CoreEx/Validation/Validation.cs
@@ -5,6 +5,7 @@ using CoreEx.Localization;
 using CoreEx.Results;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,12 +43,13 @@ namespace CoreEx.Validation
         /// <param name="text">The friendly text name used in validation messages (defaults to <paramref name="name"/> as sentence case where not specified).</param>
         /// <returns>The value where non-default.</returns>
         /// <exception cref="ValidationException">Thrown where the value is default.</exception>
+        [return: NotNull()]
 #if NETSTANDARD2_1
-        public static T? Required<T>(this T? value, string? name = null, LText? text = null)
+        public static T Required<T>(this T value, string? name = null, LText? text = null)
 #else
-        public static T? Required<T>(this T? value, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null)
+        public static T Required<T>(this T value, [CallerArgumentExpression(nameof(value))] string? name = null, LText? text = null)
 #endif
-            => (Comparer<T?>.Default.Compare(value, default!) == 0) ? throw new ValidationException(MessageItem.CreateErrorMessage(name ?? ValueNameDefault, MandatoryFormat, text ?? ((name == null || name == ValueNameDefault) ? ValueTextDefault : name.ToSentenceCase()!))) : value;
+            => (Comparer<T?>.Default.Compare(value, default!) == 0) ? throw new ValidationException(MessageItem.CreateErrorMessage(name ?? ValueNameDefault, MandatoryFormat, text ?? ((name == null || name == ValueNameDefault) ? ValueTextDefault : name.ToSentenceCase()!))) : value!;
 
         /// <summary>
         /// Requires (validates) that the <paramref name="value"/> is non-default and continues; otherwise, will return the <paramref name="result"/> with a corresponding <see cref="ValidationException"/>.

--- a/tests/CoreEx.Test/Framework/Validation/Rules/CompareValuesRuleTest.cs
+++ b/tests/CoreEx.Test/Framework/Validation/Rules/CompareValuesRuleTest.cs
@@ -76,6 +76,14 @@ namespace CoreEx.Test.Framework.Validation.Rules
                 Assert.That(v1.HasErrors, Is.False);
                 Assert.That(cc.Option, Is.EqualTo("A"));
             });
+
+            cc.Option = "c";
+            v1 = await v.ValidateAsync(cc);
+            Assert.Multiple(() =>
+            {
+                Assert.That(v1.HasErrors, Is.True);
+                Assert.That(cc.Option, Is.EqualTo("c"));
+            });
         }
 
         public class CompareClass

--- a/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
+++ b/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
@@ -10,11 +10,11 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.20.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
   </ItemGroup>


### PR DESCRIPTION
- *Fixed*: Fixed the `InvalidOperationException` with a 'Sequence contains no elements' when performing validation with the `CompareValuesRule` that has the `OverrideValue` set.