### PR TITLE
v3.27.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Represents the **NuGet** versions.
 
+## v3.27.2
+- *Fixed:* The `IServiceCollection.AddCosmosDb` extension method was registering as a singleton; this has been corrected to register as scoped. The dependent `CosmosClient` should remain a singleton as is [best practice](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/best-practice-dotnet).
+
 ## v3.27.1
 - *Fixed:* Updated `Microsoft.Extensions.Caching.Memory` package depenedency to latest (including related); resolve [Microsoft Security Advisory CVE-2024-43483](https://github.com/advisories/GHSA-qj66-m88j-hmgj).
 - *Fixed:* Fixed the `ExecutionContext.UserIsAuthorized` to have base implementation similar to `UserIsInRole`.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.27.1</Version>
+		<Version>3.27.2</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/My.Hr/My.Hr.Api/Startup.cs
+++ b/samples/My.Hr/My.Hr.Api/Startup.cs
@@ -34,7 +34,7 @@ public class Startup
             .AddAzureServiceBusSender()
             .AddAzureServiceBusPurger()
             .AddJsonMergePatch()
-            .AddWebApi((_, c) => c.UnhandledExceptionAsync = (ex, _, _) => Task.FromResult(ex is DbUpdateConcurrencyException efex ? WebApiBase.CreateActionResultFromExtendedException(new ConcurrencyException()) : null))
+            .AddWebApi((_, webapi) => webapi.UnhandledExceptionAsync = (ex, _, _) => Task.FromResult(ex is DbUpdateConcurrencyException efex ? webapi.CreateActionResultFromExtendedException(new ConcurrencyException()) : null))
             .AddReferenceDataContentWebApi()
             .AddRequestCache();
 

--- a/samples/My.Hr/My.Hr.Functions/Startup.cs
+++ b/samples/My.Hr/My.Hr.Functions/Startup.cs
@@ -40,7 +40,7 @@ public class Startup : FunctionsStartup
                 .AddEventPublisher()
                 .AddSingleton(sp => new Az.ServiceBusClient(sp.GetRequiredService<HrSettings>().ServiceBusConnection__fullyQualifiedNamespace))
                 .AddAzureServiceBusSender()
-                .AddWebApi((_, c) => c.UnhandledExceptionAsync = (ex, _, _) => Task.FromResult(ex is DbUpdateConcurrencyException efex ? WebApiBase.CreateActionResultFromExtendedException(new ConcurrencyException()) : null))
+                .AddWebApi((_, webapi) => webapi.UnhandledExceptionAsync = (ex, _, _) => Task.FromResult(ex is DbUpdateConcurrencyException efex ? webapi.CreateActionResultFromExtendedException(new ConcurrencyException()) : null))
                 .AddJsonMergePatch()
                 .AddWebApiPublisher()
                 .AddAzureServiceBusSubscriber();

--- a/src/CoreEx.Cosmos/CosmosDb.cs
+++ b/src/CoreEx.Cosmos/CosmosDb.cs
@@ -24,6 +24,10 @@ namespace CoreEx.Cosmos
     /// <param name="database">The <see cref="Microsoft.Azure.Cosmos.Database"/>.</param>
     /// <param name="mapper">The <see cref="IMapper"/>.</param>
     /// <param name="invoker">Enables the <see cref="Invoker"/> to be overridden; defaults to <see cref="CosmosDbInvoker"/>.</param>
+    /// <remarks>It is recommended that the <see cref="CosmosDb"/> is registered as a scoped service to enable capabilities such as <see cref="CosmosDbArgs.FilterByTenantId"/> that <i>must</i> be scoped. 
+    /// Use <see cref="Microsoft.Extensions.DependencyInjection.CosmosDbServiceCollectionExtensions.AddCosmosDb{TCosmosDb}(Microsoft.Extensions.DependencyInjection.IServiceCollection, Func{IServiceProvider, TCosmosDb}, string?)"/> to 
+    /// register the scoped <see cref="CosmosDb"/> instance.
+    /// <para>The dependent <see cref="CosmosClient"/> should however be registered as a singleton as is <see href="https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/best-practice-dotnet">best practice</see>.</para></remarks>
     public class CosmosDb(Database database, IMapper mapper, CosmosDbInvoker? invoker = null) : ICosmosDb
     {
         private static CosmosDbInvoker? _invoker;
@@ -181,7 +185,8 @@ namespace CoreEx.Cosmos
 
             if (multiSetList.Any(x => !x.Container.IsCosmosDbValueModel))
                 throw new ArgumentException($"All {nameof(IMultiSetArgs)} containers must be of type CosmosDbValueContainer.", nameof(multiSetArgs));
-
+            
+            // Build the Cosmos SQL statement.
             var container = multiSetList[0].Container;
             var types = new Dictionary<string, IMultiSetArgs>([ new KeyValuePair<string, IMultiSetArgs>(container.ModelType.Name, multiSetList[0]) ]);
             var sb = string.IsNullOrEmpty(sql) ? new StringBuilder($"SELECT * FROM c WHERE c.type in (\"{container.ModelType.Name}\"") : null; 

--- a/src/CoreEx.Cosmos/CosmosDbServiceCollectionExtensions.cs
+++ b/src/CoreEx.Cosmos/CosmosDbServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class CosmosDbServiceCollectionExtensions
     {
         /// <summary>
-        /// Adds an <see cref="ICosmosDb"/> as a singleton service.
+        /// Adds an <see cref="ICosmosDb"/> as a scoped service.
         /// </summary>
         /// <typeparam name="TCosmosDb">The <see cref="ICosmosDb"/> <see cref="Type"/>.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</returns>
         public static IServiceCollection AddCosmosDb<TCosmosDb>(this IServiceCollection services, Func<IServiceProvider, TCosmosDb> create, bool healthCheck = true) where TCosmosDb : class, ICosmosDb
         {
-            services.ThrowIfNull(nameof(services)).AddSingleton(sp => create.ThrowIfNull(nameof(create)).Invoke(sp));
+            services.ThrowIfNull(nameof(services)).AddScoped(sp => create.ThrowIfNull(nameof(create)).Invoke(sp));
             if (healthCheck)
                 services.AddHealthChecks().AddCosmosDbHealthCheck<TCosmosDb>();
 
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds an <see cref="ICosmosDb"/> as a singleton service including a corresponding health check.
+        /// Adds an <see cref="ICosmosDb"/> as a scoped service including a corresponding health check.
         /// </summary>
         /// <typeparam name="TCosmosDb">The <see cref="ICosmosDb"/> <see cref="Type"/>.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> to support fluent-style method-chaining.</returns>
         public static IServiceCollection AddCosmosDb<TCosmosDb>(this IServiceCollection services, Func<IServiceProvider, TCosmosDb> create, string? healthCheckName) where TCosmosDb : class, ICosmosDb
         {
-            services.ThrowIfNull(nameof(services)).AddSingleton(sp => create.ThrowIfNull(nameof(create)).Invoke(sp));
+            services.ThrowIfNull(nameof(services)).AddScoped(sp => create.ThrowIfNull(nameof(create)).Invoke(sp));
             services.AddHealthChecks().AddCosmosDbHealthCheck<TCosmosDb>(healthCheckName);
             return services;
         }

--- a/src/CoreEx/Events/EventDataFormatter.cs
+++ b/src/CoreEx/Events/EventDataFormatter.cs
@@ -152,7 +152,7 @@ namespace CoreEx.Events
             var value = @event.Value;
 
             @event.Id ??= Guid.NewGuid().ToString();
-            @event.Timestamp ??= new DateTimeOffset(ExecutionContext.SystemTime.UtcNow);
+            @event.Timestamp ??= new DateTimeOffset(ExecutionContext.HasCurrent ? ExecutionContext.Current.Timestamp : ExecutionContext.SystemTime.UtcNow);
 
             if (PropertySelection.HasFlag(EventDataProperty.Key))
             {

--- a/src/CoreEx/ExecutionContext.cs
+++ b/src/CoreEx/ExecutionContext.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 namespace CoreEx


### PR DESCRIPTION
- *Fixed:* The `IServiceCollection.AddCosmosDb` extension method was registering as a singleton; this has been corrected to register as scoped. The dependent `CosmosClient` should remain a singleton as is [best practice](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/best-practice-dotnet).