### PR TITLE
test: add Basket aggregate unit tests

### DIFF
--- a/.github/skills/coreex-aggregate/references/workflow.md
+++ b/.github/skills/coreex-aggregate/references/workflow.md
@@ -220,7 +220,9 @@ Follow the same `*.Test.Unit` conventions as validator tests (see
 `[Test]` running inside `Test.Scoped(test => { ... })` — this establishes the ambient `ExecutionContext`
 that `Runtime.UtcNow` and any `ThrowIfInactive()` reference-data check rely on. (`Runtime.NewId()`/
 `Runtime.NewGuid()` do **not** need `ExecutionContext` — they resolve via `IdentifierGenerator.Current`
-— but `Test.Scoped(...)` is still the standard wrapper for every test in these projects.)
+— but `Test.Scoped(...)` is still the standard wrapper for every test in these projects.) Name test
+methods `{Aggregate}_{MutationMethod}_{Outcome}`, matching the `{Entity}_{Action}_{Outcome}` convention
+used across the rest of the test suite (e.g. `Basket_Checkout_Success`, `Basket_Checkout_Insufficient_Quantity`).
 
 ```csharp
 namespace {Domain}.Test.Unit.Domains;
@@ -228,7 +230,7 @@ namespace {Domain}.Test.Unit.Domains;
 public class {Aggregate}Tests : WithGenericTester<EntryPoint>
 {
     [Test]
-    public void {MutationMethod}_Succeeds_When_{Condition}() => Test.Scoped(test =>
+    public void {Aggregate}_{MutationMethod}_Success() => Test.Scoped(test =>
     {
         // Arrange: construct the aggregate directly via CreateFrom — no repository, no persistence.
         var aggregate = {Aggregate}.CreateFrom({id}, {CtorArgs}, items: null, changeLog: null, etag: null);
@@ -241,7 +243,7 @@ public class {Aggregate}Tests : WithGenericTester<EntryPoint>
     });
 
     [Test]
-    public void {MutationMethod}_Fails_When_{GuardCondition}() => Test.Scoped(test =>
+    public void {Aggregate}_{MutationMethod}_{GuardOutcome}() => Test.Scoped(test =>
     {
         // Arrange: construct the aggregate in a state that should reject the mutation.
         var aggregate = {Aggregate}.CreateFrom({id}, {CtorArgsForGuardedState}, items: null, changeLog: null, etag: null);

--- a/samples/tests/Contoso.Shopping.Test.Unit/Contoso.Shopping.Test.Unit.csproj
+++ b/samples/tests/Contoso.Shopping.Test.Unit/Contoso.Shopping.Test.Unit.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\..\src\CoreEx.UnitTesting\CoreEx.UnitTesting.csproj" />
     <ProjectReference Include="..\..\src\Contoso.Shopping.Application\Contoso.Shopping.Application.csproj" />
     <ProjectReference Include="..\..\src\Contoso.Shopping.Contracts\Contoso.Shopping.Contracts.csproj" />
+    <ProjectReference Include="..\..\src\Contoso.Shopping.Domain\Contoso.Shopping.Domain.csproj" />
     <ProjectReference Include="..\..\src\Contoso.Shopping.Infrastructure\Contoso.Shopping.Infrastructure.csproj" />
     <ProjectReference Include="..\Contoso.Shopping.Test.Common\Contoso.Shopping.Test.Common.csproj" />
   </ItemGroup>

--- a/samples/tests/Contoso.Shopping.Test.Unit/Domains/BasketTests.cs
+++ b/samples/tests/Contoso.Shopping.Test.Unit/Domains/BasketTests.cs
@@ -1,0 +1,38 @@
+namespace Contoso.Shopping.Test.Unit.Domains;
+
+public class BasketTests : WithGenericTester<EntryPoint>
+{
+    [Test]
+    public void Apply_Discount_To_Existing_Active_Basket() => Test.Scoped(test =>
+    {
+        // Arrange: Create a basket with an item.
+        var basket = Domain.Basket.CreateFrom("basket-id", "customer-id", BasketStatus.Active, null,
+            [Domain.BasketItem.CreateFrom("item-id", "product-id", "sku", "text", new Domain.ValueObjects.ItemPricing { UnitOfMeasure = "EA", Quantity = 1, UnitPrice = 100m }, null)],
+            null, null);
+
+        // Act: Apply a discount coupon to the basket.
+        basket.ApplyDiscount(new DiscountCoupon { Code = "DISCOUNT10", DiscountPercentage = 10m });
+
+        // Assert: Verify that the discount has been applied correctly.
+        basket.DiscountAmount.Should().Be(10m);
+        basket.Total.Should().Be(90m);
+    });
+
+    [Test]
+    public void Apply_Discount_To_Existing_CheckedOut_Basket() => Test.Scoped(test =>
+    {
+        // Arrange: Create a basket with an item.
+        var basket = Domain.Basket.CreateFrom("basket-id", "customer-id", BasketStatus.CheckedOut, null,
+            [Domain.BasketItem.CreateFrom("item-id", "product-id", "sku", "text", new Domain.ValueObjects.ItemPricing { UnitOfMeasure = "EA", Quantity = 1, UnitPrice = 100m }, null)],
+            null, null);
+
+        // Act: Apply a discount coupon to the basket.
+        Action act = () => basket.ApplyDiscount(new DiscountCoupon { Code = "DISCOUNT10", DiscountPercentage = 10m });
+
+        // Assert: Verify that the discount can not be applied.
+        act.Should().Throw<BusinessException>().WithMessage("Basket has a status of 'Checked-out' and as such cannot be modified.");
+
+        basket.DiscountAmount.Should().Be(0m);
+        basket.Total.Should().Be(100m);
+    });
+}

--- a/samples/tests/Contoso.Shopping.Test.Unit/Domains/BasketTests.cs
+++ b/samples/tests/Contoso.Shopping.Test.Unit/Domains/BasketTests.cs
@@ -3,7 +3,7 @@ namespace Contoso.Shopping.Test.Unit.Domains;
 public class BasketTests : WithGenericTester<EntryPoint>
 {
     [Test]
-    public void Apply_Discount_To_Existing_Active_Basket() => Test.Scoped(test =>
+    public void Basket_ApplyDiscount_Success() => Test.Scoped(test =>
     {
         // Arrange: Create a basket with an item.
         var basket = Domain.Basket.CreateFrom("basket-id", "customer-id", BasketStatus.Active, null,
@@ -19,7 +19,7 @@ public class BasketTests : WithGenericTester<EntryPoint>
     });
 
     [Test]
-    public void Apply_Discount_To_Existing_CheckedOut_Basket() => Test.Scoped(test =>
+    public void Basket_ApplyDiscount_Invalid_Status() => Test.Scoped(test =>
     {
         // Arrange: Create a basket with an item.
         var basket = Domain.Basket.CreateFrom("basket-id", "customer-id", BasketStatus.CheckedOut, null,

--- a/samples/tests/Contoso.Shopping.Test.Unit/EntryPoint.cs
+++ b/samples/tests/Contoso.Shopping.Test.Unit/EntryPoint.cs
@@ -22,6 +22,7 @@ public class EntryPoint
         public override Task<IReferenceDataCollection> GetAsync(Type type, CancellationToken cancellationToken = default) => type switch
         {
             _ when type == typeof(UnitOfMeasure) => Task.FromResult((IReferenceDataCollection)jdr.Deserialize<UnitOfMeasureCollection>("Shopping.$^UnitOfMeasure")!),
+            _ when type == typeof(BasketStatus) => Task.FromResult((IReferenceDataCollection)jdr.Deserialize<BasketStatusCollection>("Shopping.$^BasketStatus")!),
             _ => throw new InvalidOperationException($"Type {type.FullName} is not a known {nameof(IReferenceData)}.")
         };
     }


### PR DESCRIPTION
## Summary

Adds `BasketTests.cs` under `Contoso.Shopping.Test.Unit/Domains/`, exercising the `Basket` aggregate directly — no repository, no Application service. This is a real, working example of the guidance added to the `coreex-aggregate` skill (#162): aggregates have no injected dependencies (beyond reference data), making them the best unit-test target in the codebase for both happy-path and business-rule-rejection coverage.

## What's included

- `Apply_Discount_To_Existing_Active_Basket` — happy path: verifies `DiscountAmount`/`Total` after `ApplyDiscount` on an `Active` basket
- `Apply_Discount_To_Existing_CheckedOut_Basket` — guard-rejection path: verifies `OnCheckCanMutate()`'s `BusinessException` on a `CheckedOut` basket, and that state is left unchanged

## Wiring changes

- `Contoso.Shopping.Test.Unit.csproj` — added `ProjectReference` to `Contoso.Shopping.Domain` so the `Domain` namespace is reachable (resolves via enclosing-namespace lookup since the test class lives in `Contoso.Shopping.Test.Unit.Domains`, a sibling of `Contoso.Shopping.Domain`)
- `EntryPoint.cs` — registered `BasketStatus` reference data in the in-memory `ReferenceDataServiceDecorator`, since `Basket.Status`'s setter requires active ref-data via `ThrowIfInactive()`

## Validation

- `dotnet build samples/tests/Contoso.Shopping.Test.Unit/Contoso.Shopping.Test.Unit.csproj` — 0 warnings, 0 errors
- `dotnet test` — all 16 tests pass across net8.0/net9.0/net10.0 (2 new + 14 pre-existing)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>