### PR TITLE
v3.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v3.30.1
+- *Fixed:* Added support for `SettingsBase.DateTimeTransform`, `StringTransform`, `StringTrim` and `StringCase` to allow specification via configuration.
+- *Fixed:* Added support for `CoreEx:` hierarchy (optional) for all _CoreEx_ settings to enable a more structured and explicit configuration.
+
 ## v3.30.0
 - *Enhancement:* Integrated `UnitTestEx` version `5.0.0` to enable the latest capabilities and improvements.
   - `CoreEx.UnitTesting.NUnit` given changes is no longer required and has been deprecated, the `UnitTestEx.NUnit` (or other) must be explicitly referenced as per testing framework being used.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.30.0</Version>
+		<Version>3.30.1</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/samples/My.Hr/My.Hr.Api/appsettings.json
+++ b/samples/My.Hr/My.Hr.Api/appsettings.json
@@ -5,14 +5,16 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "PagingDefaultTake": 25,
-  "PagingMaxTake": 500,
-  "RefDataCache": {
-    "AbsoluteExpirationRelativeToNow": "01:45:00",
-    "SlidingExpiration": "00:15:00",
-    "Gender": {
-      "AbsoluteExpirationRelativeToNow": "03:00:00",
-      "SlidingExpiration": "00:45:00"
+  "CoreEx": {
+    "PagingDefaultTake": 25,
+    "PagingMaxTake": 500,
+    "RefDataCache": {
+      "AbsoluteExpirationRelativeToNow": "01:45:00",
+      "SlidingExpiration": "00:15:00",
+      "Gender": {
+        "AbsoluteExpirationRelativeToNow": "03:00:00",
+        "SlidingExpiration": "00:45:00"
+      }
     }
   },
   "ServiceBusConnection": {

--- a/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
+++ b/samples/My.Hr/My.Hr.Database/My.Hr.Database.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DbEx.SqlServer" Version="2.6.1" />
+    <PackageReference Include="DbEx.SqlServer" Version="2.8.0" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/samples/My.Hr/My.Hr.UnitTest/EmployeeFunctionTest.cs
+++ b/samples/My.Hr/My.Hr.UnitTest/EmployeeFunctionTest.cs
@@ -86,6 +86,7 @@ namespace My.Hr.UnitTest
             using var test = FunctionTester.Create<Startup>();
 
             var e = test.HttpTrigger<EmployeeFunction>()
+                .WithRouteCheck(UnitTestEx.Azure.Functions.RouteCheckOption.PathAndQueryStartsWith)
                 .Run(f => f.GetAsync(test.CreateHttpRequest(HttpMethod.Get, $"api/employees/{1.ToGuid()}", new CoreEx.Http.HttpRequestOptions().Include("FirstName", "LastName")), 1.ToGuid()))
                 .AssertOK()
                 .AssertJson("{\"firstName\":\"Wendy\",\"lastName\":\"Jones\"}");
@@ -114,6 +115,7 @@ namespace My.Hr.UnitTest
             using var test = FunctionTester.Create<Startup>();
 
             var v = test.HttpTrigger<EmployeeFunction>()
+                .WithRouteCheck(UnitTestEx.Azure.Functions.RouteCheckOption.PathAndQueryStartsWith)
                 .Run(f => f.GetAllAsync(test.CreateHttpRequest(HttpMethod.Get, "api/employees", CoreEx.Http.HttpRequestOptions.Create(PagingArgs.CreateSkipAndTake(1, 2, true)))))
                 .AssertOK()
                 .GetValue<EmployeeCollectionResult>();
@@ -134,6 +136,7 @@ namespace My.Hr.UnitTest
             using var test = FunctionTester.Create<Startup>();
 
             var v = test.HttpTrigger<EmployeeFunction>()
+                .WithRouteCheck(UnitTestEx.Azure.Functions.RouteCheckOption.PathAndQueryStartsWith)
                 .Run(f => f.GetAllAsync(test.CreateHttpRequest(HttpMethod.Get, "api/employees", CoreEx.Http.HttpRequestOptions.Create(PagingArgs.CreateSkipAndTake(1, 2, false)).Include("lastname"))))
                 .AssertOK()
                 .AssertJson("[ { \"lastName\": \"Jones\" }, { \"lastName\": \"Smith\" } ]")

--- a/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
+++ b/samples/My.Hr/My.Hr.UnitTest/My.Hr.UnitTest.csproj
@@ -31,7 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusOrchestratedSubscriber.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusOrchestratedSubscriber.cs
@@ -39,10 +39,10 @@ namespace CoreEx.Azure.ServiceBus
         {
             Orchestrator = orchestrator.ThrowIfNull(nameof(orchestrator));
             ServiceBusSubscriberInvoker = serviceBusSubscriberInvoker ?? (ServiceBusSubscriber._invoker ??= new ServiceBusSubscriberInvoker());
-            AbandonOnTransient = settings.GetValue($"{GetType().Name}__{nameof(AbandonOnTransient)}", false);
-            MaxDeliveryCount = settings.GetValue<int?>($"{GetType().Name}__{nameof(MaxDeliveryCount)}");
-            RetryDelay = settings.GetValue<TimeSpan?>($"{GetType().Name}__{nameof(RetryDelay)}");
-            MaxRetryDelay = settings.GetValue<TimeSpan?>($"{GetType().Name}__{nameof(MaxRetryDelay)}");
+            AbandonOnTransient = settings.GetCoreExValue($"{GetType().Name}:{nameof(AbandonOnTransient)}", false);
+            MaxDeliveryCount = settings.GetCoreExValue<int?>($"{GetType().Name}:{nameof(MaxDeliveryCount)}");
+            RetryDelay = settings.GetCoreExValue<TimeSpan?>($"{GetType().Name}:{nameof(RetryDelay)}");
+            MaxRetryDelay = settings.GetCoreExValue<TimeSpan?>($"{GetType().Name}:{nameof(MaxRetryDelay)}");
         }
 
         /// <summary>

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusPurger.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusPurger.cs
@@ -45,8 +45,8 @@ namespace CoreEx.Azure.ServiceBus
             queueOrTopicName.ThrowIfNullOrEmpty(nameof(queueOrTopicName));
 
             // Get queue name and subscription name by checking settings override.
-            var qn = Settings.GetValue($"Publisher_ServiceBusQueueName_{queueOrTopicName}", defaultValue: queueOrTopicName);
-            var sn = string.IsNullOrEmpty(subscriptionName) ? null : Settings.GetValue($"Publisher_ServiceBusSubscriptionName_{subscriptionName}", defaultValue: subscriptionName);
+            var qn = Settings.GetCoreExValue($"Publisher_ServiceBusQueueName_{queueOrTopicName}", defaultValue: queueOrTopicName);
+            var sn = string.IsNullOrEmpty(subscriptionName) ? null : Settings.GetCoreExValue($"Publisher_ServiceBusSubscriptionName_{subscriptionName}", defaultValue: subscriptionName);
 
             // Receive from Dead letter
             var o = new ServiceBusReceiverOptions { SubQueue = subQueue, PrefetchCount = 500, ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete };

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusSender.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusSender.cs
@@ -96,7 +96,7 @@ namespace CoreEx.Azure.ServiceBus
                 {
                     var n = qitem.Key == _unspecifiedQueueOrTopicName ? null : qitem.Key;
                     var key = $"{GetType().Name}_QueueOrTopicName{(n is null ? "" : $"_{n}")}";
-                    var qn = Settings.GetValue($"{GetType().Name}:QueueOrTopicName{(n is null ? "" : $"_{n}")}", defaultValue: n) ?? throw new EventSendException(PrependStats($"'{key}' configuration setting must have a non-null value.", totalCount, unsentEvents.Count), unsentEvents);
+                    var qn = Settings.GetCoreExValue($"{GetType().Name}:QueueOrTopicName{(n is null ? "" : $"_{n}")}", defaultValue: n) ?? throw new EventSendException(PrependStats($"'{key}' configuration setting must have a non-null value.", totalCount, unsentEvents.Count), unsentEvents);
                     var queue = qitem.Value;
                     var sentIds = new List<string>();
 

--- a/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriber.cs
+++ b/src/CoreEx.Azure/ServiceBus/ServiceBusSubscriber.cs
@@ -51,10 +51,10 @@ namespace CoreEx.Azure.ServiceBus
             : base(eventDataConverter ?? new ServiceBusReceivedMessageEventDataConverter(eventSerializer ?? new CoreEx.Text.Json.EventDataSerializer()), executionContext, settings, logger, eventSubscriberInvoker)
         {
             ServiceBusSubscriberInvoker = serviceBusSubscriberInvoker ?? (_invoker ??= new ServiceBusSubscriberInvoker());
-            AbandonOnTransient = settings.GetValue($"{GetType().Name}__{nameof(AbandonOnTransient)}", false);
-            MaxDeliveryCount = settings.GetValue<int?>($"{GetType().Name}__{nameof(MaxDeliveryCount)}");
-            RetryDelay = settings.GetValue<TimeSpan?>($"{GetType().Name}__{nameof(RetryDelay)}");
-            MaxRetryDelay = settings.GetValue<TimeSpan?>($"{GetType().Name}__{nameof(MaxRetryDelay)}");
+            AbandonOnTransient = settings.GetCoreExValue($"{GetType().Name}:{nameof(AbandonOnTransient)}", false);
+            MaxDeliveryCount = settings.GetCoreExValue<int?>($"{GetType().Name}:{nameof(MaxDeliveryCount)}");
+            RetryDelay = settings.GetCoreExValue<TimeSpan?>($"{GetType().Name}:{nameof(RetryDelay)}");
+            MaxRetryDelay = settings.GetCoreExValue<TimeSpan?>($"{GetType().Name}:{nameof(MaxRetryDelay)}");
         }
 
         /// <summary>

--- a/src/CoreEx.Data/CoreEx.Data.csproj
+++ b/src/CoreEx.Data/CoreEx.Data.csproj
@@ -12,7 +12,7 @@
   <Import Project="..\..\Common.targets" />
 
   <ItemGroup>
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.9" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoreEx.Data/Querying/QueryFilterFieldConfigBase.cs
+++ b/src/CoreEx.Data/Querying/QueryFilterFieldConfigBase.cs
@@ -219,7 +219,11 @@ namespace CoreEx.Data.Querying
         protected StringBuilder AppendOperatorsToString(StringBuilder stringBuilder)
         {
             var first = true;
+#if NET6_0_OR_GREATER
+            foreach (var e in Enum.GetValues<QueryFilterOperator>())
+#else
             foreach (var e in Enum.GetValues(typeof(QueryFilterOperator)))
+#endif
             {
                 if (Operators.HasFlag((QueryFilterOperator)e))
                 {

--- a/src/CoreEx.Database.SqlServer/DatabaseServiceCollectionExtensions.cs
+++ b/src/CoreEx.Database.SqlServer/DatabaseServiceCollectionExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <remarks>To turn off the execution of the <see cref="EventOutboxHostedService"/>(s) at runtime set the '<c>EventOutboxHostedService:Enabled</c>' configuration setting to <c>false</c>.</remarks>
         public static IServiceCollection AddSqlServerEventOutboxHostedService(this IServiceCollection services, Func<IServiceProvider, EventOutboxDequeueBase> eventOutboxDequeueFactory, string? partitionKey = null, string? destination = null, bool healthCheck = true)
         {
-            var exe = services.BuildServiceProvider().GetRequiredService<SettingsBase>().GetValue<bool?>("EventOutboxHostedService__Enabled");
+            var exe = services.BuildServiceProvider().GetRequiredService<SettingsBase>().GetCoreExValue<bool?>("EventOutboxHostedService:Enabled");
             if (!exe.HasValue || exe.Value)
             {
                 // Add the health check.

--- a/src/CoreEx.Database.SqlServer/Outbox/EventOutboxHostedService.cs
+++ b/src/CoreEx.Database.SqlServer/Outbox/EventOutboxHostedService.cs
@@ -110,7 +110,7 @@ namespace CoreEx.Database.SqlServer.Outbox
         /// <remarks>Will default to <see cref="SettingsBase"/> configuration, a) <see cref="TimerHostedServiceBase.ServiceName"/> : <see cref="IntervalName"/>, then b) <see cref="IntervalName"/>, where specified; otherwise, <see cref="DefaultInterval"/>.</remarks>
         public override TimeSpan Interval
         {
-            get => _interval ?? Settings.GetValue<TimeSpan?>($"{ServiceName}:{IntervalName}".Replace(".", "_")) ?? Settings.GetValue<TimeSpan?>(IntervalName.Replace(".", "_")) ?? DefaultInterval;
+            get => _interval ?? Settings.GetCoreExValue<TimeSpan?>($"{ServiceName}:{IntervalName}".Replace(".", "_")) ?? Settings.GetCoreExValue<TimeSpan?>(IntervalName.Replace(".", "_")) ?? DefaultInterval;
             set => _interval = value;
         }
 
@@ -120,7 +120,7 @@ namespace CoreEx.Database.SqlServer.Outbox
         /// <remarks>Will default to <see cref="SettingsBase"/> configuration, a) <see cref="TimerHostedServiceBase.ServiceName"/> : <see cref="MaxDequeueSizeName"/>, then b) <see cref="MaxDequeueSizeName"/>, where specified; otherwise, 10.</remarks>
         public int MaxDequeueSize
         {
-            get => _maxDequeueSize ?? Settings.GetValue<int?>($"{ServiceName}:{MaxDequeueSizeName}".Replace(".", "_")) ?? Settings.GetValue<int?>(MaxDequeueSizeName.Replace(".", "_")) ?? 10;
+            get => _maxDequeueSize ?? Settings.GetCoreExValue<int?>($"{ServiceName}:{MaxDequeueSizeName}".Replace(".", "_")) ?? Settings.GetCoreExValue<int?>(MaxDequeueSizeName.Replace(".", "_")) ?? 10;
             set => _maxDequeueSize = value;
         }
 

--- a/src/CoreEx.Database.SqlServer/Outbox/EventOutboxService.cs
+++ b/src/CoreEx.Database.SqlServer/Outbox/EventOutboxService.cs
@@ -49,7 +49,7 @@ namespace CoreEx.Database.SqlServer.Outbox
         /// <remarks>Will default to <see cref="SettingsBase"/> configuration, a) <see cref="ServiceBase.ServiceName"/> : <see cref="ServiceBase.MaxIterationsName"/>, then b) <see cref="ServiceBase.MaxIterationsName"/>, where specified; otherwise, <see cref="ServiceBase.DefaultMaxIterations"/>.</remarks>
         public override int MaxIterations
         {
-            get => _maxIterations ?? Settings.GetValue<int?>($"{ServiceName}:{MaxIterationsName}".Replace(".", "_")) ?? Settings.GetValue<int?>(MaxIterationsName.Replace(".", "_")) ?? DefaultMaxIterations;
+            get => _maxIterations ?? Settings.GetCoreExValue<int?>($"{ServiceName}:{MaxIterationsName}".Replace(".", "_")) ?? Settings.GetCoreExValue<int?>(MaxIterationsName.Replace(".", "_")) ?? DefaultMaxIterations;
             set => _maxIterations = value;
         }
 
@@ -59,7 +59,7 @@ namespace CoreEx.Database.SqlServer.Outbox
         /// <remarks>Will default to <see cref="SettingsBase"/> configuration, a) <see cref="ServiceBase.ServiceName"/> : <see cref="MaxDequeueSizeName"/>, then b) <see cref="MaxDequeueSizeName"/>, where specified; otherwise, 10.</remarks>
         public int MaxDequeueSize
         {
-            get => _maxDequeueSize ?? Settings.GetValue<int?>($"{ServiceName}:{MaxDequeueSizeName}".Replace(".", "_")) ?? Settings.GetValue<int?>(MaxDequeueSizeName.Replace(".", "_")) ?? 10;
+            get => _maxDequeueSize ?? Settings.GetCoreExValue<int?>($"{ServiceName}:{MaxDequeueSizeName}".Replace(".", "_")) ?? Settings.GetCoreExValue<int?>(MaxDequeueSizeName.Replace(".", "_")) ?? 10;
             set => _maxDequeueSize = value;
         }
 

--- a/src/CoreEx.Database/Mapping/DatabaseMapperT.cs
+++ b/src/CoreEx.Database/Mapping/DatabaseMapperT.cs
@@ -122,19 +122,18 @@ namespace CoreEx.Database.Mapping
         /// <summary>
         /// Validates and adds a new IPropertyColumnMapper.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "They are the arguments from the calling method.")]
-        private void AddMapping(IPropertyColumnMapper pcm)
+        private void AddMapping<TSourceProperty>(PropertyColumnMapper<TSource, TSourceProperty> propertyColumnMapper)
         {
-            if (_mappings.Any(x => x.PropertyName == pcm.PropertyName))
-                throw new ArgumentException($"Source property '{pcm.PropertyName}' must not be specified more than once.", "propertyExpression");
+            if (_mappings.Any(x => x.PropertyName == propertyColumnMapper.PropertyName))
+                throw new ArgumentException($"Source property '{propertyColumnMapper.PropertyName}' must not be specified more than once.", nameof(propertyColumnMapper));
 
-            if (_mappings.Any(x => x.ColumnName == pcm.ColumnName))
-                throw new ArgumentException($"Column '{pcm.ColumnName}' must not be specified more than once.", "columnName");
+            if (_mappings.Any(x => x.ColumnName == propertyColumnMapper.ColumnName))
+                throw new ArgumentException($"Column '{propertyColumnMapper.ColumnName}' must not be specified more than once.", nameof(propertyColumnMapper));
 
-            if (_mappings.Any(x => x.ParameterName == pcm.ParameterName))
-                throw new ArgumentException($"Parameter '{pcm.ParameterName}' must not be specified more than once.", "parameterName");
+            if (_mappings.Any(x => x.ParameterName == propertyColumnMapper.ParameterName))
+                throw new ArgumentException($"Parameter '{propertyColumnMapper.ParameterName}' must not be specified more than once.", nameof(propertyColumnMapper));
 
-            _mappings.Add(pcm);
+            _mappings.Add(propertyColumnMapper);
         }
 
         /// <summary>

--- a/src/CoreEx.Dataverse/Mapping/DataverseMapperT.cs
+++ b/src/CoreEx.Dataverse/Mapping/DataverseMapperT.cs
@@ -133,16 +133,15 @@ namespace CoreEx.Dataverse.Mapping
         /// <summary>
         /// Validates and adds a new IPropertyColumnMapper.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "They are the arguments from the calling method.")]
-        private void AddMapping(IPropertyColumnMapper pcm)
+        private void AddMapping<TSourceProperty>(PropertyColumnMapper<TSource, TSourceProperty> propertyColumnMapper)
         {
-            if (_mappings.Any(x => x.PropertyName == pcm.PropertyName))
-                throw new ArgumentException($"Source property '{pcm.PropertyName}' must not be specified more than once.", "propertyExpression");
+            if (_mappings.Any(x => x.PropertyName == propertyColumnMapper.PropertyName))
+                throw new ArgumentException($"Source property '{propertyColumnMapper.PropertyName}' must not be specified more than once.", nameof(propertyColumnMapper));
 
-            if (_mappings.Any(x => x.ColumnName == pcm.ColumnName))
-                throw new ArgumentException($"Column '{pcm.ColumnName}' must not be specified more than once.", "columnName");
+            if (_mappings.Any(x => x.ColumnName == propertyColumnMapper.ColumnName))
+                throw new ArgumentException($"Column '{propertyColumnMapper.ColumnName}' must not be specified more than once.", nameof(propertyColumnMapper));
 
-            _mappings.Add(pcm);
+            _mappings.Add(propertyColumnMapper);
         }
 
         /// <summary>

--- a/src/CoreEx.Newtonsoft/Json/ContractResolver.cs
+++ b/src/CoreEx.Newtonsoft/Json/ContractResolver.cs
@@ -31,8 +31,8 @@ namespace CoreEx.Newtonsoft.Json
         /// </summary>
         static ContractResolver()
         {
-            _default.AddType(typeof(EntityCore))
-                    .AddType(typeof(EntityBase))
+            _default.AddType<EntityCore>()
+                    .AddType<EntityBase>()
                     .AddType(typeof(ReferenceDataBaseEx<,>))
                     .AddType(typeof(ReferenceDataBase<>))
                     .AddType<MessageItem>()

--- a/src/CoreEx.OData/Mapping/ODataMapperT.cs
+++ b/src/CoreEx.OData/Mapping/ODataMapperT.cs
@@ -142,16 +142,15 @@ namespace CoreEx.OData.Mapping
         /// <summary>
         /// Validates and adds a new IPropertyColumnMapper.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "They are the arguments from the calling method.")]
-        private void AddMapping(IPropertyColumnMapper pcm)
+        private void AddMapping<TSourceProperty>(PropertyColumnMapper<TSource, TSourceProperty> propertyColumnMapper)
         {
-            if (_mappings.Any(x => x.PropertyName == pcm.PropertyName))
-                throw new ArgumentException($"Source property '{pcm.PropertyName}' must not be specified more than once.", "propertyExpression");
+            if (_mappings.Any(x => x.PropertyName == propertyColumnMapper.PropertyName))
+                throw new ArgumentException($"Source property '{propertyColumnMapper.PropertyName}' must not be specified more than once.", nameof(propertyColumnMapper));
 
-            if (_mappings.Any(x => x.ColumnName == pcm.ColumnName))
-                throw new ArgumentException($"Column '{pcm.ColumnName}' must not be specified more than once.", "columnName");
+            if (_mappings.Any(x => x.ColumnName == propertyColumnMapper.ColumnName))
+                throw new ArgumentException($"Column '{propertyColumnMapper.ColumnName}' must not be specified more than once.", nameof(propertyColumnMapper));
 
-            _mappings.Add(pcm);
+            _mappings.Add(propertyColumnMapper);
         }
 
         /// <summary>

--- a/src/CoreEx.OData/README.md
+++ b/src/CoreEx.OData/README.md
@@ -136,7 +136,7 @@ public class DemoSettings : SettingsBase
     /// <summary>
     /// Gets the Dataverse connection string.
     /// </summary>
-    public string DataverseConnectionString => GetRequiredValue<string>("ConnectionStrings__Dataverse");
+    public string DataverseConnectionString => GetRequiredValue<string>("ConnectionStrings:Dataverse");
 
     /// <summary>
     /// Gets the <see cref="DataverseSettings"/> from the <see cref="DataverseConnectionString"/>.

--- a/src/CoreEx.Solace/PubSub/PubSubSender.cs
+++ b/src/CoreEx.Solace/PubSub/PubSubSender.cs
@@ -39,7 +39,7 @@ namespace CoreEx.Solace.PubSub
             Logger = logger.ThrowIfNull(nameof(logger));
             Invoker = invoker ?? (_invoker ??= new PubSubSenderInvoker());
             Converter = converter ?? new EventSendDataToPubSubConverter();
-            DefaultQueueOrTopicName = Settings.GetValue($"{GetType().Name}:QueueOrTopicName", defaultValue: _unspecifiedQueueOrTopicName);
+            DefaultQueueOrTopicName = Settings.GetCoreExValue($"{GetType().Name}:QueueOrTopicName", defaultValue: _unspecifiedQueueOrTopicName);
         }
 
         /// <summary>

--- a/src/CoreEx.UnitTesting.Azure.Functions/CoreEx.UnitTesting.Azure.Functions.csproj
+++ b/src/CoreEx.UnitTesting.Azure.Functions/CoreEx.UnitTesting.Azure.Functions.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx.Azure.Functions" Version="5.0.0" />
+    <PackageReference Include="UnitTestEx.Azure.Functions" Version="5.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreEx.UnitTesting.Azure.ServiceBus/CoreEx.UnitTesting.Azure.ServiceBus.csproj
+++ b/src/CoreEx.UnitTesting.Azure.ServiceBus/CoreEx.UnitTesting.Azure.ServiceBus.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx.Azure.ServiceBus" Version="5.0.0" />
+    <PackageReference Include="UnitTestEx.Azure.ServiceBus" Version="5.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
+++ b/src/CoreEx.UnitTesting/CoreEx.UnitTesting.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnitTestEx" Version="5.0.0" />
+    <PackageReference Include="UnitTestEx" Version="5.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CoreEx.Validation/Rules/CompareRuleBase.cs
+++ b/src/CoreEx.Validation/Rules/CompareRuleBase.cs
@@ -11,18 +11,13 @@ namespace CoreEx.Validation.Rules
     /// </summary>
     /// <typeparam name="TEntity">The entity <see cref="Type"/>.</typeparam>
     /// <typeparam name="TProperty">The property <see cref="Type"/>.</typeparam>
-    public abstract class CompareRuleBase<TEntity, TProperty> : ValueRuleBase<TEntity, TProperty> where TEntity : class
+    /// <param name="compareOperator">The <see cref="CompareOperator"/>.</param>
+    public abstract class CompareRuleBase<TEntity, TProperty>(CompareOperator compareOperator) : ValueRuleBase<TEntity, TProperty> where TEntity : class
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CompareRuleBase{TEntity, TProperty}"/> class.
-        /// </summary>
-        /// <param name="compareOperator">The <see cref="CompareOperator"/>.</param>
-        protected CompareRuleBase(CompareOperator compareOperator) => Operator = compareOperator;
-
         /// <summary>
         /// Gets the <see cref="CompareOperator"/>.
         /// </summary>
-        public CompareOperator Operator { get; private set; }
+        public CompareOperator Operator { get; private set; } = compareOperator;
 
         /// <summary>
         /// Gets or sets the comparer.

--- a/src/CoreEx.Validation/Rules/EnumRule.cs
+++ b/src/CoreEx.Validation/Rules/EnumRule.cs
@@ -22,7 +22,11 @@ namespace CoreEx.Validation.Rules
         protected override Task ValidateAsync(PropertyContext<TEntity, TProperty> context, CancellationToken cancellationToken = default)
         {
             // Make sure the enum is defined.
+#if NET6_0_OR_GREATER
+            if (!Enum.IsDefined(context.Value))
+#else
             if (!Enum.IsDefined(typeof(TProperty), context.Value))
+#endif
                 context.CreateErrorMessage(ErrorText ?? ValidatorStrings.InvalidFormat);
 
             return Task.CompletedTask;

--- a/src/CoreEx.Validation/ValidationServiceCollectionExtensions.cs
+++ b/src/CoreEx.Validation/ValidationServiceCollectionExtensions.cs
@@ -107,9 +107,9 @@ namespace Microsoft.Extensions.DependencyInjection
                                       select new { valueType, type })
                 {
                     if (alsoRegisterInterfaces)
-                        av.MakeGenericMethod(match.valueType, match.type).Invoke(null, new object[] { services });
+                        av.MakeGenericMethod(match.valueType, match.type).Invoke(null, [services]);
                     else
-                        av.MakeGenericMethod(match.type).Invoke(null, new object[] { services });
+                        av.MakeGenericMethod(match.type).Invoke(null, [services]);
                 }
             }
 

--- a/src/CoreEx/Abstractions/Internal.cs
+++ b/src/CoreEx/Abstractions/Internal.cs
@@ -1,6 +1,14 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
 using Microsoft.Extensions.Caching.Memory;
+using System.Runtime.CompilerServices;
+
+[assembly: 
+    InternalsVisibleTo("CoreEx.AspNetCore, PublicKey=00240000048000009400000006020000002400005253413100040000010001007dee530af6d801902d40685e9cd0a3d8991ddbf545be3ef6147c9f79bacd7464d92fbd94fee34e885c37e3dff4ea15a4f9978f1f614798e0f48e3a3d5bf15e8b2fba9c19b6966838f97444bc247bc101454946d70ac93207cf2c611956aed59c316f81f1bf8c8486f8f0b3f9adf93c2f07e06a86745f6dc4b819c2bc2f3fdad5"),
+    InternalsVisibleTo("CoreEx.Azure, PublicKey=00240000048000009400000006020000002400005253413100040000010001007dee530af6d801902d40685e9cd0a3d8991ddbf545be3ef6147c9f79bacd7464d92fbd94fee34e885c37e3dff4ea15a4f9978f1f614798e0f48e3a3d5bf15e8b2fba9c19b6966838f97444bc247bc101454946d70ac93207cf2c611956aed59c316f81f1bf8c8486f8f0b3f9adf93c2f07e06a86745f6dc4b819c2bc2f3fdad5"),
+    InternalsVisibleTo("CoreEx.Database.SqlServer, PublicKey=00240000048000009400000006020000002400005253413100040000010001007dee530af6d801902d40685e9cd0a3d8991ddbf545be3ef6147c9f79bacd7464d92fbd94fee34e885c37e3dff4ea15a4f9978f1f614798e0f48e3a3d5bf15e8b2fba9c19b6966838f97444bc247bc101454946d70ac93207cf2c611956aed59c316f81f1bf8c8486f8f0b3f9adf93c2f07e06a86745f6dc4b819c2bc2f3fdad5"),
+    InternalsVisibleTo("CoreEx.Solace, PublicKey=00240000048000009400000006020000002400005253413100040000010001007dee530af6d801902d40685e9cd0a3d8991ddbf545be3ef6147c9f79bacd7464d92fbd94fee34e885c37e3dff4ea15a4f9978f1f614798e0f48e3a3d5bf15e8b2fba9c19b6966838f97444bc247bc101454946d70ac93207cf2c611956aed59c316f81f1bf8c8486f8f0b3f9adf93c2f07e06a86745f6dc4b819c2bc2f3fdad5"),
+]
 
 namespace CoreEx.Abstractions
 {
@@ -15,7 +23,7 @@ namespace CoreEx.Abstractions
         /// <summary>
         /// Gets the <b>CoreEx</b> fallback <see cref="IMemoryCache"/>.
         /// </summary>
-        public static IMemoryCache MemoryCache => ExecutionContext.GetService<IInternalCache>() ?? (_fallbackCache ??= new MemoryCache(new MemoryCacheOptions()));
+        internal static IMemoryCache MemoryCache => ExecutionContext.GetService<IInternalCache>() ?? (_fallbackCache ??= new MemoryCache(new MemoryCacheOptions()));
 
         /// <summary>
         /// Represents a cache for internal capabilities.

--- a/src/CoreEx/Abstractions/Reflection/TypeReflector.cs
+++ b/src/CoreEx/Abstractions/Reflection/TypeReflector.cs
@@ -70,7 +70,7 @@ namespace CoreEx.Abstractions.Reflection
             => (args ??= TypeReflectorArgs.Default).Cache.GetOrCreate(type.ThrowIfNull(nameof(args)), ce =>
             {
                 var ec = typeof(TypeReflector<>).MakeGenericType(type).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, [typeof(TypeReflectorArgs)], null)!;
-                var tr = (ITypeReflector)ec.Invoke(new object[] { args });
+                var tr = (ITypeReflector)ec.Invoke([args]);
                 args.TypeBuilder?.Invoke(tr);
                 return ConfigureCacheEntry(ce, tr);
             })!;

--- a/src/CoreEx/CoreEx.csproj
+++ b/src/CoreEx/CoreEx.csproj
@@ -67,7 +67,7 @@
   <ItemGroup>
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="YamlDotNet" Version="16.2.0" />
+    <PackageReference Include="YamlDotNet" Version="16.2.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/CoreEx/Entities/Cleaner.cs
+++ b/src/CoreEx/Entities/Cleaner.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.Configuration;
 using CoreEx.Globalization;
 using System;
 using System.Collections.Generic;
@@ -72,14 +73,8 @@ namespace CoreEx.Entities
         /// <returns>The cleaned value.</returns>
         public static string? Clean(string? value, StringTrim trim = StringTrim.UseDefault, StringTransform transform = StringTransform.UseDefault, StringCase casing = StringCase.UseDefault)
         {
-            if (trim == StringTrim.UseDefault)
-                trim = DefaultStringTrim;
-
             if (transform == StringTransform.UseDefault)
-                transform = DefaultStringTransform;
-
-            if (casing == StringCase.UseDefault)
-                casing = DefaultStringCase;
+                transform = ExecutionContext.GetService<SettingsBase>()?.StringTransform ?? DefaultStringTransform;
 
             // Handle a null string.
             if (value == null)
@@ -89,6 +84,9 @@ namespace CoreEx.Entities
                 else
                     return value;
             }
+
+            if (trim == StringTrim.UseDefault)
+                trim = ExecutionContext.GetService<SettingsBase>()?.StringTrim ?? DefaultStringTrim;
 
             // Trim the string.
             var tmp = trim switch
@@ -111,6 +109,9 @@ namespace CoreEx.Entities
                 return tmp;
 
             // Apply casing to the string.
+            if (casing == StringCase.UseDefault)
+                casing = ExecutionContext.GetService<SettingsBase>()?.StringCase ?? DefaultStringCase;
+
             return casing switch
             {
                 StringCase.Lower => CultureInfo.CurrentCulture.TextInfo.ToCasing(tmp, TextInfoCasing.Lower),
@@ -134,10 +135,11 @@ namespace CoreEx.Entities
         /// <param name="value">The value to clean.</param>
         /// <param name="transform">The <see cref="DateTimeTransform"/> to be applied.</param>
         /// <returns>The cleaned value.</returns>
+        /// <remarks>Will attempt to use <see cref="SettingsBase.DateTimeTransform"/> as a default where possible.</remarks>
         public static DateTime Clean(DateTime value, DateTimeTransform transform)
         {
             if (transform == DateTimeTransform.UseDefault)
-                transform = DefaultDateTimeTransform;
+                transform = ExecutionContext.GetService<SettingsBase>()?.DateTimeTransform ?? DefaultDateTimeTransform;
 
             switch (transform)
             {

--- a/src/CoreEx/Entities/Extended/EntityCore.cs
+++ b/src/CoreEx/Entities/Extended/EntityCore.cs
@@ -15,7 +15,11 @@ namespace CoreEx.Entities.Extended
     [System.Diagnostics.DebuggerStepThrough]
     public abstract class EntityCore : INotifyPropertyChanged, IChangeTracking, IReadOnly
     {
+#if NET9_0_OR_GREATER
+        private readonly System.Threading.Lock _lock = new();
+#else
         private readonly object _lock = new();
+#endif
         private Dictionary<string, PropertyChangedEventHandler>? _propertyEventHandlers;
 
         /// <summary>

--- a/src/CoreEx/Events/CloudEventSerializerBase.cs
+++ b/src/CoreEx/Events/CloudEventSerializerBase.cs
@@ -15,7 +15,8 @@ namespace CoreEx.Events
     /// <summary>
     /// Provides the base <see cref="CloudEvent"/> <see cref="IEventSerializer"/> capabilities.
     /// </summary>
-    public abstract class CloudEventSerializerBase : IEventSerializer
+    /// <param name="eventDataFormatter">The <see cref="Events.EventDataFormatter"/>.</param>
+    public abstract class CloudEventSerializerBase(EventDataFormatter? eventDataFormatter) : IEventSerializer
     {
         private const string SubjectName = "subject";
         private const string ActionName = "action";
@@ -32,14 +33,8 @@ namespace CoreEx.Events
         /// an attribute name must consist of lowercase letters and digits only; any that contain other characters will be ignored.</remarks>
         public static string[] ReservedNames { get; } = ["id", "time", "type", "source", SubjectName, ActionName, CorrelationIdName, TenantIdName, ETagName, PartitionKeyName, KeyName];
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CloudEventSerializerBase"/> class.
-        /// </summary>
-        /// <param name="eventDataFormatter">The <see cref="Events.EventDataFormatter"/>.</param>
-        protected CloudEventSerializerBase(EventDataFormatter? eventDataFormatter) => EventDataFormatter = eventDataFormatter ?? new EventDataFormatter();
-
         /// <inheritdoc/>
-        public EventDataFormatter EventDataFormatter { get; }
+        public EventDataFormatter EventDataFormatter { get; } = eventDataFormatter ?? new EventDataFormatter();
 
         /// <inheritdoc/>
         public IAttachmentStorage? AttachmentStorage { get; set; }

--- a/src/CoreEx/Events/EventDataSerializerBase.cs
+++ b/src/CoreEx/Events/EventDataSerializerBase.cs
@@ -12,26 +12,17 @@ namespace CoreEx.Events
     /// Provides the base <see cref="EventData"/> <see cref="IEventSerializer"/> capabilities.
     /// </summary>
     /// <remarks>The <see cref="SerializeValueOnly"/> indicates whether the <see cref="EventData.Value"/> is serialized only (default); or alternatively, the complete <see cref="EventData"/>.</remarks>
-    public abstract class EventDataSerializerBase : IEventSerializer
+    /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
+    /// <param name="eventDataFormatter">The <see cref="Events.EventDataFormatter"/>.</param>
+    public abstract class EventDataSerializerBase(IJsonSerializer jsonSerializer, EventDataFormatter? eventDataFormatter) : IEventSerializer
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EventDataSerializerBase"/> class.
-        /// </summary>
-        /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>.</param>
-        /// <param name="eventDataFormatter">The <see cref="Events.EventDataFormatter"/>.</param>
-        protected EventDataSerializerBase(IJsonSerializer jsonSerializer, EventDataFormatter? eventDataFormatter)
-        {
-            JsonSerializer = jsonSerializer.ThrowIfNull(nameof(jsonSerializer));
-            EventDataFormatter = eventDataFormatter ?? new EventDataFormatter();
-        }
-
         /// <summary>
         /// Gets the <see cref="IJsonSerializer"/>.
         /// </summary>
-        public IJsonSerializer JsonSerializer { get; }
+        public IJsonSerializer JsonSerializer { get; } = jsonSerializer.ThrowIfNull(nameof(jsonSerializer));
 
         /// <inheritdoc/>
-        public EventDataFormatter EventDataFormatter { get; }
+        public EventDataFormatter EventDataFormatter { get; } = eventDataFormatter ?? new EventDataFormatter();
 
         /// <inheritdoc/>
         public IAttachmentStorage? AttachmentStorage { get; set; }

--- a/src/CoreEx/Events/EventPublisher.cs
+++ b/src/CoreEx/Events/EventPublisher.cs
@@ -83,7 +83,7 @@ namespace CoreEx.Events
                 list.Add(esd);
             }
 
-            await EventSender.SendAsync(list.ToArray(), cancellationToken).ConfigureAwait(false);
+            await EventSender.SendAsync([.. list], cancellationToken).ConfigureAwait(false);
         }, cancellationToken);
 
         /// <summary>

--- a/src/CoreEx/Events/EventSubscriberBase.cs
+++ b/src/CoreEx/Events/EventSubscriberBase.cs
@@ -15,7 +15,12 @@ namespace CoreEx.Events
     /// <summary>
     /// Provides the base event subscriber capabilities.
     /// </summary>
-    public abstract class EventSubscriberBase : IErrorHandling
+    /// <param name="eventDataConverter">The <see cref="IEventDataConverter"/>.</param>
+    /// <param name="executionContext">The <see cref="ExecutionContext"/>.</param>
+    /// <param name="settings">The <see cref="SettingsBase"/>.</param>
+    /// <param name="logger">The <see cref="ILogger"/>.</param>
+    /// <param name="eventSubscriberInvoker">The <see cref="EventSubscriberInvoker"/>.</param>
+    public abstract class EventSubscriberBase(IEventDataConverter eventDataConverter, ExecutionContext executionContext, SettingsBase settings, ILogger<EventSubscriberBase> logger, EventSubscriberInvoker? eventSubscriberInvoker = null) : IErrorHandling
     {
         private static EventSubscriberInvoker? _invoker;
         private ErrorHandler? _errorHandler;
@@ -36,46 +41,29 @@ namespace CoreEx.Events
         public static readonly LText NullEventErrorText = new($"{typeof(BusinessException).FullName}.{nameof(NullEventErrorText)}", $"{MessageErrorText} Event deserialized as null.");
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EventSubscriberBase"/> class.
-        /// </summary>
-        /// <param name="eventDataConverter">The <see cref="IEventDataConverter"/>.</param>
-        /// <param name="executionContext">The <see cref="ExecutionContext"/>.</param>
-        /// <param name="settings">The <see cref="SettingsBase"/>.</param>
-        /// <param name="logger">The <see cref="ILogger"/>.</param>
-        /// <param name="eventSubscriberInvoker">The <see cref="EventSubscriberInvoker"/>.</param>
-        protected EventSubscriberBase(IEventDataConverter eventDataConverter, ExecutionContext executionContext, SettingsBase settings, ILogger<EventSubscriberBase> logger, EventSubscriberInvoker? eventSubscriberInvoker = null)
-        {
-            EventDataConverter = eventDataConverter.ThrowIfNull(nameof(eventDataConverter));
-            ExecutionContext = executionContext.ThrowIfNull(nameof(executionContext));
-            Settings = settings.ThrowIfNull(nameof(settings));
-            Logger = logger.ThrowIfNull(nameof(logger));
-            EventSubscriberInvoker = eventSubscriberInvoker ?? (_invoker ??= new EventSubscriberInvoker());
-        }
-
-        /// <summary>
         /// Gets the <see cref="IEventDataConverter"/>.
         /// </summary>
-        public IEventDataConverter EventDataConverter { get; }
+        public IEventDataConverter EventDataConverter { get; } = eventDataConverter.ThrowIfNull(nameof(eventDataConverter));
 
         /// <summary>
         /// Gets the <see cref="CoreEx.ExecutionContext"/>.
         /// </summary>
-        public ExecutionContext ExecutionContext { get; }
+        public ExecutionContext ExecutionContext { get; } = executionContext.ThrowIfNull(nameof(executionContext));
 
         /// <summary>
         /// Gets the <see cref="SettingsBase"/>.
         /// </summary>
-        public SettingsBase Settings { get; }
+        public SettingsBase Settings { get; } = settings.ThrowIfNull(nameof(settings));
 
         /// <summary>
         /// Gets the <see cref="ILogger"/>.
         /// </summary>
-        public ILogger Logger { get; }
+        public ILogger Logger { get; } = logger.ThrowIfNull(nameof(logger));
 
         /// <summary>
         /// Gets the <see cref="Subscribing.EventSubscriberInvoker"/>.
         /// </summary>
-        public EventSubscriberInvoker EventSubscriberInvoker { get; }
+        public EventSubscriberInvoker EventSubscriberInvoker { get; } = eventSubscriberInvoker ?? (_invoker ??= new EventSubscriberInvoker());
 
         /// <summary>
         /// Gets or sets the <see cref="ErrorHandling"/> where an <see cref="Exception"/> occurs during <see cref="EventData"/>/<see cref="EventData{T}"/> <see cref="IEventSerializer.DeserializeAsync(BinaryData, CancellationToken)"/>/<see cref="IEventSerializer.DeserializeAsync{T}(BinaryData, CancellationToken)"/>.

--- a/src/CoreEx/Events/InMemoryPublisher.cs
+++ b/src/CoreEx/Events/InMemoryPublisher.cs
@@ -53,14 +53,14 @@ namespace CoreEx.Events
         /// </summary>
         /// <returns>An array of names.</returns>
         /// <remarks>Where <see cref="EventPublisher.Publish(EventData[])"/> (with no name) is used the underlying destination name will be <c>null</c>.</remarks>
-        public string?[] GetNames() => _dict.Keys.ToArray();
+        public string?[] GetNames() => [.. _dict.Keys];
 
         /// <summary>
         /// Gets the events sent (in order) to the named destination.
         /// </summary>
         /// <param name="name">The destination name.</param>
         /// <returns>The corresponding events.</returns>
-        public EventData[] GetEvents(string? name = null) => _dict.TryGetValue(name ?? NullName, out var queue) ? [.. queue] : Array.Empty<EventData>();
+        public EventData[] GetEvents(string? name = null) => _dict.TryGetValue(name ?? NullName, out var queue) ? [.. queue] : [];
 
         /// <summary>
         /// Resets (clears) the in-memory state.

--- a/src/CoreEx/Events/InMemorySender.cs
+++ b/src/CoreEx/Events/InMemorySender.cs
@@ -27,7 +27,7 @@ namespace CoreEx.Events
         /// <summary>
         /// Gets the events sent (in order).
         /// </summary>
-        public EventSendData[] GetEvents() => _queue.ToArray();
+        public EventSendData[] GetEvents() => [.. _queue];
 
         /// <summary>
         /// Resets (clears) the in-memory state.

--- a/src/CoreEx/Events/Subscribing/EventSubscriberOrchestrator.cs
+++ b/src/CoreEx/Events/Subscribing/EventSubscriberOrchestrator.cs
@@ -181,7 +181,7 @@ namespace CoreEx.Events.Subscribing
                         if (subscriber != null)
                             return false;
 
-                        if (att.ExtendedMatchMethodInfo is not null && !(bool)att.ExtendedMatchMethodInfo.Invoke(null, new object[] { @event, args })!)
+                        if (att.ExtendedMatchMethodInfo is not null && !(bool)att.ExtendedMatchMethodInfo.Invoke(null, [@event, args])!)
                             return false;
 
                         subscriber = (IEventSubscriber)(ServiceProvider?.GetService(item.SubscriberType) ?? ExecutionContext.GetRequiredService(item.SubscriberType));

--- a/src/CoreEx/ExecutionContext.cs
+++ b/src/CoreEx/ExecutionContext.cs
@@ -30,7 +30,11 @@ namespace CoreEx
         private HashSet<string>? _permissions;
         private bool _isCopied;
         private bool _disposed;
+#if NET9_0_OR_GREATER
+        private readonly System.Threading.Lock _lock = new();
+#else
         private readonly object _lock = new();
+#endif
 
         /// <summary>
         /// Gets or sets the function to create a default <see cref="ExecutionContext"/> instance.

--- a/src/CoreEx/Hosting/FileLockSynchronizer.cs
+++ b/src/CoreEx/Hosting/FileLockSynchronizer.cs
@@ -21,7 +21,7 @@ namespace CoreEx.Hosting
         /// </summary>
         public const string ConfigKey = "FileLockSynchronizerPath";
 
-        private readonly string _path = settings.ThrowIfNull(nameof(settings)).GetValue<string>(ConfigKey) ?? throw new ArgumentException($"Configuration setting '{ConfigKey}' either does not exist or has no value.", nameof(settings));
+        private readonly string _path = settings.ThrowIfNull(nameof(settings)).GetCoreExValue<string>(ConfigKey) ?? throw new ArgumentException($"Configuration setting '{ConfigKey}' either does not exist or has no value.", nameof(settings));
         private readonly ConcurrentDictionary<string, FileStream> _dict = new();
         private bool _disposed;
 

--- a/src/CoreEx/Hosting/TimerHostedServiceBase.cs
+++ b/src/CoreEx/Hosting/TimerHostedServiceBase.cs
@@ -25,8 +25,12 @@ namespace CoreEx.Hosting
     {
         private static readonly Random _random = new();
 
-        private readonly TimerHostedServiceHealthCheck? _healthCheck;
+#if NET9_0_OR_GREATER
+        private readonly System.Threading.Lock _lock = new();
+#else
         private readonly object _lock = new();
+#endif
+        private readonly TimerHostedServiceHealthCheck? _healthCheck;
         private TimerHostedServiceStatus _status = TimerHostedServiceStatus.Initialized;
         private string? _name;
         private CancellationTokenSource? _cts;

--- a/src/CoreEx/Hosting/Work/FileWorkStatePersistence.cs
+++ b/src/CoreEx/Hosting/Work/FileWorkStatePersistence.cs
@@ -32,7 +32,7 @@ namespace CoreEx.Hosting.Work
         /// <param name="jsonSerializer">The <see cref="IJsonSerializer"/>. Defaults to <see cref="JsonSerializer.Default"/>.</param>
         public FileWorkStatePersistence(SettingsBase settings, IJsonSerializer? jsonSerializer = null)
         {
-            _path = settings.ThrowIfNull(nameof(settings)).GetValue<string>(ConfigKey);
+            _path = settings.ThrowIfNull(nameof(settings)).GetCoreExValue<string>(ConfigKey);
 
             if (string.IsNullOrEmpty(_path))
                 throw new ArgumentException($"Configuration setting '{ConfigKey}' either does not exist or has no value.", nameof(settings));

--- a/src/CoreEx/Hosting/Work/InMemoryWorkStatePersistence.cs
+++ b/src/CoreEx/Hosting/Work/InMemoryWorkStatePersistence.cs
@@ -22,7 +22,7 @@ namespace CoreEx.Hosting.Work
         /// <summary>
         /// Gets all the <see cref="WorkState"/> entries.
         /// </summary>
-        public WorkState[] GetWorkStates() => _workStates.Values.ToArray();
+        public WorkState[] GetWorkStates() => [.. _workStates.Values];
 
         /// <inheritdoc/>
         public Task<WorkState?> GetAsync(string id, CancellationToken cancellationToken)

--- a/src/CoreEx/Hosting/Work/WorkStateOrchestrator.cs
+++ b/src/CoreEx/Hosting/Work/WorkStateOrchestrator.cs
@@ -261,7 +261,7 @@ namespace CoreEx.Hosting.Work
             if (WorkStatus.Finished.HasFlag(ws.Status))
                 return Result.Fail($"A cancellation can not be performed when the current status is {ws.Status}.");
 
-            ws.Status = WorkStatus.Cancelled;
+            ws.Status = WorkStatus.Canceled;
             ws.Finished = DateTimeOffset.UtcNow;
             ws.Reason = reason.ThrowIfNullOrEmpty(nameof(reason));
 

--- a/src/CoreEx/Hosting/Work/WorkStatus.cs
+++ b/src/CoreEx/Hosting/Work/WorkStatus.cs
@@ -41,7 +41,7 @@ namespace CoreEx.Hosting.Work
         /// <summary>
         /// Indicates that the underlying work has been cancelled.
         /// </summary>
-        Cancelled = 128,
+        Canceled = 128,
 
         /// <summary>
         /// Indicates that the underlying work is in progress; either started or indeterminate.
@@ -56,11 +56,11 @@ namespace CoreEx.Hosting.Work
         /// <summary>
         /// Indicates the the underlying work has been terminated; either expired, failed or cancelled.
         /// </summary>
-        Terminated = Expired | Failed | Cancelled,
+        Terminated = Expired | Failed | Canceled,
 
         /// <summary>
         /// Indicates that the underlying work has been completed, expired, failed or cancelled.
         /// </summary>
-        Finished = Completed | Expired | Failed | Cancelled
+        Finished = Completed | Expired | Failed | Canceled
     }
 }   

--- a/src/CoreEx/Http/HttpArg.cs
+++ b/src/CoreEx/Http/HttpArg.cs
@@ -56,6 +56,10 @@ namespace CoreEx.Http
                 str = rd?.Code;
             else if (Value is DateTime dt)
                 str = dt.ToString("o", CultureInfo.InvariantCulture);
+            else if (Value is DateTimeOffset dto)
+                str = dto.ToString("o", CultureInfo.InvariantCulture);
+            else if (Value is bool b)
+                str = b.ToString().ToLowerInvariant();
             else if (Value is IFormattable fmt)
                 str = fmt.ToString(null, CultureInfo.InvariantCulture);
             else

--- a/src/CoreEx/Http/TypedHttpClientBase.cs
+++ b/src/CoreEx/Http/TypedHttpClientBase.cs
@@ -123,7 +123,7 @@ namespace CoreEx.Http
             var qs = HttpUtility.ParseQueryString(ub.Query);
 
             // Extend the query string from the IHttpArgs.
-            foreach (var arg in (args ??= Array.Empty<IHttpArg>()).Where(x => x != null))
+            foreach (var arg in (args ??= []).Where(x => x != null))
             {
                 arg.AddToQueryString(qs, JsonSerializer);
             }
@@ -235,7 +235,6 @@ namespace CoreEx.Http
             return braceIndex;
         }
 
-
         /// <summary>
         /// Deserialize the JSON <see cref="HttpResponseMessage.Content"/> into <see cref="Type"/> of <typeparamref name="TResp"/>.
         /// </summary>
@@ -279,7 +278,7 @@ namespace CoreEx.Http
                     return (true, $"Http Request Exception occurred: {exception.Message}");
 
                 if (exception is TaskCanceledException)
-                    return (true, "Task was cancelled.");
+                    return (true, "Task was canceled.");
             }
 
             if (response == null)

--- a/src/CoreEx/Invokers/InvokeArgs.cs
+++ b/src/CoreEx/Invokers/InvokeArgs.cs
@@ -42,7 +42,7 @@ namespace CoreEx.Invokers
             if (settings.Configuration is null)
                 return true;
 
-            return settings.GetValue<bool?>($"Invokers:{invokerType.FullName}:TracingEnabled") ?? settings.GetValue<bool?>("Invokers:Default:TracingEnabled") ?? true;
+            return settings.GetCoreExValue<bool?>($"Invokers:{invokerType.FullName}:TracingEnabled") ?? settings.GetCoreExValue<bool?>("Invokers:Default:TracingEnabled") ?? true;
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace CoreEx.Invokers
             if (settings.Configuration is null)
                 return true;
 
-            return settings.GetValue<bool?>($"Invokers:{invokerType.FullName}:LoggingEnabled") ?? settings.GetValue<bool?>("Invokers:Default:LoggingEnabled") ?? true;
+            return settings.GetCoreExValue<bool?>($"Invokers:{invokerType.FullName}:LoggingEnabled") ?? settings.GetCoreExValue<bool?>("Invokers:Default:LoggingEnabled") ?? true;
         }
 
         /// <summary>

--- a/src/CoreEx/Json/Compare/JsonElementComparer.cs
+++ b/src/CoreEx/Json/Compare/JsonElementComparer.cs
@@ -377,8 +377,8 @@ namespace CoreEx.Json.Compare
         /// </summary>
         private sealed class CompareState
         {
-            private readonly Stack<string> _unqualifiedPaths = new(new[] { "$" });
-            private readonly Stack<string> _paths = new(new[] { "$" });
+            private readonly Stack<string> _unqualifiedPaths = new(["$"]);
+            private readonly Stack<string> _paths = new(["$"]);
 
             /// <summary>
             /// Initializes a new instance of the <see cref="CompareState"/> class.
@@ -391,7 +391,7 @@ namespace CoreEx.Json.Compare
                 Result = result;
                 PathComparer = pathComparer ?? StringComparer.InvariantCultureIgnoreCase;
                 var maxDepth = 0;
-                PathsToIgnore = new(Text.Json.JsonFilterer.CreateDictionary(pathsToIgnore, JsonPropertyFilter.Exclude, StringComparison.Ordinal, ref maxDepth, true).Keys);
+                PathsToIgnore = new(JsonFilterer.CreateDictionary(pathsToIgnore, JsonPropertyFilter.Exclude, StringComparison.Ordinal, ref maxDepth, true).Keys);
             }
 
             /// <summary>

--- a/src/CoreEx/Json/Compare/JsonElementComparerResult.cs
+++ b/src/CoreEx/Json/Compare/JsonElementComparerResult.cs
@@ -77,7 +77,7 @@ namespace CoreEx.Json.Compare
         /// Gets the <see cref="JsonElementDifference"/> array.
         /// </summary>
         /// <remarks>The differences found up to the <see cref="MaxDifferences"/> specified.</remarks>
-        public JsonElementDifference[] GetDifferences() => _differences is null ? [] : _differences.ToArray();
+        public JsonElementDifference[] GetDifferences() => _differences is null ? [] : [.. _differences];
 
         /// <summary>
         /// Adds a <see cref="JsonElementDifference"/>.

--- a/src/CoreEx/Json/Mapping/JsonObjectMapperT.cs
+++ b/src/CoreEx/Json/Mapping/JsonObjectMapperT.cs
@@ -138,16 +138,15 @@ namespace CoreEx.Json.Mapping
         /// <summary>
         /// Validates and adds a new IPropertyJsonMapper.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2208:Instantiate argument exceptions correctly", Justification = "They are the arguments from the calling method.")]
-        private void AddMapping(IPropertyJsonMapper pcm)
+        private void AddMapping<TSourceProperty>(PropertyJsonMapper<TSource, TSourceProperty> propertyJsonMapper)
         {
-            if (_mappings.Any(x => x.PropertyName == pcm.PropertyName))
-                throw new ArgumentException($"Source property '{pcm.PropertyName}' must not be specified more than once.", "propertyExpression");
+            if (_mappings.Any(x => x.PropertyName == propertyJsonMapper.PropertyName))
+                throw new ArgumentException($"Source property '{propertyJsonMapper.PropertyName}' must not be specified more than once.", nameof(propertyJsonMapper));
 
-            if (_mappings.Any(x => x.JsonName == pcm.JsonName))
-                throw new ArgumentException($"Column '{pcm.JsonName}' must not be specified more than once.", "jsonName");
+            if (_mappings.Any(x => x.JsonName == propertyJsonMapper.JsonName))
+                throw new ArgumentException($"Column '{propertyJsonMapper.JsonName}' must not be specified more than once.", nameof(propertyJsonMapper));
 
-            _mappings.Add(pcm);
+            _mappings.Add(propertyJsonMapper);
         }
 
         /// <summary>

--- a/src/CoreEx/RefData/Caching/SettingsBasedCacheEntry.cs
+++ b/src/CoreEx/RefData/Caching/SettingsBasedCacheEntry.cs
@@ -36,8 +36,8 @@ namespace CoreEx.RefData.Caching
         /// This should be overridden where more advanced behaviour is required.</remarks>
         public virtual void CreateCacheEntry(Type type, ICacheEntry entry)
         {
-            entry.AbsoluteExpirationRelativeToNow = Settings?.GetValue($"RefDataCache__{type.Name}__{nameof(ICacheEntry.AbsoluteExpirationRelativeToNow)}", Settings.RefDataCacheAbsoluteExpirationRelativeToNow) ?? TimeSpan.FromHours(2);
-            entry.SlidingExpiration = Settings?.GetValue($"RefDataCache__{type.Name}__{nameof(ICacheEntry.SlidingExpiration)}", Settings.RefDataCacheSlidingExpiration) ?? TimeSpan.FromMinutes(30);
+            entry.AbsoluteExpirationRelativeToNow = Settings?.GetCoreExValue($"RefDataCache:{type.Name}:{nameof(ICacheEntry.AbsoluteExpirationRelativeToNow)}", Settings.RefDataCacheAbsoluteExpirationRelativeToNow) ?? TimeSpan.FromHours(2);
+            entry.SlidingExpiration = Settings?.GetCoreExValue($"RefDataCache:{type.Name}:{nameof(ICacheEntry.SlidingExpiration)}", Settings.RefDataCacheSlidingExpiration) ?? TimeSpan.FromMinutes(30);
         }
     }
 }

--- a/src/CoreEx/RefData/ReferenceDataCodeList.cs
+++ b/src/CoreEx/RefData/ReferenceDataCodeList.cs
@@ -32,7 +32,7 @@ namespace CoreEx.RefData
         /// Initializes a new instance of the <see cref="ReferenceDataCodeList{TRef}"/> class with a list of items.
         /// </summary>
         /// <param name="items">The list of <see cref="IReferenceData"/> items.</param>
-        public ReferenceDataCodeList(IEnumerable<TRef> items) => _codes = new((items ?? Array.Empty<TRef>()).Select(x => x.Code));
+        public ReferenceDataCodeList(IEnumerable<TRef> items) => _codes = new((items ?? []).Select(x => x.Code));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ReferenceDataCodeList{TRef}"/> class with a <see cref="IReferenceData.Code"/> array.
@@ -53,7 +53,7 @@ namespace CoreEx.RefData
         /// Creates a new <typeparamref name="TRef"/> list from the underlying contents.
         /// </summary>
         /// <returns>A new <typeparamref name="TRef"/> list</returns>
-        public List<TRef> ToRefDataList() => this.ToList();
+        public List<TRef> ToRefDataList() => [.. this];
 
         /// <summary>
         /// Creates a new <see cref="IIdentifier{TId}.Id"/> list from the underlying contents.

--- a/src/CoreEx/RefData/ReferenceDataCollection.cs
+++ b/src/CoreEx/RefData/ReferenceDataCollection.cs
@@ -16,7 +16,11 @@ namespace CoreEx.RefData
     /// <typeparam name="TRef">The <see cref="IReferenceData{TId}"/> <see cref="Type"/>.</typeparam>
     public class ReferenceDataCollection<TId, TRef> : IReferenceDataCollection<TId, TRef>, ICollection<TRef> where TId : IComparable<TId>, IEquatable<TId> where TRef : class, IReferenceData<TId>
     {
+#if NET9_0_OR_GREATER
+        private readonly System.Threading.Lock _lock = new();
+#else
         private readonly object _lock = new();
+#endif
         private readonly ConcurrentDictionary<TId, TRef> _rdcId = new();
         private readonly ConcurrentDictionary<string, TRef> _rdcCode;
         private Dictionary<(string, object?), TRef>? _mappingsDict;

--- a/src/CoreEx/RefData/ReferenceDataOrchestrator.cs
+++ b/src/CoreEx/RefData/ReferenceDataOrchestrator.cs
@@ -38,7 +38,11 @@ namespace CoreEx.RefData
 
         private static readonly AsyncLocal<ReferenceDataOrchestrator?> _asyncLocal = new();
 
+#if NET9_0_OR_GREATER
+        private readonly System.Threading.Lock _lock = new();
+#else
         private readonly object _lock = new();
+#endif
         private readonly ConcurrentDictionary<Type, Type> _typeToProvider = new();
         private readonly ConcurrentDictionary<string, Type> _nameToType = new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<object, SemaphoreSlim> _semaphores = new();

--- a/src/CoreEx/ValidationException.cs
+++ b/src/CoreEx/ValidationException.cs
@@ -58,7 +58,7 @@ namespace CoreEx
         /// </summary>
         /// <param name="item">The <see cref="MessageItem"/>.</param>
         /// <param name="message">The error message.</param>
-        public ValidationException(MessageItem item, string? message = null) : this(new MessageItem[] { item }, message) { }
+        public ValidationException(MessageItem item, string? message = null) : this([item], message) { }
 
         /// <summary>
         /// Gets the underlying messages.

--- a/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
+++ b/tests/CoreEx.Cosmos.Test/CoreEx.Cosmos.Test.csproj
@@ -34,7 +34,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Test/CoreEx.Test.csproj
+++ b/tests/CoreEx.Test/CoreEx.Test.csproj
@@ -23,7 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Test/Framework/WebApis/WebApiPublisherTest.cs
+++ b/tests/CoreEx.Test/Framework/WebApis/WebApiPublisherTest.cs
@@ -544,7 +544,7 @@ namespace CoreEx.Test.Framework.WebApis
             Assert.That(ws, Is.Not.Null);
             Assert.Multiple(() =>
             {
-                Assert.That(ws!.Status, Is.EqualTo(WorkStatus.Cancelled));
+                Assert.That(ws!.Status, Is.EqualTo(WorkStatus.Canceled));
                 Assert.That(ws.Reason, Is.EqualTo("No reason was specified."));
             });
         }

--- a/tests/CoreEx.Test/TestFunction/HttpTriggerPublishFunctionTest.cs
+++ b/tests/CoreEx.Test/TestFunction/HttpTriggerPublishFunctionTest.cs
@@ -97,7 +97,7 @@ namespace CoreEx.Test.TestFunction
 
             test.ReplaceScoped<IEventPublisher>(_ => imp)
                 .HttpTrigger<HttpTriggerPublishFunction>()
-                .Run(f => f.RunAsync(test.CreateJsonHttpRequest(HttpMethod.Post, "https://unittest/products", new { id = "A", price = 1.99m })))
+                .Run(f => f.RunAsync(test.CreateJsonHttpRequest(HttpMethod.Post, "https://unittest/products/publish", new { id = "A", price = 1.99m })))
                 .AssertBadRequest()
                 .AssertErrors(new ApiError("Name", "'Name' must not be empty."));
 
@@ -113,7 +113,7 @@ namespace CoreEx.Test.TestFunction
             test.ReplaceScoped<IEventPublisher>(_ => imp)
                 .ConfigureServices(sc => sc.ReplaceScoped<IJsonSerializer, CoreEx.Newtonsoft.Json.JsonSerializer>())
                 .HttpTrigger<HttpTriggerPublishFunction>()
-                .Run(f => f.RunAsync(test.CreateJsonHttpRequest(HttpMethod.Post, "https://unittest/products", new { id = "A", price = 1.99m })))
+                .Run(f => f.RunAsync(test.CreateJsonHttpRequest(HttpMethod.Post, "https://unittest/products/publish", new { id = "A", price = 1.99m })))
                 .AssertBadRequest()
                 .AssertErrors(new ApiError("Name", "'Name' must not be empty."));
 
@@ -128,7 +128,7 @@ namespace CoreEx.Test.TestFunction
 
             test.ReplaceScoped<IEventPublisher>(_ => imp)
                 .HttpTrigger<HttpTriggerPublishFunction>()
-                .Run(f => f.RunAsync(test.CreateJsonHttpRequest(HttpMethod.Post, "https://unittest/products", new { id = "A", name = "B", price = 1.99m })))
+                .Run(f => f.RunAsync(test.CreateJsonHttpRequest(HttpMethod.Post, "https://unittest/products/publish", new { id = "A", name = "B", price = 1.99m })))
                 .AssertAccepted();
 
             Assert.That(imp.GetNames(), Has.Length.EqualTo(1));
@@ -147,7 +147,7 @@ namespace CoreEx.Test.TestFunction
             test.ReplaceScoped<IEventPublisher>(_ => imp)
                 .ConfigureServices(sc => sc.ReplaceScoped<IJsonSerializer, CoreEx.Newtonsoft.Json.JsonSerializer>())
                 .HttpTrigger<HttpTriggerPublishFunction>()
-                .Run(f => f.RunAsync(test.CreateJsonHttpRequest(HttpMethod.Post, "https://unittest/products", new { id = "A", name = "B", price = 1.99m })))
+                .Run(f => f.RunAsync(test.CreateJsonHttpRequest(HttpMethod.Post, "https://unittest/products/publish", new { id = "A", name = "B", price = 1.99m })))
                 .AssertAccepted();
 
             Assert.That(imp.GetNames(), Has.Length.EqualTo(1));

--- a/tests/CoreEx.Test2/CoreEx.Test2.csproj
+++ b/tests/CoreEx.Test2/CoreEx.Test2.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="UnitTestEx.NUnit" Version="5.0.0" />
+    <PackageReference Include="UnitTestEx.NUnit" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CoreEx.Test2/Framework/Validation/ValidationExtensionsTest.cs
+++ b/tests/CoreEx.Test2/Framework/Validation/ValidationExtensionsTest.cs
@@ -27,7 +27,7 @@ namespace CoreEx.Test2.Framework.Validation
             return await Result.Go().ValidatesAsync(email2, v =>
             {
                 var v2 = v;
-                var v3 = v.Email();
+                var v3 = v2.Email();
             });
         }
     }

--- a/tests/CoreEx.Test2/TestFunctionIso/ServiceBusTest.cs
+++ b/tests/CoreEx.Test2/TestFunctionIso/ServiceBusTest.cs
@@ -42,7 +42,7 @@ namespace CoreEx.Test2.TestFunctionIso
             await wo.CancelAsync(message.MessageId, "No longer needed.");
 
             test.ServiceBusTrigger<ServiceBusFunction>()
-                .ExpectLogContains("warn: Unable to process message as corresponding work state status is Cancelled: No longer needed.")
+                .ExpectLogContains("warn: Unable to process message as corresponding work state status is Canceled: No longer needed.")
                 .Run(f => f.Run(message, actions))
                 .AssertSuccess();
 
@@ -50,7 +50,7 @@ namespace CoreEx.Test2.TestFunctionIso
 
             var ws = await wo.GetAsync(message.MessageId);
             Assert.That(ws, Is.Not.Null);
-            Assert.That(ws!.Status, Is.EqualTo(WorkStatus.Cancelled));
+            Assert.That(ws!.Status, Is.EqualTo(WorkStatus.Canceled));
         }
 
         [Test]

--- a/tests/CoreEx.TestFunction/Functions/HttpTriggerFunction.cs
+++ b/tests/CoreEx.TestFunction/Functions/HttpTriggerFunction.cs
@@ -10,16 +10,10 @@ using System.Threading.Tasks;
 
 namespace CoreEx.TestFunction.Functions
 {
-    public class HttpTriggerFunction
+    public class HttpTriggerFunction(WebApi webApi, ProductService service)
     {
-        private readonly WebApi _webApi;
-        private readonly ProductService _service;
-
-        public HttpTriggerFunction(WebApi webApi, ProductService service)
-        {
-            _webApi = webApi;
-            _service = service;
-        }
+        private readonly WebApi _webApi = webApi;
+        private readonly ProductService _service = service;
 
         [FunctionName("HttpTriggerProductGet")]
         public Task<IActionResult> GetAsync([HttpTrigger(AuthorizationLevel.Function, "get", Route = "products/{id}")] HttpRequest request, string id)


### PR DESCRIPTION
- *Fixed:* Added support for `SettingsBase.DateTimeTransform`, `StringTransform`, `StringTrim` and `StringCase` to allow specification via configuration.
- *Fixed:* Added support for `CoreEx:` hierarchy (optional) for all _CoreEx_ settings to enable a more structured and explicit configuration.