### PR TITLE
v3.25.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.25.5
+- *Fixed:* Fixed the unit testing `CreateServiceBusMessage` extension method so that it no longer invokes a `TesterBase.ResetHost` (this reset should now be invoked explicitly by the developer as required).
+
 ## v3.25.4
 - *Fixed*: Fixed the `InvalidOperationException` with a 'Sequence contains no elements' when performing validation with the `CompareValuesRule` that has the `OverrideValue` set. 
 - *Fixed:* Updated all dependencies to latest versions.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.25.4</Version>
+		<Version>3.25.5</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriberInvoker.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriberInvoker.cs
@@ -34,6 +34,9 @@ namespace CoreEx.Azure.ServiceBus
             if (args.MessageActions == null)
                 throw new ArgumentException($"The {nameof(ServiceBusMessageActions)} value is required.", nameof(args));
 
+            var stopwatch = invoker.Logger.IsEnabled(LogLevel.Debug) ? System.Diagnostics.Stopwatch.StartNew() : null;
+            invoker.Logger.LogDebug("ServiceBusSubscriber start.");
+
             if (!string.IsNullOrEmpty(args.Message.CorrelationId))
                 invoker.ExecutionContext.CorrelationId = args.Message.CorrelationId;
 
@@ -66,6 +69,12 @@ namespace CoreEx.Azure.ServiceBus
             }
             finally
             {
+                if (stopwatch is not null)
+                {
+                    stopwatch.Stop();
+                    invoker.Logger.LogDebug("ServiceBusSubscriber elapsed {Elapsed}ms.", stopwatch.Elapsed.TotalMilliseconds);
+                }
+
                 scope?.Dispose();
             }
         }

--- a/src/CoreEx.UnitTesting/UnitTestExExtensions.cs
+++ b/src/CoreEx.UnitTesting/UnitTestExExtensions.cs
@@ -555,11 +555,11 @@ namespace UnitTestEx
         /// <param name="tester">The tester.</param>
         /// <param name="event">The <see cref="EventData"/> or <see cref="EventData{T}"/> value.</param>
         /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
+        /// <remarks>This will result in the <see cref="TesterBase.Services"/> from the underlying host being instantiated. If a <b>Services</b>-related error occurs then consider performing a <see cref="TesterBase.ResetHost()"/> after creation to reset.</remarks>
         public static ServiceBusReceivedMessage CreateServiceBusMessage<TSelf>(this TesterBase<TSelf> tester, EventData @event) where TSelf : TesterBase<TSelf>
         {
             @event.ThrowIfNull(nameof(@event));
             var message = (tester.Services.GetService<EventDataToServiceBusConverter>() ?? new EventDataToServiceBusConverter(tester.Services.GetService<IEventSerializer>(), tester.Services.GetService<IValueConverter<EventSendData, ServiceBusMessage>>())).Convert(@event).GetRawAmqpMessage();
-            tester.ResetHost(false);
             return tester.CreateServiceBusMessage(message);
         }
 
@@ -571,11 +571,11 @@ namespace UnitTestEx
         /// <param name="event">The <see cref="EventData"/> or <see cref="EventData{T}"/> value.</param>
         /// <param name="messageModify">Optional <see cref="AmqpAnnotatedMessage"/> modifier than enables the message to be further configured.</param>
         /// <returns>The <see cref="ServiceBusReceivedMessage"/>.</returns>
+        /// <remarks>This will result in the <see cref="TesterBase.Services"/> from the underlying host being instantiated. If a <b>Services</b>-related error occurs then consider performing a <see cref="TesterBase.ResetHost()"/> after creation to reset.</remarks>
         public static ServiceBusReceivedMessage CreateServiceBusMessage<TSelf>(this TesterBase<TSelf> tester, EventData @event, Action<AmqpAnnotatedMessage>? messageModify) where TSelf : TesterBase<TSelf>
         {
             @event.ThrowIfNull(nameof(@event));
             var message = (tester.Services.GetService<EventDataToServiceBusConverter>() ?? new EventDataToServiceBusConverter(tester.Services.GetService<IEventSerializer>(), tester.Services.GetService<IValueConverter<EventSendData, ServiceBusMessage>>())).Convert(@event).GetRawAmqpMessage();
-            tester.ResetHost(false);
             return tester.CreateServiceBusMessage(message, messageModify);
         }
 


### PR DESCRIPTION
- *Fixed:* Fixed the unit testing `CreateServiceBusMessage` extension method so that it no longer invokes a `TesterBase.ResetHost` (this reset should now be invoked explicitly by the developer as required).