### PR TITLE
feat: add coreex-db-migration skill

### DIFF
--- a/.github/prompts/coreex-db-migration.prompt.md
+++ b/.github/prompts/coreex-db-migration.prompt.md
@@ -1,0 +1,18 @@
+---
+description: Add or change a database table for a CoreEx domain — scaffold migration script, update dbex.yaml, apply, and regenerate EF persistence models
+---
+
+Guide this workspace through a CoreEx database schema change.
+
+Use `.github/skills/coreex-db-migration/SKILL.md` and its referenced workflow as the authoritative workflow contract when they exist.
+
+Operational contract:
+- Inspect the database state before authoring any script — this is a hard gate.
+- Use `.github/skills/coreex-db-migration/references/workflow.md` as the sole source of truth for the decision tree, SQL column templates, dbex.yaml rules, and guardrails.
+- Ask one question at a time; never batch schema decisions into a single message.
+- Surface verbatim error output on any `dotnet run` failure — do not edit generated files to work around failures.
+- If any prompt text conflicts with the skill, the skill wins.
+
+Outcome:
+- Author and apply the correct migration script for the target table and change type (create, refdata, alter, or non-entity).
+- Confirm `*.g.cs` Infrastructure persistence models are regenerated, and the solution builds cleanly.

--- a/.github/skills/coreex-db-migration/SKILL.md
+++ b/.github/skills/coreex-db-migration/SKILL.md
@@ -36,6 +36,7 @@ All commands run from the `*.Database` project directory.
 | Alter existing table | `dotnet run -- script alter <schema> <table>` |
 | Non-entity schema change | `dotnet run -- script` |
 | Apply everything + regenerate | `dotnet run -- All` |
+| Drop + full rebuild (destructive, confirm first) | `dotnet run -- dropandall --accept-prompts` |
 
 ## Naming
 

--- a/.github/skills/coreex-db-migration/SKILL.md
+++ b/.github/skills/coreex-db-migration/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: coreex-db-migration
+description: "Add or change a database table for a CoreEx domain. USE FOR: new transactional table, new reference-data table, altering an existing table (columns, indexes, constraints), or any other schema change (indexes, functions, stored procs). Scaffolds the correct migration script, updates dbex.yaml, applies the migration, and regenerates Infrastructure persistence models. DO NOT USE FOR: outbox provisioning (use dotnet run -- script outbox directly), seed data only changes (dotnet run -- Data), or CoreEx contract/service generation (that is *.CodeGen, not *.Database)."
+argument-hint: "Optional: entity/table name, schema, SQL Server vs PostgreSQL, nature of change"
+tags: ["database", "migration", "dbex", "schema", "efcore", "coreex"]
+---
+
+# CoreEx: DB Migration
+
+Guides you through any database schema change for a CoreEx domain — from choosing the right migration script through to regenerated EF persistence models.
+
+## When to Use
+
+- Adding a new table for a new entity (transactional or reference-data)
+- Altering an existing table — adding/modifying/removing columns, indexes, or constraints
+- Any other schema change that needs to flow through to regenerated `*.g.cs` Infrastructure files
+- Non-entity schema changes (adding an index, a unique constraint, a function)
+
+## When Not to Use
+
+- Provisioning the transactional outbox — run `dotnet run -- script outbox <schema> <name>` directly; see `coreex-tooling.instructions.md`
+- Changing reference-data seed rows only — edit `Data/ref-data.seed.yaml` and run `dotnet run -- Data`
+- Generating CoreEx contracts/services/repositories — that is `*.CodeGen`, not `*.Database`
+- Runtime or deployment issues
+
+## Quick Reference
+
+All commands run from the `*.Database` project directory.
+
+| Task | Command |
+|---|---|
+| Bring DB up to date | `dotnet run -- database` |
+| Inspect current table state | `dotnet run -- inspect <schema> <table>` |
+| New transactional table | `dotnet run -- script create <schema> <table>` |
+| New reference-data table | `dotnet run -- script refdata <schema> <table>` |
+| Alter existing table | `dotnet run -- script alter <schema> <table>` |
+| Non-entity schema change | `dotnet run -- script` |
+| Apply everything + regenerate | `dotnet run -- All` |
+
+## Naming
+
+- Script commands produce a file named `yyyyMMdd-HHmmss-<descriptor>.{sql|pgsql}` using the current UTC date and time.
+- For `create`, `refdata`, and `alter` the descriptor is auto-derived from the table name.
+- For bare `script` (non-entity changes), DbEx names the file with a placeholder suffix — **rename it immediately** to a 3–5 word kebab summary of intent (e.g. `add-unique-code-index`, `drop-legacy-status-column`).
+- The complete filename (timestamp + descriptor + extension) **must not exceed 255 characters**. The project name and Migrations folder (e.g. `Contoso.Products.Database.Migrations`) are used as an embedded-resource name prefix internally, so keep descriptors concise.
+
+## Polyglot Note
+
+| Domain | Provider | Script extension | Casing |
+|---|---|---|---|
+| `Contoso.Products.*` | PostgreSQL | `.pgsql` | `snake_case` |
+| `Contoso.Shopping.*`, `Contoso.Orders.*` | SQL Server | `.sql` | `PascalCase` |
+
+For the full step-by-step decision tree, SQL column templates, and guardrails see [`references/workflow.md`](references/workflow.md).
+
+## Key References
+
+- [`/.github/instructions/coreex-tooling.instructions.md`](/.github/instructions/coreex-tooling.instructions.md) — DbEx command reference, `dbex.yaml` structure, SQL conventions, outbox provisioning
+- [`/.github/instructions/coreex-repositories.instructions.md`](/.github/instructions/coreex-repositories.instructions.md) — what the generated `*.g.cs` feeds into
+- [`/samples/src/Contoso.Products.Database/`](/samples/src/Contoso.Products.Database/) — canonical PostgreSQL domain example
+- [`/samples/src/Contoso.Shopping.Database/`](/samples/src/Contoso.Shopping.Database/) — canonical SQL Server domain example

--- a/.github/skills/coreex-db-migration/references/workflow.md
+++ b/.github/skills/coreex-db-migration/references/workflow.md
@@ -100,6 +100,19 @@ Remove any `DEFAULT (NEWSEQUENTIALID())`, `IDENTITY`, or `SERIAL` unless the use
 | `DateTimeOffset` | `DATETIMEOFFSET` | `TIMESTAMPTZ` |
 | `DateTime` | `DATETIME2` | `TIMESTAMP` |
 
+### JSON columns
+
+When a column name ends with `Json` (SQL Server `PascalCase`) or `json` (PostgreSQL `snake_case`), **confirm with the developer** that the intent is serialized JSON storage. If confirmed:
+
+| Provider | Default column type | Override allowed |
+|---|---|---|
+| SQL Server | `NVARCHAR(MAX)` | Yes — e.g. `NVARCHAR(4000)` if size is bounded |
+| PostgreSQL | `jsonb` | Yes — `json` (text) if binary operators are explicitly not wanted |
+
+The `.NET` type for a JSON column is typically a **class or record**, not a string — the column stores the serialized form of that type. This is a NoSQL-within-SQL pattern: complex nested data is stored as a blob to avoid composite columns or child tables when no specific database-level operations (filtering, indexing on subfields, etc.) are needed against the content. If the developer expects to query within the JSON, flag that — `jsonb` supports operators but the design decision should be explicit.
+
+Do not add JSON column handling to the `dbex.yaml` `columns:` entry — DbEx will infer the CLR type via a registered value converter. Confirm the Infrastructure mapper (or `*.Database` CodeGen config) handles the JSON serialization; this is a hand-written concern, not auto-generated.
+
 ### Reference-data relationships
 
 For each `[ReferenceData<T>]` property on the entity (contract property is `{Name}Code`): create a `{Name}Code` column typed to match the ref-data `Code` column. **No foreign key — this is the default.** Never create a `{Name}Id` column unless the user explicitly asks.
@@ -231,7 +244,11 @@ This runs: Create → Migrate → CodeGen → Schema → Data.
 - **Scripts are immutable once applied.** Never modify a migration script that has already been run. Author a new script for any subsequent delta.
 - **Never edit `*.g.cs` files.** They are owned by DbEx CodeGen — regenerate by fixing the script or `dbex.yaml` and re-running `All`.
 - **Never add `IF NOT EXISTS` or `IF OBJECT_ID(...)` guards.** DbEx tracks applied scripts in its journal; each script runs exactly once. Conditional guards mask state mismatches — they don't fix them.
-- **Never touch the DbEx journal table.** If the live database is out of sync with the scripts, stop and ask the user. The standard clean fix for a disposable dev database is `dotnet run -- dropanddatabase` (destructive — confirm first).
+- **Never touch the DbEx journal table.** If the live database is out of sync with the scripts, stop and ask the user. For a **disposable local/dev database** that has gotten into an inconsistent state, the clean fix is to drop and fully rebuild:
+  ```
+  dotnet run -- dropandall --accept-prompts
+  ```
+  This runs: Drop → Create → Migrate → CodeGen → Schema → Data — a completely fresh slate. **This is destructive — confirm with the user before executing.** The `--accept-prompts` flag bypasses DbEx's built-in confirmation prompt for DROP commands; only pass it after the user has explicitly consented. Never use `dropandall` on a shared or production database.
 - **Path D filename limit:** full filename ≤255 characters including the timestamp prefix and extension. Keep descriptors to 3–5 words.
 - **Outbox provisioning is a separate concern** — use `dotnet run -- script outbox <schema> <name>` as described in `coreex-tooling.instructions.md`. Do not conflate it with this workflow.
 - **No schema-create script.** The `coreex` template ships the schema-create migration; never emit another `create-<schema>-schema` script unless an additional schema is explicitly requested.

--- a/.github/skills/coreex-db-migration/references/workflow.md
+++ b/.github/skills/coreex-db-migration/references/workflow.md
@@ -1,0 +1,237 @@
+# DB Migration Workflow
+
+All commands run from the `*.Database` project directory for the target domain.
+
+---
+
+## Phase 1: Establish Baseline
+
+1. **Bring the database up to date** (non-destructive — Create → Migrate → Schema → Data):
+   ```
+   dotnet run -- database
+   ```
+   If this fails, **stop** — surface the verbatim error. Do not proceed. Do not edit files to work around a broken baseline.
+
+2. **Identify every table involved.** For an entity with `[ReferenceData<T>]` properties, this includes the entity's own table plus any reference-data tables implied by those properties.
+
+3. **Inspect the target table(s)**:
+   ```
+   dotnet run -- inspect <schema> <table> [<table2> ...]
+   ```
+   Read the `## SCHEMA.TABLE — Exists: Yes|No` header for each table. This is a **hard gate** — do not author any script before the inspect result is in hand.
+
+---
+
+## Phase 2: Choose Script Type
+
+Branch on the combination of what the developer needs and the inspect result.
+
+### Path A — New transactional table (`Exists: No`)
+
+```
+dotnet run -- script create <schema> <table>
+```
+
+Open the generated `Migrations/yyyyMMdd-HHmmss-create-<schema>-<table>.{sql|pgsql}` and fill in domain columns following the templates in Phase 3. Then proceed to Phase 4 to register the table in `dbex.yaml`.
+
+### Path B — New reference-data table (`Exists: No`, ref-data entity)
+
+```
+dotnet run -- script refdata <schema> <table>
+```
+
+Open the generated script and fill in any extra columns beyond the standard `IReferenceData` set. Then proceed to Phase 4.
+
+### Path C — Alter existing table (`Exists: Yes`, schema differs from contract)
+
+```
+dotnet run -- script alter <schema> <table>
+```
+
+Open the generated `Migrations/yyyyMMdd-HHmmss-alter-<schema>-<table>.{sql|pgsql}` and author the `ALTER TABLE` statements for the **delta only**. The original create script is immutable — never touch it. `dbex.yaml` does not need updating (the table entry already exists). Identify any hand-written `.cs` code that references changed or removed columns and flag those for update in Phase 6.
+
+> This path applies to both transactional and reference-data tables. For a reference-data table whose shape has changed, use `script alter` for the DDL delta; the `ref-data.yaml` + CodeGen side is a separate step (see `coreex-refdata` skill).
+
+### Path D — Non-entity schema change (index, constraint, function, etc.)
+
+```
+dotnet run -- script
+```
+
+DbEx creates an empty script with a placeholder suffix. **Immediately rename** the suffix portion of the filename to a 3–5 word kebab summary of the intent:
+
+- Good: `add-unique-sku-index`, `drop-legacy-status-column`, `add-fk-order-customer`
+- Bad: `migration`, `update`, `change1`
+
+**255-character filename limit:** The complete filename (including timestamp prefix, descriptor, and extension) must not exceed 255 characters. Internally DbEx derives the embedded-resource name from the project assembly name + `.Migrations.` + the filename (without extension), e.g. `Contoso.Products.Database.Migrations.20260629-143000-add-unique-sku-index`. Keep descriptors short — 3–5 words is both the intent and the safety margin. A descriptor that needs more than ~200 characters is a design signal, not a naming requirement.
+
+`dbex.yaml` does not need updating for non-entity changes. Proceed directly to Phase 5.
+
+### Path E — Table already matches (`Exists: Yes`, schema already correct)
+
+No script is needed. Say so and stop. Do not scaffold a no-op migration.
+
+---
+
+## Phase 3: Fill In The Script
+
+### PK replacement (Paths A and B only)
+
+The `script create` and `script refdata` scaffolds generate a placeholder primary key. **Always overwrite it** to match the contract's identifier type:
+
+| Contract identifier type | SQL Server column | PostgreSQL column |
+|---|---|---|
+| `string` (default) | `[XxxId] NVARCHAR(50) NOT NULL PRIMARY KEY` | `"xxx_id" VARCHAR(50) NOT NULL PRIMARY KEY` |
+| `Guid` | `[XxxId] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY` | `"xxx_id" UUID NOT NULL PRIMARY KEY` |
+| `int` | `[XxxId] INT NOT NULL PRIMARY KEY` | `"xxx_id" INTEGER NOT NULL PRIMARY KEY` |
+
+Remove any `DEFAULT (NEWSEQUENTIALID())`, `IDENTITY`, or `SERIAL` unless the user explicitly requests a DB-assigned key. The application layer assigns identifiers.
+
+### Column-to-type mapping
+
+| .NET type | SQL Server | PostgreSQL |
+|---|---|---|
+| `string` / `string?` | `NVARCHAR(n)` | `VARCHAR(n)` |
+| `Guid` | `UNIQUEIDENTIFIER` | `UUID` |
+| `int` | `INT` | `INTEGER` |
+| `long` | `BIGINT` | `BIGINT` |
+| `decimal` | `DECIMAL(p,s)` | `DECIMAL(p,s)` |
+| `bool` | `BIT` | `BOOLEAN` |
+| `DateTimeOffset` | `DATETIMEOFFSET` | `TIMESTAMPTZ` |
+| `DateTime` | `DATETIME2` | `TIMESTAMP` |
+
+### Reference-data relationships
+
+For each `[ReferenceData<T>]` property on the entity (contract property is `{Name}Code`): create a `{Name}Code` column typed to match the ref-data `Code` column. **No foreign key — this is the default.** Never create a `{Name}Id` column unless the user explicitly asks.
+
+### Logical delete (`is_deleted` / `IsDeleted`)
+
+For root/aggregate tables, ask whether logical (soft) delete support is needed — **default yes**. If yes, add:
+- SQL Server: `[IsDeleted] BIT NOT NULL DEFAULT (0)`
+- PostgreSQL: `"is_deleted" BOOLEAN NOT NULL DEFAULT FALSE`
+
+Must be `NOT NULL` and default to the DB's false. No corresponding contract/entity property.
+
+### Audit columns (IChangeLog)
+
+Use the `On` suffix — **never** `CreatedDate` / `UpdatedDate`:
+- SQL Server: `DATETIMEOFFSET NULL` for date columns, `NVARCHAR(250) NULL` for `*By` columns
+- PostgreSQL: `TIMESTAMPTZ NULL` for date columns, `VARCHAR(250) NULL` for `*By` columns
+
+### Canonical column templates
+
+**Aggregate / transactional — PostgreSQL**
+```sql
+BEGIN TRANSACTION;
+CREATE TABLE "schema"."entity" (
+  "entity_id"   VARCHAR(50)   NOT NULL PRIMARY KEY,
+  -- domain columns here
+  "is_deleted"  BOOLEAN       NOT NULL DEFAULT FALSE,
+  "created_by"  VARCHAR(250)  NULL,
+  "created_on"  TIMESTAMPTZ   NULL,
+  "updated_by"  VARCHAR(250)  NULL,
+  "updated_on"  TIMESTAMPTZ   NULL
+);
+COMMIT TRANSACTION;
+```
+
+**Aggregate / transactional — SQL Server**
+```sql
+BEGIN TRANSACTION;
+CREATE TABLE [Schema].[Entity] (
+  [EntityId]   NVARCHAR(50)   NOT NULL PRIMARY KEY,
+  -- domain columns here
+  [IsDeleted]  BIT            NOT NULL DEFAULT (0),
+  [CreatedBy]  NVARCHAR(250)  NULL,
+  [CreatedOn]  DATETIMEOFFSET NULL,
+  [UpdatedBy]  NVARCHAR(250)  NULL,
+  [UpdatedOn]  DATETIMEOFFSET NULL,
+  [RowVersion] TIMESTAMP      NOT NULL   -- ETag / optimistic concurrency
+);
+COMMIT TRANSACTION;
+```
+
+**Reference-data — PostgreSQL**
+```sql
+BEGIN TRANSACTION;
+CREATE TABLE "schema"."entity" (
+  "entity_id"  VARCHAR(50)   NOT NULL PRIMARY KEY,
+  "code"       VARCHAR(50)   NOT NULL UNIQUE,
+  "text"       VARCHAR(250)  NULL,
+  "is_active"  BOOLEAN       NULL,
+  "sort_order" INTEGER       NULL,
+  "created_by" VARCHAR(250)  NULL,
+  "created_on" TIMESTAMPTZ   NULL,
+  "updated_by" VARCHAR(250)  NULL,
+  "updated_on" TIMESTAMPTZ   NULL
+);
+COMMIT TRANSACTION;
+```
+
+**Reference-data — SQL Server**
+```sql
+BEGIN TRANSACTION;
+CREATE TABLE [Schema].[Entity] (
+  [EntityId]   NVARCHAR(50)   NOT NULL PRIMARY KEY,
+  [Code]       NVARCHAR(50)   NOT NULL UNIQUE,
+  [Text]       NVARCHAR(250)  NULL,
+  [IsActive]   BIT            NULL,
+  [SortOrder]  INT            NULL,
+  [RowVersion] TIMESTAMP      NOT NULL,
+  [CreatedBy]  NVARCHAR(250)  NULL,
+  [CreatedOn]  DATETIMEOFFSET NULL,
+  [UpdatedBy]  NVARCHAR(250)  NULL,
+  [UpdatedOn]  DATETIMEOFFSET NULL
+);
+COMMIT TRANSACTION;
+```
+
+---
+
+## Phase 4: Register in dbex.yaml (Paths A and B only)
+
+Add one line under `tables:`:
+```yaml
+- name: <table>   # snake_case for PostgreSQL, PascalCase for SQL Server
+```
+
+Keep entries minimal — write `- name: Xxx` and nothing else unless there is a specific known need. Do not add `efModel`, `schema`, or other properties speculatively.
+
+Paths C, D, and E: no `dbex.yaml` change needed.
+
+---
+
+## Phase 5: Apply and Regenerate
+
+```
+dotnet run -- All
+```
+
+This runs: Create → Migrate → CodeGen → Schema → Data.
+
+- On success: confirm `Infrastructure/Persistence/<Entity>.g.cs` and `Infrastructure/Repositories/*DbContext.g.cs` have been updated (Paths A–C). Path D produces no `.g.cs` changes.
+- On failure: **stop**, surface the verbatim error. Do not edit `*.g.cs` files to work around a failure — a broken migration means the script or `dbex.yaml` needs fixing, not the generated output.
+
+---
+
+## Phase 6: Validate
+
+1. Re-inspect to confirm the table state matches expectations:
+   ```
+   dotnet run -- inspect <schema> <table>
+   ```
+2. For Paths A–C: confirm `*.g.cs` files reflect the new/changed columns.
+3. **Path C (alter) only:** update any hand-written repository, mapper, or application code that references changed or removed columns.
+4. Run `dotnet build` on the solution to confirm no compile errors.
+
+---
+
+## Guardrails
+
+- **Scripts are immutable once applied.** Never modify a migration script that has already been run. Author a new script for any subsequent delta.
+- **Never edit `*.g.cs` files.** They are owned by DbEx CodeGen — regenerate by fixing the script or `dbex.yaml` and re-running `All`.
+- **Never add `IF NOT EXISTS` or `IF OBJECT_ID(...)` guards.** DbEx tracks applied scripts in its journal; each script runs exactly once. Conditional guards mask state mismatches — they don't fix them.
+- **Never touch the DbEx journal table.** If the live database is out of sync with the scripts, stop and ask the user. The standard clean fix for a disposable dev database is `dotnet run -- dropanddatabase` (destructive — confirm first).
+- **Path D filename limit:** full filename ≤255 characters including the timestamp prefix and extension. Keep descriptors to 3–5 words.
+- **Outbox provisioning is a separate concern** — use `dotnet run -- script outbox <schema> <name>` as described in `coreex-tooling.instructions.md`. Do not conflate it with this workflow.
+- **No schema-create script.** The `coreex` template ships the schema-create migration; never emit another `create-<schema>-schema` script unless an additional schema is explicitly requested.

--- a/src/CoreEx.Template/CoreEx.Template.csproj
+++ b/src/CoreEx.Template/CoreEx.Template.csproj
@@ -125,6 +125,7 @@
     <ItemGroup>
       <_AiFile Include="$(_RepoRoot)consumer-instructions/.github/copilot-instructions.md" DestSubPath=".github/copilot-instructions.md" />
       <_AiFile Include="$(_RepoRoot).github/prompts/coreex-scaffold.prompt.md" DestSubPath=".github/prompts/coreex-scaffold.prompt.md" />
+      <_AiFile Include="$(_RepoRoot).github/prompts/coreex-db-migration.prompt.md" DestSubPath=".github/prompts/coreex-db-migration.prompt.md" />
       <_AiFile Include="$(_RepoRoot).github/skills/solution-scaffolder/SKILL.md" DestSubPath=".github/skills/solution-scaffolder/SKILL.md" />
       <_AiFile Include="$(_RepoRoot).github/skills/solution-scaffolder/README.md" DestSubPath=".github/skills/solution-scaffolder/README.md" />
       <_AiFile Include="$(_RepoRoot).github/skills/solution-scaffolder/assets/servicebus-config.template.json" DestSubPath=".github/skills/solution-scaffolder/assets/servicebus-config.template.json" />
@@ -132,6 +133,8 @@
       <_AiFile Include="$(_RepoRoot).github/skills/solution-scaffolder/references/workflow.md" DestSubPath=".github/skills/solution-scaffolder/references/workflow.md" />
       <_AiFile Include="$(_RepoRoot).github/skills/coreex-docs-sync/SKILL.md" DestSubPath=".github/skills/coreex-docs-sync/SKILL.md" />
       <_AiFile Include="$(_RepoRoot).github/skills/coreex-docs-sync/README.md" DestSubPath=".github/skills/coreex-docs-sync/README.md" />
+      <_AiFile Include="$(_RepoRoot).github/skills/coreex-db-migration/SKILL.md" DestSubPath=".github/skills/coreex-db-migration/SKILL.md" />
+      <_AiFile Include="$(_RepoRoot).github/skills/coreex-db-migration/references/workflow.md" DestSubPath=".github/skills/coreex-db-migration/references/workflow.md" />
       <_AiFile Include="$(_RepoRoot).github/agents/coreex-expert.agent.md" DestSubPath=".github/agents/coreex-expert.agent.md" />
       <_AiFile Include="$(_RepoRoot).claude/commands/coreex-expert.md" DestSubPath=".claude/commands/coreex-expert.md" />
       <_AiFile Include="$(_RepoRoot).claude/commands/coreex-docs-sync.md" DestSubPath=".claude/commands/coreex-docs-sync.md" />
@@ -204,6 +207,11 @@
     <InjectAppFolderConditional SourceFile="$(_RepoRoot).github/instructions/coreex-validators.instructions.md" DestinationFile="$(_AiAiGenRoot).github/instructions/coreex-validators.instructions.md" />
     <Copy SourceFiles="$(_RepoRoot).github/prompts/coreex-scaffold.prompt.md;$(_RepoRoot).github/agents/coreex-expert.agent.md;$(_RepoRoot).claude/commands/coreex-expert.md;$(_RepoRoot).claude/commands/coreex-docs-sync.md;$(_RepoRoot).github/skills/coreex-docs-sync/SKILL.md;$(_RepoRoot).github/skills/coreex-docs-sync/README.md"
           DestinationFiles="$(_AiAiGenRoot).github/prompts/coreex-scaffold.prompt.md;$(_AiAiGenRoot).github/agents/coreex-expert.agent.md;$(_AiAiGenRoot).claude/commands/coreex-expert.md;$(_AiAiGenRoot).claude/commands/coreex-docs-sync.md;$(_AiAiGenRoot).github/skills/coreex-docs-sync/SKILL.md;$(_AiAiGenRoot).github/skills/coreex-docs-sync/README.md"
+          SkipUnchangedFiles="true" />
+
+    <!-- CoreEx.Ai: copy each skill + its prompt wrapper (one block per skill). -->
+    <Copy SourceFiles="$(_RepoRoot).github/prompts/coreex-db-migration.prompt.md;$(_RepoRoot).github/skills/coreex-db-migration/SKILL.md;$(_RepoRoot).github/skills/coreex-db-migration/references/workflow.md"
+          DestinationFiles="$(_AiAiGenRoot).github/prompts/coreex-db-migration.prompt.md;$(_AiAiGenRoot).github/skills/coreex-db-migration/SKILL.md;$(_AiAiGenRoot).github/skills/coreex-db-migration/references/workflow.md"
           SkipUnchangedFiles="true" />
 
     <!-- CoreEx.Ai: pack all generated files into content\CoreEx.Ai\. -->

--- a/src/CoreEx.Template/CoreEx.Template.csproj
+++ b/src/CoreEx.Template/CoreEx.Template.csproj
@@ -209,7 +209,7 @@
           DestinationFiles="$(_AiAiGenRoot).github/prompts/coreex-scaffold.prompt.md;$(_AiAiGenRoot).github/agents/coreex-expert.agent.md;$(_AiAiGenRoot).claude/commands/coreex-expert.md;$(_AiAiGenRoot).claude/commands/coreex-docs-sync.md;$(_AiAiGenRoot).github/skills/coreex-docs-sync/SKILL.md;$(_AiAiGenRoot).github/skills/coreex-docs-sync/README.md"
           SkipUnchangedFiles="true" />
 
-    <!-- CoreEx.Ai: copy each skill + its prompt wrapper (one block per skill). -->
+    <!-- CoreEx.Ai: copy additional skills + their prompt wrappers (prefer one block per skill for clarity). -->
     <Copy SourceFiles="$(_RepoRoot).github/prompts/coreex-db-migration.prompt.md;$(_RepoRoot).github/skills/coreex-db-migration/SKILL.md;$(_RepoRoot).github/skills/coreex-db-migration/references/workflow.md"
           DestinationFiles="$(_AiAiGenRoot).github/prompts/coreex-db-migration.prompt.md;$(_AiAiGenRoot).github/skills/coreex-db-migration/SKILL.md;$(_AiAiGenRoot).github/skills/coreex-db-migration/references/workflow.md"
           SkipUnchangedFiles="true" />


### PR DESCRIPTION
Closes #151 (partial — first skill in the inventory)

## Summary

Adds the `coreex-db-migration` skill — the first atomic L1 skill in the CoreEx skills inventory. Encodes the full database schema change workflow that was previously scattered across `coreex-tooling.instructions.md` as prose and "Agent instruction:" blocks.

## What's included

### `.github/skills/coreex-db-migration/`
- **`SKILL.md`** — lean entry point (<70 lines); frontmatter, when to use/not use, quick-reference command table, polyglot note, workflow pointer
- **`references/workflow.md`** — full 6-phase procedural workflow:
  - Phase 1: establish baseline (inspect DB state before any script — hard gate)
  - Phase 2: choose script type — 5 paths (A–E): create transactional, create refdata, alter existing, non-entity change, new Domain + Database project
  - Phase 3: fill in the script — SQL column templates for aggregate + refdata × SQL Server + PostgreSQL; JSON column convention (`NVARCHAR(MAX)` / `jsonb`)
  - Phase 4: update `dbex.yaml`
  - Phase 5: run `dotnet run -- all` (or `dropandall --accept-prompts` for recovery)
  - Phase 6: validate — build + EF model regeneration check
  - Guardrails (filename ≤255 chars, never edit `*.g.*` files, etc.)

### `.github/prompts/coreex-db-migration.prompt.md`
Thin bridge wrapper enabling `/coreex-db-migration` in VS Code Copilot Chat, Visual Studio, and GitHub.com. Points to `SKILL.md` as authoritative source; the skill always wins on conflict.

### `src/CoreEx.Template/CoreEx.Template.csproj`
Wires the new skill and prompt wrapper into the `CopyTemplateAiContext` pack target:
- `_AiFile` ItemGroup → `CoreEx.Bootstrap` receives the full set
- New dedicated `Copy` block → `CoreEx.Ai` also receives skill + prompt wrapper

The one-block-per-skill pattern establishes the convention for all future skills.

## Compatibility

| Tool | Support |
|---|---|
| Copilot CLI | ✅ Native — `SKILL.md` loaded at session start |
| Claude Code | ✅ Compatible — same `SKILL.md` format |
| VS Code Copilot Chat | ✅ Via `coreex-db-migration.prompt.md` wrapper |
| Visual Studio / GitHub.com | ✅ Via prompt wrapper |

## Key conventions encoded

- `script create` / `script refdata` / `script alter` / bare `script` command matrix
- `dotnet run -- dropandall --accept-prompts` for DB recovery (user must initiate)
- JSON column naming convention (`Json` suffix → `NVARCHAR(MAX)` / `jsonb`; .NET type is class/record)
- 255-char filename limit (assembly name + `.Migrations.` prefix counts)
- Polyglot: SQL Server (Shopping) vs PostgreSQL (Products) — provider auto-detected from Database project