### PR TITLE
Add omitted Shopping tests to CI filters

### DIFF
--- a/CoreEx.Samples.Build.slnf
+++ b/CoreEx.Samples.Build.slnf
@@ -38,7 +38,9 @@
       "samples/tests/Contoso.Products.Test.Subscribe/Contoso.Products.Test.Subscribe.csproj",
       "samples/tests/Contoso.Products.Test.Unit/Contoso.Products.Test.Unit.csproj",
       "samples/tests/Contoso.Shopping.Test.Api/Contoso.Shopping.Test.Api.csproj",
-      "samples/tests/Contoso.Shopping.Test.Common/Contoso.Shopping.Test.Common.csproj"
+      "samples/tests/Contoso.Shopping.Test.Common/Contoso.Shopping.Test.Common.csproj",
+      "samples/tests/Contoso.Shopping.Test.Subscribe/Contoso.Shopping.Test.Subscribe.csproj",
+      "samples/tests/Contoso.Shopping.Test.Unit/Contoso.Shopping.Test.Unit.csproj"
     ]
   }
 }

--- a/CoreEx.Samples.Test.slnf
+++ b/CoreEx.Samples.Test.slnf
@@ -8,7 +8,9 @@
       "samples/tests/Contoso.Products.Test.Relay/Contoso.Products.Test.Relay.csproj",
       "samples/tests/Contoso.Products.Test.Subscribe/Contoso.Products.Test.Subscribe.csproj",
       "samples/tests/Contoso.Products.Test.Unit/Contoso.Products.Test.Unit.csproj",
-      "samples/tests/Contoso.Shopping.Test.Api/Contoso.Shopping.Test.Api.csproj"
+      "samples/tests/Contoso.Shopping.Test.Api/Contoso.Shopping.Test.Api.csproj",
+      "samples/tests/Contoso.Shopping.Test.Subscribe/Contoso.Shopping.Test.Subscribe.csproj",
+      "samples/tests/Contoso.Shopping.Test.Unit/Contoso.Shopping.Test.Unit.csproj"
     ]
   }
 }


### PR DESCRIPTION
## Summary

- add `Contoso.Shopping.Test.Unit` and `Contoso.Shopping.Test.Subscribe` to the sample build and test solution filters
- restore pull-request CI coverage for two previously passing Shopping suites that were omitted from both filters

## Validation

- `dotnet build CoreEx.Samples.Build.slnf --no-restore --configuration Release` — succeeded with 0 warnings and 0 errors
- `Contoso.Shopping.Test.Unit` — 48 passed across net8.0, net9.0, and net10.0
- `Contoso.Shopping.Test.Subscribe` — 15 passed across net8.0, net9.0, and net10.0
- confirmed both projects are selected by both solution filters
