### PR TITLE
v3.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Represents the **NuGet** versions.
 
+## v3.30.2
+- *Fixed:* Missing `QueryArgs.IncludeText` added to set the `$text=true` equivalent.
+- *Fixed:* Simplification of creating and setting the `QueryArgs.Filter` using an implict string operator.
+
 ## v3.30.1
 - *Fixed:* Added support for `SettingsBase.DateTimeTransform`, `StringTransform`, `StringTrim` and `StringCase` to allow specification via configuration.
 - *Fixed:* Added support for `CoreEx:` hierarchy (optional) for all _CoreEx_ settings to enable a more structured and explicit configuration.

--- a/Common.targets
+++ b/Common.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.30.1</Version>
+		<Version>3.30.2</Version>
 		<LangVersion>preview</LangVersion>
 		<Authors>Avanade</Authors>
 		<Company>Avanade</Company>

--- a/src/CoreEx/Entities/QueryArgs.cs
+++ b/src/CoreEx/Entities/QueryArgs.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/CoreEx
 
+using CoreEx.RefData;
 using System.Collections.Generic;
 
 namespace CoreEx.Entities
@@ -40,6 +41,12 @@ namespace CoreEx.Entities
         public List<string>? ExcludeFields { get; set; }
 
         /// <summary>
+        /// Indicates whether to include any related texts for the item(s).
+        /// </summary>
+        /// <remarks>For example, include corresponding <see cref="IReferenceData.Text"/> for any <b>ReferenceData</b> values returned in the JSON response payload.</remarks>
+        public bool IsTextIncluded { get; set; }
+
+        /// <summary>
         /// Appends the <paramref name="fields"/> to the <see cref="IncludeFields"/>.
         /// </summary>
         /// <param name="fields">The fields to append.</param>
@@ -60,5 +67,23 @@ namespace CoreEx.Entities
             (ExcludeFields ??= []).AddRange(fields);
             return this;
         }
+
+        /// <summary>
+        /// Indicates whether to include any related texts for the item(s); see <see cref="IsTextIncluded"/>.
+        /// </summary>
+        /// <returns>The <see cref="QueryArgs"/> to support fluent-style method-chaining.</returns>
+        /// <remarks>For example, include corresponding <see cref="IReferenceData.Text"/> for any <b>ReferenceData</b> values returned in the JSON response payload.</remarks>
+        public QueryArgs IncludeText()
+        {
+            IsTextIncluded = true;
+            return this;
+        }
+
+        /// <summary>
+        /// An implicit cast from a filter <see cref="string"/> to a <see cref="QueryArgs"/>.
+        /// </summary>
+        /// <param name="filter">The <see cref="Filter"/>.</param>
+        /// <returns>The corresponding <see cref="QueryArgs"/>.</returns>
+        public static implicit operator QueryArgs(string? filter) => Create(filter);
     }
 }

--- a/src/CoreEx/Http/HttpRequestOptions.cs
+++ b/src/CoreEx/Http/HttpRequestOptions.cs
@@ -152,6 +152,9 @@ namespace CoreEx.Http
 
                 if (Query.ExcludeFields is not null)
                     query.Exclude([.. Query.ExcludeFields]);
+
+                if (Query.IsTextIncluded)
+                    query.IsTextIncluded = true;
             }
 
             Query = query;
@@ -255,7 +258,7 @@ namespace CoreEx.Http
                     AddNameValuePairs(sb, QueryStringNameExcludeFields, Query.ExcludeFields.Where(x => !string.IsNullOrEmpty(x)).Select(x => HttpUtility.UrlEncode(x)).ToArray(), false, true);
             }
 
-            if (IncludeText)
+            if (IncludeText || (Query is not null && Query.IsTextIncluded))
                 AddNameValuePair(sb, QueryStringNameIncludeText, "true", false);
 
             if (IncludeInactive)

--- a/tests/CoreEx.Test/Framework/Data/QueryArgsConfigTest.cs
+++ b/tests/CoreEx.Test/Framework/Data/QueryArgsConfigTest.cs
@@ -57,8 +57,8 @@ namespace CoreEx.Test.Framework.Data
             Assert.That(ex.Messages, Has.Count.EqualTo(1));
             Assert.Multiple(() =>
             {
-                Assert.That(ex.Messages.First().Property, Is.EqualTo("$filter"));
-                Assert.That(ex.Messages.First().Text, Does.StartWith(expected));
+                Assert.That(ex.Messages!.First().Property, Is.EqualTo("$filter"));
+                Assert.That(ex.Messages!.First().Text, Does.StartWith(expected));
             });
         }
 
@@ -305,12 +305,12 @@ Note: The OData-like filtering is awesome!"));
             void AssertException(string? orderBy, string expected)
             {
                 var ex = Assert.Throws<QueryOrderByParserException>(() => _queryConfig.OrderByParser.Parse(orderBy).ThrowOnError());
-                Assert.That(ex.Messages, Is.Not.Null);
-                Assert.That(ex.Messages, Has.Count.EqualTo(1));
+                Assert.That(ex?.Messages, Is.Not.Null);
+                Assert.That(ex!.Messages, Has.Count.EqualTo(1));
                 Assert.Multiple(() =>
                 {
-                    Assert.That(ex.Messages.First().Property, Is.EqualTo("$orderby"));
-                    Assert.That(ex.Messages.First().Text, Does.StartWith(expected));
+                    Assert.That(ex.Messages!.First().Property, Is.EqualTo("$orderby"));
+                    Assert.That(ex.Messages!.First().Text, Does.StartWith(expected));
                 });
             }
 

--- a/tests/CoreEx.Test/Framework/Http/HttpRequestOptionsTest.cs
+++ b/tests/CoreEx.Test/Framework/Http/HttpRequestOptionsTest.cs
@@ -161,12 +161,23 @@ namespace CoreEx.Test.Framework.Http
         [Test]
         public void QueryArgsQueryString()
         {
-            var qa = QueryArgs.Create("name eq 'bob'");
+            QueryArgs qa = "name eq 'bob'";
             var hr = new HttpRequestMessage(HttpMethod.Get, "https://unittest/testing");
             var ro = new HttpRequestOptions() { IncludeInactive = true }.Include("name", "text");
             ro = ro.WithQuery(qa);
             hr.ApplyRequestOptions(ro);
             Assert.That(hr.RequestUri!.AbsoluteUri, Is.EqualTo("https://unittest/testing?$filter=name+eq+%27bob%27&$fields=name,text&$inactive=true"));
+        }
+
+        [Test]
+        public void QueryArgsQueryStringWithIncludeText()
+        {
+            var qa = QueryArgs.Create("name eq 'bob'").IncludeText();
+            var hr = new HttpRequestMessage(HttpMethod.Get, "https://unittest/testing");
+            var ro = new HttpRequestOptions() { IncludeInactive = true }.Include("name", "text");
+            ro = ro.WithQuery(qa);
+            hr.ApplyRequestOptions(ro);
+            Assert.That(hr.RequestUri!.AbsoluteUri, Is.EqualTo("https://unittest/testing?$filter=name+eq+%27bob%27&$fields=name,text&$text=true&$inactive=true"));
         }
     }
 }


### PR DESCRIPTION
- *Fixed:* Missing `QueryArgs.IncludeText` added to set the `$text=true` equivalent.
- *Fixed:* Simplification of creating and setting the `QueryArgs.Filter` using an implict string operator.