### PR TITLE
v3.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Represents the **NuGet** versions.
 
+## v3.27.0
+- *Fixed:* The `ValueContentResult.TryCreateValueContentResult` would return `NotModified` where the request `ETag` was `null`; this has been corrected to return `OK` with the resulting `value`.
+- *Fixed:* The `ValueContentResult.TryCreateValueContentResult` now returns `ExtendedStatusCodeResult` versus `StatusCodeResult` as this offers additional capabilities where required.
+- *Enhancement:* The `ExtendedStatusCodeResult` and `ExtendedContentResult` now implement `IExtendedActionResult` to standardize access to the `BeforeExtension` and `AfterExtension` functions.
+- *Enhancement:* Added `WebApiParam.CreateActionResult` helper methods to enable execution of the underlying `ValueContentResult.CreateValueContentResult` (which is no longer public as this was always intended as internal only).
+- *Fixed:* `PostgresDatabase.OnDbException` corrected to use `PostgresException.MessageText` versus `Message` as it does not include the `SQLSTATE` code.
+- *Enhancement:* Improve debugging insights by adding `ILogger.LogDebug` start/stop/elapsed for the `InvokerArgs`.
+- *Fixed*: Updated `System.Text.Json` package depenedency to latest (including related); resolve [Microsoft Security Advisory CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4).
+
 ## v3.26.0
 - *Enhancement:* Enable JSON serialization of database parameter values; added `DatabaseParameterCollection.AddJsonParameter` method and associated `JsonParam`, `JsonParamWhen` and `JsonParamWith` extension methods.
 - *Enhancement:* Updated (simplified) `EventOutboxEnqueueBase` to pass events to the underlying stored procedures as JSON versus existing TVP removing database dependency on a UDT (user-defined type).

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.26.0</Version>
+		<Version>3.27.0</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
+++ b/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.5.9" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.6.1" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/samples/My.Hr/My.Hr.Functions/My.Hr.Functions.csproj
+++ b/samples/My.Hr/My.Hr.Functions/My.Hr.Functions.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.5.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
+++ b/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CoreEx.AspNetCore/CoreEx.AspNetCore.csproj
+++ b/src/CoreEx.AspNetCore/CoreEx.AspNetCore.csproj
@@ -13,7 +13,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.AspNetCore/WebApis/ExtendedContentResult.cs
+++ b/src/CoreEx.AspNetCore/WebApis/ExtendedContentResult.cs
@@ -11,17 +11,13 @@ namespace CoreEx.AspNetCore.WebApis
     /// <summary>
     /// Represents an extended <see cref="ContentResult"/> that enables customization of the <see cref="HttpResponse"/>.
     /// </summary>
-    public class ExtendedContentResult : ContentResult
+    public class ExtendedContentResult : ContentResult, IExtendedActionResult
     {
-        /// <summary>
-        /// Gets or sets the function to perform the extended <see cref="HttpResponse"/> customization.
-        /// </summary>
+        /// <inheritdoc/>
         [JsonIgnore]
         public Func<HttpResponse, Task>? BeforeExtension { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function to perform the extended <see cref="HttpResponse"/> customization.
-        /// </summary>
+        /// <inheritdoc/>
         [JsonIgnore]
         public Func<HttpResponse, Task>? AfterExtension { get; set; }
 

--- a/src/CoreEx.AspNetCore/WebApis/ExtendedStatusCodeResult.cs
+++ b/src/CoreEx.AspNetCore/WebApis/ExtendedStatusCodeResult.cs
@@ -12,23 +12,25 @@ namespace CoreEx.AspNetCore.WebApis
     /// <summary>
     /// Represents an extended <see cref="StatusCodeResult"/> that enables customization of the <see cref="HttpResponse"/>.
     /// </summary>
-    /// <param name="statusCode">The <see cref="HttpStatusCode"/>.</param>
-    public class ExtendedStatusCodeResult(HttpStatusCode statusCode) : StatusCodeResult((int)statusCode)
+    /// <param name="statusCode">The status code value.</param>
+    public class ExtendedStatusCodeResult(int statusCode) : StatusCodeResult(statusCode), IExtendedActionResult
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExtendedStatusCodeResult"/> class with the specified <see cref="HttpStatusCode"/>.
+        /// </summary>
+        /// <param name="statusCode">The <see cref="HttpStatusCode"/>.</param>
+        public ExtendedStatusCodeResult(HttpStatusCode statusCode) : this((int)statusCode) { }
+
         /// <summary>
         /// Gets or sets the <see cref="Microsoft.AspNetCore.Http.Headers.ResponseHeaders.Location"/> <see cref="Uri"/>.
         /// </summary>
         public Uri? Location { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function to perform the extended <see cref="HttpResponse"/> customization.
-        /// </summary>
+        /// <inheritdoc/>
         [JsonIgnore]
         public Func<HttpResponse, Task>? BeforeExtension { get; set; }
 
-        /// <summary>
-        /// Gets or sets the function to perform the extended <see cref="HttpResponse"/> customization.
-        /// </summary>
+        /// <inheritdoc/>
         [JsonIgnore]
         public Func<HttpResponse, Task>? AfterExtension { get; set; }
 

--- a/src/CoreEx.AspNetCore/WebApis/IExtendedActionResult.cs
+++ b/src/CoreEx.AspNetCore/WebApis/IExtendedActionResult.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace CoreEx.AspNetCore.WebApis
+{
+    /// <summary>
+    /// Extends an <see cref="IActionResult"/> to enable customization of the resulting <see cref="HttpResponse"/> using the <see cref="BeforeExtension"/> and <see cref="AfterExtension"/> functions.
+    /// </summary>
+    public interface IExtendedActionResult : IActionResult
+    {
+        /// <summary>
+        /// Gets or sets the function to perform the extended <see cref="HttpResponse"/> customization.
+        /// </summary>
+        [JsonIgnore]
+        Func<HttpResponse, Task>? BeforeExtension { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function to perform the extended <see cref="HttpResponse"/> customization.
+        /// </summary>
+        [JsonIgnore]
+        Func<HttpResponse, Task>? AfterExtension { get; set; }
+    }
+}

--- a/src/CoreEx.AspNetCore/WebApis/WebApiInvoker.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiInvoker.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -55,9 +54,6 @@ namespace CoreEx.AspNetCore.WebApis
             // Start logging scope and begin work.
             using (owner.Logger.BeginScope(new Dictionary<string, object>() { { HttpConsts.CorrelationIdHeaderName, owner.ExecutionContext.CorrelationId } }))
             {
-                owner.Logger.LogDebug("WebApi started.");
-                var stopwatch = owner.Logger.IsEnabled(LogLevel.Debug) ? Stopwatch.StartNew() : null;
-
                 try
                 {
                     return await func(invokeArgs, cancellationToken).ConfigureAwait(false);
@@ -70,14 +66,6 @@ namespace CoreEx.AspNetCore.WebApis
                 {
                     owner.Logger.LogDebug("WebApi unhandled exception: {Error} [{Type}]", ex.Message, ex.GetType().Name);
                     throw;
-                }
-                finally
-                {
-                    if (stopwatch is not null)
-                    {
-                        stopwatch.Stop();
-                        owner.Logger.LogDebug("WebApi elapsed: {Elapsed}ms.", stopwatch.Elapsed.TotalMilliseconds);
-                    }
                 }
             }
         }

--- a/src/CoreEx.AspNetCore/WebApis/WebApiParam.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiParam.cs
@@ -2,7 +2,9 @@
 
 using CoreEx.Entities;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Net;
 
 namespace CoreEx.AspNetCore.WebApis
 {
@@ -12,6 +14,7 @@ namespace CoreEx.AspNetCore.WebApis
     /// <param name="webApi">The parent <see cref="WebApiBase"/> instance.</param>
     /// <param name="requestOptions">The <see cref="WebApiRequestOptions"/>.</param>
     /// <param name="operationType">The <see cref="CoreEx.OperationType"/>.</param>
+    /// <remarks>This enables access to the corresponding <see cref="WebApi"/>, <see cref="Request"/>, <see cref="RequestOptions"/>, etc.</remarks>
     public class WebApiParam(WebApiBase webApi, WebApiRequestOptions requestOptions, OperationType operationType = OperationType.Unspecified)
     {
         /// <summary>
@@ -55,5 +58,23 @@ namespace CoreEx.AspNetCore.WebApis
 
             return value;
         }
+
+        /// <summary>
+        /// Creates the <see cref="IActionResult"/> as either <see cref="ValueContentResult"/> or <see cref="ExtendedStatusCodeResult"/> (<see cref="IExtendedActionResult"/>) as per <see cref="ValueContentResult.TryCreateValueContentResult"/>; unless <paramref name="value"/> is an instance of <see cref="IActionResult"/> which will return as-is.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="statusCode">The primary status code where there is a value.</param>
+        /// <param name="alternateStatusCode">The alternate status code where there is not a value (i.e. <c>null</c>).</param>
+        /// <param name="checkForNotModified">Indicates whether to check for <see cref="HttpStatusCode.NotModified"/> by comparing request and response <see cref="IETag.ETag"/> values.</param>
+        /// <param name="location">The <see cref="Microsoft.AspNetCore.Http.Headers.ResponseHeaders.Location"/> <see cref="Uri"/>.</param>
+        /// <returns>The <see cref="IActionResult"/>.</returns>
+        public IActionResult CreateActionResult<T>(T value, HttpStatusCode statusCode, HttpStatusCode? alternateStatusCode = null, bool checkForNotModified = true, Uri? location = null)
+            => ValueContentResult.CreateResult(value, statusCode, alternateStatusCode, WebApi.JsonSerializer, RequestOptions, checkForNotModified, location);
+
+        /// <summary>
+        /// Creates the <see cref="IActionResult"/> as a <see cref="ExtendedStatusCodeResult"/> (<see cref="IExtendedActionResult"/>).
+        /// </summary>
+        /// <param name="statusCode">The status code.</param>
+        public static IActionResult CreateActionResult(HttpStatusCode statusCode) => new ExtendedStatusCodeResult(statusCode);
     }
 }

--- a/src/CoreEx.AspNetCore/WebApis/WebApiParamT.cs
+++ b/src/CoreEx.AspNetCore/WebApis/WebApiParamT.cs
@@ -5,6 +5,7 @@ namespace CoreEx.AspNetCore.WebApis
     /// <summary>
     /// Represents a <see cref="WebApi"/> parameter with a request <see cref="Value"/>.
     /// </summary>
+    /// <remarks>This enables access to the corresponding <see cref="WebApiParam.WebApi"/>, <see cref="WebApiParam.Request"/>, <see cref="WebApiParam.RequestOptions"/>, deserialized <see cref="Value"/>, etc.</remarks>
     public class WebApiParam<T> : WebApiParam
     {
         /// <summary>

--- a/src/CoreEx.Azure/CoreEx.Azure.csproj
+++ b/src/CoreEx.Azure/CoreEx.Azure.csproj
@@ -15,12 +15,12 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.16.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.0.0" />
   </ItemGroup>
 
   <Import Project="..\..\Common.targets" />

--- a/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
+++ b/src/CoreEx.Cosmos/CoreEx.Cosmos.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.44.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Data/Querying/QueryArgsParseResult.cs
+++ b/src/CoreEx.Data/Querying/QueryArgsParseResult.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+namespace CoreEx.Data.Querying
+{
+    /// <summary>
+    /// Represents the <see cref="QueryArgsConfig.Parse"/> result.
+    /// </summary>
+    public sealed class QueryArgsParseResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryArgsParseResult"/> class.
+        /// </summary>
+        /// <param name="filterResult">The <see cref="QueryFilterParserResult"/>.</param>
+        /// <param name="orderByResult">The <see cref="QueryOrderByParserResult"/>.</param>
+        internal QueryArgsParseResult(QueryFilterParserResult? filterResult = null, QueryOrderByParserResult? orderByResult = null)
+        {
+            FilterResult = filterResult;
+            OrderByResult = orderByResult;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="QueryOrderByParserResult"/>.
+        /// </summary>
+        public QueryFilterParserResult? FilterResult { get; }
+
+        /// <summary>
+        /// Gets the <see cref="QueryOrderByParserResult"/>.
+        /// </summary>
+        public QueryOrderByParserResult? OrderByResult { get; }
+    }
+}

--- a/src/CoreEx.Data/Querying/QueryFilterParserResult.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterParserResult.cs
@@ -7,10 +7,15 @@ using System.Text;
 namespace CoreEx.Data.Querying
 {
     /// <summary>
-    /// Represents the result of a successful <see cref="QueryFilterParser.Parse(string?)"/>.
+    /// Represents the result of a <see cref="QueryFilterParser.Parse(string?)"/>.
     /// </summary>
     public sealed class QueryFilterParserResult
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryFilterParserResult"/> that is a success.
+        /// </summary>
+        internal QueryFilterParserResult() { }
+
         /// <summary>
         /// Gets the field names referenced within the resulting LINQ query.
         /// </summary>
@@ -26,9 +31,10 @@ namespace CoreEx.Data.Querying
         /// </summary>
         public List<object?> Args { get; } = [];
 
-        /// <inheritdoc/>
-        /// <remarks>Provides the resulting dynamic LINQ filter.</remarks>
-        public override string? ToString() => FilterBuilder.ToString();
+        /// <summary>
+        /// Provides the resulting dynamic LINQ filter.
+        /// </summary>
+        public string? ToLinqString() => FilterBuilder.ToString();
 
         /// <summary>
         /// Appends a value to the <see cref="FilterBuilder"/> as a placeholder and adds into the <see cref="Args"/>.

--- a/src/CoreEx.Data/Querying/QueryOrderByParserResult.cs
+++ b/src/CoreEx.Data/Querying/QueryOrderByParserResult.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
+
+namespace CoreEx.Data.Querying
+{
+    /// <summary>
+    /// Represents the result of <see cref="QueryOrderByParser.Parse(string?)"/>.
+    /// </summary>
+    public sealed class QueryOrderByParserResult
+    {
+        private readonly string? _orderByStatement;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryOrderByParserResult"/> class.
+        /// </summary>
+        /// <param name="orderByStatement">The resulting dynamic LINQ order by statement.</param>
+        internal QueryOrderByParserResult(string? orderByStatement) => _orderByStatement = orderByStatement;
+
+        /// <summary>
+        /// Provides the resulting dynamic LINQ order by.
+        /// </summary>
+        public string? ToLinqString() => _orderByStatement;
+    }
+}

--- a/src/CoreEx.Database.Postgres/PostgresDatabaseColumns.cs
+++ b/src/CoreEx.Database.Postgres/PostgresDatabaseColumns.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using CoreEx.Database.Extended;
+using CoreEx.Entities;
 
 namespace CoreEx.Database.Postgres
 {
@@ -11,6 +12,26 @@ namespace CoreEx.Database.Postgres
     /// and <see href="https://www.npgsql.org/efcore/modeling/concurrency.html"/> for more information.</remarks>
     public class PostgresDatabaseColumns : DatabaseColumns
     {
+        /// <summary>
+        /// Gets or sets the session context '<c>Username</c>' column name.
+        /// </summary>
+        public string SessionContextUsernameName { get; set; } = "Username";
+
+        /// <summary>
+        /// Gets or sets the session context '<c>Timestamp</c>' column name.
+        /// </summary>
+        public string SessionContextTimestampName { get; set; } = "Timestamp";
+
+        /// <summary>
+        /// Gets or sets the <see cref="ITenantId.TenantId"/> column name.
+        /// </summary>
+        public string SessionContextTenantIdName { get; set; } = "TenantId";
+
+        /// <summary>
+        /// Gets or sets the session context '<c>UserId</c>' column name.
+        /// </summary>
+        public string SessionContextUserIdName { get; set; } = "UserId";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PostgresDatabaseColumns"/> class.
         /// </summary>

--- a/src/CoreEx.EntityFrameworkCore/CoreEx.EntityFrameworkCore.csproj
+++ b/src/CoreEx.EntityFrameworkCore/CoreEx.EntityFrameworkCore.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
+++ b/src/CoreEx.UnitTesting.NUnit/CoreEx.UnitTesting.NUnit.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.4.1" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
+++ b/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="UnitTestEx" Version="4.4.1" />
+    <PackageReference Include="UnitTestEx" Version="4.4.2" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreEx.Validation/ValueValidationConfiguration.cs
+++ b/src/CoreEx.Validation/ValueValidationConfiguration.cs
@@ -20,19 +20,16 @@ namespace CoreEx.Validation
         internal ValueValidatorConfiguration(string name, LText? text = null, string? jsonName = null) : base(name, text, jsonName) { }
 
         /// <summary>
-        /// 
+        /// Performs the underlying validation.
         /// </summary>
         /// <param name="validationValue">The <see cref="ValidationValue{T}"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
-        internal Task<ValueValidatorResult<ValidationValue<T>, T>> ValidateAsync(ValidationValue<T> validationValue, CancellationToken cancellationToken)
+        internal async Task<ValueValidatorResult<ValidationValue<T>, T>> ValidateAsync(ValidationValue<T> validationValue, CancellationToken cancellationToken)
         {
-            return ValidationInvoker.Current.InvokeAsync(this, async (_, cancellationToken) =>
-            {
-                var ctx = new PropertyContext<ValidationValue<T>, T>(new ValidationContext<ValidationValue<T>>(validationValue, new ValidationArgs()), validationValue.Value, Name, JsonName, Text);
-                await InvokeAsync(ctx, cancellationToken).ConfigureAwait(false);
-                return new ValueValidatorResult<ValidationValue<T>, T>(ctx);
-            }, cancellationToken);
+            var ctx = new PropertyContext<ValidationValue<T>, T>(new ValidationContext<ValidationValue<T>>(validationValue, new ValidationArgs()), validationValue.Value, Name, JsonName, Text);
+            await InvokeAsync(ctx, cancellationToken).ConfigureAwait(false);
+            return new ValueValidatorResult<ValidationValue<T>, T>(ctx);
         }
     }
 }

--- a/src/CoreEx.Validation/ValueValidator.cs
+++ b/src/CoreEx.Validation/ValueValidator.cs
@@ -49,7 +49,8 @@ namespace CoreEx.Validation
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
         /// <returns>The <see cref="ValueValidatorResult{TEntity, TProperty}"/>.</returns>
-        public Task<ValueValidatorResult<ValidationValue<T>, T>> ValidateAsync(CancellationToken cancellationToken = default) => _configuration.ValidateAsync(_validationValue, cancellationToken);
+        public Task<ValueValidatorResult<ValidationValue<T>, T>> ValidateAsync(CancellationToken cancellationToken = default)
+            => ValidationInvoker.Current.InvokeAsync(this, (_, cancellationToken) => _configuration.ValidateAsync(_validationValue, cancellationToken), cancellationToken);
 
         /// <summary>
         /// Validates the <see cref="Value"/>.

--- a/src/CoreEx/CoreEx.csproj
+++ b/src/CoreEx/CoreEx.csproj
@@ -13,16 +13,16 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-    <PackageReference Include="System.Memory.Data" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Memory.Data" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
@@ -35,11 +35,11 @@
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
     <PackageReference Include="System.Memory.Data" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.33" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
@@ -48,7 +48,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Include="System.Memory.Data" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
@@ -61,13 +61,13 @@
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Include="System.Memory.Data" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="YamlDotNet" Version="16.1.2" />
+    <PackageReference Include="YamlDotNet" Version="16.1.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/CoreEx/Entities/CompositeKey.cs
+++ b/src/CoreEx/Entities/CompositeKey.cs
@@ -73,6 +73,8 @@ namespace CoreEx.Entities
                 return;
             }
 
+#if !RELEASE
+            // Validate supported types in Debug-mode only; fast-path for Release.
             object? temp;
             for (int idx = 0; idx < args.Length; idx++)
             {
@@ -94,6 +96,7 @@ namespace CoreEx.Entities
                         + "string, char, short, int, long, ushort, uint, ulong, Guid, DateTime and DateTimeOffset.")
                 };
             }
+#endif
 
 #if NET8_0_OR_GREATER
             _args = [.. args];

--- a/src/CoreEx/Invokers/InvokeArgs.cs
+++ b/src/CoreEx/Invokers/InvokeArgs.cs
@@ -3,6 +3,7 @@
 using CoreEx.Configuration;
 using CoreEx.Results;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -14,7 +15,7 @@ namespace CoreEx.Invokers
     /// </summary>
     public struct InvokeArgs
     {
-        private static readonly ConcurrentDictionary<Type, (ActivitySource ActivitySource, bool IsTracingEnabled)> _invokerOptions = new();
+        private static readonly ConcurrentDictionary<Type, (ActivitySource ActivitySource, bool IsTracingEnabled, bool IsLoggingEnabled)> _invokerOptions = new();
 
         private const string NullName = "null";
         private const string InvokerType = "invoker.type";
@@ -30,42 +31,6 @@ namespace CoreEx.Invokers
         private bool _isComplete;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InvokeArgs"/> struct.
-        /// </summary>
-        /// <param name="invokerType">The invoker <see cref="Type"/> used to manage the activity sources.</param>
-        /// <param name="ownerType">The invoking (owner) <see cref="Type"/> to include as part of the <see cref="Activity.OperationName"/>.</param>
-        /// <param name="memberName">The calling member name.</param>
-        /// <param name="invokeArgs">The optional parent <see cref="InvokeArgs"/>.</param>
-        /// <remarks>Creates the tracing <see cref="Activity.OperationName"/> by concatenating the invoking <paramref name="ownerType"/> (<see cref="Type.FullName"/>) and <paramref name="memberName"/> separated by '<c> -> </c>'. This is <i>not</i>
-        /// meant to represent the fully-qualified member/method name.</remarks>
-        public InvokeArgs(Type invokerType, Type? ownerType, string? memberName, InvokeArgs? invokeArgs)
-        {
-            try
-            {
-                var options = _invokerOptions.GetOrAdd(invokerType, type => (new ActivitySource(type.FullName ?? NullName), IsTracingEnabled(invokerType)));
-                if (!options.IsTracingEnabled)
-                    return;
-
-                Activity = options.ActivitySource.CreateActivity(ownerType is null ? memberName ?? NullName : $"{ownerType.FullName} -> {memberName ?? NullName}", ActivityKind.Internal);
-                if (Activity is not null)
-                {
-                    if (invokeArgs.HasValue && invokeArgs.Value.Activity is not null)
-                        Activity.SetParentId(invokeArgs.Value.Activity!.TraceId, invokeArgs.Value.Activity.SpanId, invokeArgs.Value.Activity.ActivityTraceFlags);
-
-                    Activity.SetTag(InvokerType, options.ActivitySource!.Name);
-                    Activity.SetTag(InvokerOwner, ownerType?.FullName);
-                    Activity.SetTag(InvokerMember, memberName);
-                    Activity.Start();
-                }
-            }
-            catch
-            {
-                // Continue; do not allow tracing to impact the execution.
-                Activity = null;
-            }
-        }
-
-        /// <summary>
         /// Determines whether tracing is enabled for the <paramref name="invokerType"/>.
         /// </summary>
         private static bool IsTracingEnabled(Type invokerType)
@@ -78,10 +43,110 @@ namespace CoreEx.Invokers
         }
 
         /// <summary>
+        /// Determines whether logging is enabled for the <paramref name="invokerType"/>.
+        /// </summary>
+        private static bool IsLoggingEnabled(Type invokerType)
+        {
+            var settings = ExecutionContext.GetService<SettingsBase>() ?? new DefaultSettings(ExecutionContext.GetService<IConfiguration>());
+            if (settings.Configuration is null)
+                return true;
+
+            return settings.GetValue<bool?>($"Invokers:{invokerType.FullName}:LoggingEnabled") ?? settings.GetValue<bool?>("Invokers:Default:LoggingEnabled") ?? true;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeArgs"/> struct.
+        /// </summary>
+        public InvokeArgs() => Type = typeof(Invoker);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeArgs"/> struct.
+        /// </summary>
+        /// <param name="invokerType">The invoker <see cref="Type"/> used to manage the activity sources.</param>
+        /// <param name="ownerType">The invoking (owner) <see cref="Type"/> to include as part of the <see cref="Activity.OperationName"/>.</param>
+        /// <param name="memberName">The calling member name.</param>
+        /// <param name="invokeArgs">The optional parent <see cref="InvokeArgs"/>.</param>
+        /// <remarks>Creates the tracing <see cref="Activity.OperationName"/> by concatenating the invoking <paramref name="ownerType"/> (<see cref="Type.FullName"/>) and <paramref name="memberName"/> separated by '<c> -> </c>'. This is <i>not</i>
+        /// meant to represent the fully-qualified member/method name.</remarks>
+        public InvokeArgs(Type invokerType, Type? ownerType, string? memberName, InvokeArgs? invokeArgs)
+        {
+            Type = invokerType;
+            OwnerType = ownerType;
+            MemberName = memberName;
+
+            try
+            {
+                var options = _invokerOptions.GetOrAdd(invokerType, type => (new ActivitySource(type.FullName ?? NullName), IsTracingEnabled(invokerType), IsLoggingEnabled(invokerType)));
+                if (options.IsTracingEnabled)
+                {
+                    Activity = options.ActivitySource.CreateActivity(ownerType is null ? memberName ?? NullName : $"{ownerType}->{memberName ?? NullName}", ActivityKind.Internal);
+                    if (Activity is not null)
+                    {
+                        if (invokeArgs.HasValue && invokeArgs.Value.Activity is not null)
+                            Activity.SetParentId(invokeArgs.Value.Activity!.TraceId, invokeArgs.Value.Activity.SpanId, invokeArgs.Value.Activity.ActivityTraceFlags);
+
+                        Activity.SetTag(InvokerType, options.ActivitySource!.Name);
+                        Activity.SetTag(InvokerOwner, ownerType?.FullName);
+                        Activity.SetTag(InvokerMember, memberName);
+                        Activity.Start();
+                    }
+                }
+
+                if (options.IsLoggingEnabled)
+                {
+                    Logger = ExecutionContext.GetService<ILogger<Invoker>>();
+                    if (Logger is null || !Logger.IsEnabled(LogLevel.Debug))
+                        Logger = null;
+                    else
+                    {
+                        Logger.LogDebug("{InvokerType}: Start {InvokerCaller}.", invokerType.ToString(), FormatCaller());
+                        Stopwatch = Stopwatch.StartNew();
+                    }
+                }
+            }
+            catch
+            {
+                // Continue; do not allow tracing/logging to impact the execution.
+                Activity = null;
+                Logger = null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the invoker <see cref="Type"/>.
+        /// </summary>
+        public Type Type { get; }
+
+        /// <summary>
+        /// Gets the invoking (owner) <see cref="Type"/>
+        /// </summary>
+        public Type? OwnerType { get; }
+
+        /// <summary>
+        /// Gets the calling member name.
+        /// </summary>
+        public string? MemberName { get; }
+
+        /// <summary>
         /// Gets the <see cref="System.Diagnostics.Activity"/> leveraged for standardized (open-telemetry) tracing.
         /// </summary>
         /// <remarks>Will be <c>null</c> where tracing is <i>not</i> enabled.</remarks>
         public Activity? Activity { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ILogger"/> leveraged for standardized invoker logging.
+        /// </summary>
+        public ILogger? Logger { get; }
+
+        /// <summary>
+        /// Gets the <see cref="Stopwatch"/> leveraged for standardized invoker timing.
+        /// </summary>
+        public Stopwatch? Stopwatch { get; }
+
+        /// <summary>
+        /// Formats the caller.
+        /// </summary>
+        private readonly string FormatCaller() => OwnerType is null ? MemberName ?? NullName : $"{OwnerType}->{MemberName ?? NullName}";
 
         /// <summary>
         /// Adds the result outcome to the <see cref="Activity"/> (where started).
@@ -97,8 +162,18 @@ namespace CoreEx.Invokers
                 var ir = result as IResult;
                 Activity.SetTag(InvokerResult, ir is null ? CompleteState : (ir.IsSuccess ? SuccessState : FailureState));
                 if (ir is not null && ir.IsFailure)
-                    Activity.SetTag(InvokerFailure, $"{ir.Error.Message} [{ir.Error.GetType().Name}]");
+                    Activity.SetTag(InvokerFailure, $"{ir.Error.Message} ({ir.Error.GetType()})");
 
+                _isComplete = true;
+            }
+
+            if (Logger is not null)
+            {
+                Stopwatch!.Stop();
+                var ir = result as IResult;
+                Logger.LogDebug("{InvokerType}: {InvokerResult} {InvokerCaller}{InvokerFailure} [{Elapsed}ms].", 
+                    Type.ToString(), ir is null ? CompleteState : (ir.IsSuccess ? SuccessState : FailureState), FormatCaller(), (ir is not null && ir.IsFailure) ? $" {ir.Error.Message} ({ir.Error.GetType()})" : string.Empty, Stopwatch.Elapsed.TotalMilliseconds);
+               
                 _isComplete = true;
             }
 
@@ -109,12 +184,19 @@ namespace CoreEx.Invokers
         /// Completes the <see cref="Activity"/> tracing (where started) recording the <see cref="InvokerResult"/> with the <see cref="ExceptionState"/> and capturing the corresponding <see cref="Exception.Message"/>.
         /// </summary>
         /// <param name="ex">The <see cref="System.Exception"/>.</param>
-        public void TraceException(Exception ex) 
+        public void TraceException(Exception ex)
         {
             if (Activity is not null && ex is not null)
             {
                 Activity.SetTag(InvokerResult, ExceptionState);
-                Activity.SetTag(InvokerFailure, $"{ex.Message} [{ex.GetType().Name}]");
+                Activity.SetTag(InvokerFailure, $"{ex.Message} ({ex.GetType()})");
+                _isComplete = true;
+            }
+
+            if (Logger is not null && ex is not null)
+            {
+                Stopwatch!.Stop();
+                Logger.LogDebug("{InvokerType}: {InvokerResult} {InvokerCaller}{InvokerFailure} [{Elapsed}ms].", Type.ToString(), ExceptionState, FormatCaller(), $" {ex.Message} ({ex.GetType()})", Stopwatch.Elapsed.TotalMilliseconds);
                 _isComplete = true;
             }
         }
@@ -132,6 +214,12 @@ namespace CoreEx.Invokers
                     Activity.SetTag(InvokerResult, ExceptionState);
 
                 Activity.Stop();
+            }
+
+            if (Logger is not null && !_isComplete)
+            {
+                Stopwatch!.Stop();
+                Logger.LogDebug("{InvokerType}: {InvokerResult} {InvokerCaller} [{Elapsed}ms].", Type.ToString(), ExceptionState, FormatCaller(), Stopwatch.Elapsed.TotalMilliseconds);
             }
         }
 

--- a/src/CoreEx/Invokers/Invoker.cs
+++ b/src/CoreEx/Invokers/Invoker.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
-using CoreEx.Results;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +9,7 @@ namespace CoreEx.Invokers
     /// <summary>
     /// Provides invoking capabilities including <see cref="RunSync(Func{Task})"/> and <see cref="RunSync{T}(Func{Task{T}})"/> to execute an async <see cref="Task"/> synchronously.
     /// </summary>
-    public static class Invoker
+    public class Invoker
     {
         private static readonly TaskFactory _taskFactory = new(CancellationToken.None, TaskCreationOptions.None, TaskContinuationOptions.None, TaskScheduler.Default);
 
@@ -45,5 +44,10 @@ namespace CoreEx.Invokers
         /// <remarks>The general guidance is to avoid sync over async as this may result in deadlock, so please consider all options before using. There are many <see href="https://stackoverflow.com/questions/5095183/how-would-i-run-an-async-taskt-method-synchronously">articles</see>
         /// written discussing this subject; however, if sync over async is needed this method provides a consistent approach to perform. This implementation has been inspired by <see href="https://www.ryadel.com/en/asyncutil-c-helper-class-async-method-sync-result-wait/"/>.</remarks>
         public static T RunSync<T>(Func<Task<T>> task) => _taskFactory.StartNew(task.ThrowIfNull(nameof(task))).Unwrap().GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Private constructor.
+        /// </summary>
+        private Invoker() { }
     }
 }

--- a/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
+++ b/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -34,7 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.4.1" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Solace.Test/CoreEx.Solace.Test.csproj
+++ b/tests/CoreEx.Solace.Test/CoreEx.Solace.Test.csproj
@@ -13,10 +13,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/CoreEx.Test/CoreEx.Test.csproj
+++ b/tests/CoreEx.Test/CoreEx.Test.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -23,7 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="4.4.1" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Test2/CoreEx.Test2.csproj
+++ b/tests/CoreEx.Test2/CoreEx.Test2.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/CoreEx.TestFunction/CoreEx.TestFunction.csproj
+++ b/tests/CoreEx.TestFunction/CoreEx.TestFunction.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\CoreEx.AspNetCore\CoreEx.AspNetCore.csproj" />

--- a/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
+++ b/tests/CoreEx.TestFunctionIso/CoreEx.TestFunctionIso.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- *Fixed:* The `ValueContentResult.TryCreateValueContentResult` would return `NotModified` where the request `ETag` was `null`; this has been corrected to return `OK` with the resulting `value`.
- *Fixed:* The `ValueContentResult.TryCreateValueContentResult` now returns `ExtendedStatusCodeResult` versus `StatusCodeResult` as this offers additional capabilities where required.
- *Enhancement:* The `ExtendedStatusCodeResult` and `ExtendedContentResult` now implement `IExtendedActionResult` to standardize access to the `BeforeExtension` and `AfterExtension` functions.
- *Enhancement:* Added `WebApiParam.CreateActionResult` helper methods to enable execution of the underlying `ValueContentResult.CreateValueContentResult` (which is no longer public as this was always intended as internal only).
- *Fixed:* `PostgresDatabase.OnDbException` corrected to use `PostgresException.MessageText` versus `Message` as it does not include the `SQLSTATE` code.
- *Enhancement:* Improve debugging insights by adding `ILogger.LogDebug` start/stop/elapsed for the `InvokerArgs`.
- *Fixed*: Updated `System.Text.Json` package depenedency to latest (including related); resolve [Microsoft Security Advisory CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4).