### PR TITLE
Fix JsonElementStringConverter non-generic IConverter swapped casts (#175)

### DIFF
--- a/src/CoreEx/Mapping/Converters/EncodedStringToUInt32Converter.cs
+++ b/src/CoreEx/Mapping/Converters/EncodedStringToUInt32Converter.cs
@@ -29,12 +29,6 @@ public readonly struct EncodedStringToUInt32Converter : IConverter<string?, uint
     public IValueConverter<uint, string?> ToSource => _convertToSource;
 
     /// <inheritdoc />
-    public readonly object? ConvertToDestination(object? source) => ConvertToDestination((string?)source);
-
-    /// <inheritdoc />
-    public readonly object? ConvertToSource(object? destination) => ConvertToSource((uint)destination!);
-
-    /// <inheritdoc />
     public readonly uint ConvertToDestination(string? source) => ToDestination.Convert(source);
 
     /// <inheritdoc />

--- a/src/CoreEx/Mapping/Converters/IConverterT.cs
+++ b/src/CoreEx/Mapping/Converters/IConverterT.cs
@@ -19,6 +19,12 @@ public interface IConverter<TSource, TDestination> : ISourceConverter<TSource>, 
     /// <inheritdoc/>
     object? IDestinationConverter<TDestination>.ConvertToSource(TDestination destination) => ConvertToSource((TDestination)destination!);
 
+    /// <inheritdoc/>
+    object? IConverter.ConvertToDestination(object? source) => ConvertToDestination((TSource)source!);
+
+    /// <inheritdoc/>
+    object? IConverter.ConvertToSource(object? destination) => ConvertToSource((TDestination)destination!);
+
     /// <summary>
     /// Gets the source to destination <see cref="IValueConverter{TSource, TDestination}"/>.
     /// </summary>

--- a/src/CoreEx/Mapping/Converters/JsonElementStringConverter.cs
+++ b/src/CoreEx/Mapping/Converters/JsonElementStringConverter.cs
@@ -36,12 +36,6 @@ public readonly struct JsonElementStringConverter : IConverter<JsonElement?, str
     public IValueConverter<string?, JsonElement?> ToSource => _convertToSource;
 
     /// <inheritdoc />
-    public readonly object? ConvertToDestination(object? source) => ConvertToDestination((string?)source);
-
-    /// <inheritdoc />
-    public readonly object? ConvertToSource(object? destination) => ConvertToSource((JsonElement?)destination);
-
-    /// <inheritdoc />
     public readonly string? ConvertToDestination(JsonElement? source) => ToDestination.Convert(source);
 
     /// <inheritdoc />

--- a/src/CoreEx/Mapping/Converters/StringBase64Converter.cs
+++ b/src/CoreEx/Mapping/Converters/StringBase64Converter.cs
@@ -29,12 +29,6 @@ public readonly struct StringBase64Converter : IConverter<string?, byte[]?>
     public IValueConverter<byte[]?, string?> ToSource => _convertToSource;
 
     /// <inheritdoc />
-    public readonly object? ConvertToDestination(object? source) => ConvertToDestination((string?)source);
-
-    /// <inheritdoc />
-    public readonly object? ConvertToSource(object? destination) => ConvertToSource((byte[]?)destination);
-
-    /// <inheritdoc />
     public readonly byte[]? ConvertToDestination(string? source) => ToDestination.Convert(source);
 
     /// <inheritdoc />

--- a/src/CoreEx/Mapping/Converters/TypeToJsonStringConverter.cs
+++ b/src/CoreEx/Mapping/Converters/TypeToJsonStringConverter.cs
@@ -30,12 +30,6 @@ public readonly struct TypeToJsonStringConverter<T> : IConverter<T, string?>
     public IValueConverter<string?, T> ToSource => _convertToSource;
 
     /// <inheritdoc />
-    public readonly object? ConvertToDestination(object? source) => ConvertToDestination((T)source!);
-
-    /// <inheritdoc />
-    public readonly object? ConvertToSource(object? destination) => ConvertToSource((string?)destination);
-
-    /// <inheritdoc />
     public readonly string? ConvertToDestination(T source) => ToDestination.Convert(source);
 
     /// <inheritdoc />

--- a/tests/CoreEx.Test.Unit/Mapping/Converters/EncodedStringToUInt32ConverterTests.cs
+++ b/tests/CoreEx.Test.Unit/Mapping/Converters/EncodedStringToUInt32ConverterTests.cs
@@ -1,0 +1,75 @@
+using CoreEx.Mapping.Converters;
+
+namespace CoreEx.Test.Unit.Mapping.Converters;
+
+[TestFixture]
+public class EncodedStringToUInt32ConverterTests
+{
+    private readonly EncodedStringToUInt32Converter _converter = EncodedStringToUInt32Converter.Default;
+
+    [Test]
+    public void ConvertToDestination_ValidBase64String_ReturnsUInt32()
+    {
+        var value = 12345u;
+        var base64 = Convert.ToBase64String(BitConverter.GetBytes(value));
+
+        _converter.ConvertToDestination(base64).Should().Be(value);
+    }
+
+    [Test]
+    public void ConvertToDestination_Null_ReturnsZero()
+    {
+        _converter.ConvertToDestination((string?)null).Should().Be(0u);
+    }
+
+    [Test]
+    public void ConvertToSource_ValidUInt32_ReturnsBase64String()
+    {
+        var value = 98765u;
+
+        var result = _converter.ConvertToSource(value);
+
+        result.Should().Be(Convert.ToBase64String(BitConverter.GetBytes(value)));
+    }
+
+    [Test]
+    public void ConvertToSource_Zero_ReturnsNull()
+    {
+        _converter.ConvertToSource(0u).Should().BeNull();
+    }
+
+    [Test]
+    public void RoundTrip_UInt32ToBase64AndBack()
+    {
+        var value = 555u;
+        var base64 = _converter.ConvertToSource(value);
+        var roundTrip = _converter.ConvertToDestination(base64);
+
+        roundTrip.Should().Be(value);
+    }
+
+    // The following two tests exercise the non-generic IConverter object-based overloads directly (see issue #175,
+    // which found the exact same defect class in JsonElementStringConverter's non-generic overloads).
+    [Test]
+    public void IConverter_ConvertToDestination_Object_ReturnsUInt32()
+    {
+        IConverter converter = _converter;
+        var value = 4242u;
+        var base64 = Convert.ToBase64String(BitConverter.GetBytes(value));
+
+        var result = converter.ConvertToDestination(base64);
+
+        result.Should().Be(value);
+    }
+
+    [Test]
+    public void IConverter_ConvertToSource_Object_ReturnsBase64String()
+    {
+        IConverter converter = _converter;
+        var value = 111u;
+
+        var result = converter.ConvertToSource(value);
+
+        result.Should().Be(Convert.ToBase64String(BitConverter.GetBytes(value)));
+    }
+}

--- a/tests/CoreEx.Test.Unit/Mapping/Converters/JsonElementStringConverterTests.cs
+++ b/tests/CoreEx.Test.Unit/Mapping/Converters/JsonElementStringConverterTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using CoreEx.Mapping.Converters;
+
+namespace CoreEx.Test.Unit.Mapping.Converters;
+
+[TestFixture]
+public class JsonElementStringConverterTests
+{
+    private readonly JsonElementStringConverter _converter = JsonElementStringConverter.Default;
+
+    [Test]
+    public void ConvertToDestination_Value_ReturnsJson()
+    {
+        using var doc = JsonDocument.Parse("""{"name":"Bob","number":42}""");
+        var result = _converter.ConvertToDestination(doc.RootElement);
+
+        result.Should().Be("""{"name":"Bob","number":42}""");
+    }
+
+    [Test]
+    public void ConvertToDestination_Null_ReturnsNull()
+    {
+        _converter.ConvertToDestination((JsonElement?)null).Should().BeNull();
+    }
+
+    [Test]
+    public void ConvertToSource_Json_ReturnsJsonElement()
+    {
+        var result = _converter.ConvertToSource("""{"name":"Bob","number":42}""");
+
+        result!.Value.GetProperty("name").GetString().Should().Be("Bob");
+        result.Value.GetProperty("number").GetInt32().Should().Be(42);
+    }
+
+    [Test]
+    public void ConvertToSource_Null_ReturnsNull()
+    {
+        _converter.ConvertToSource((string?)null).Should().BeNull();
+    }
+
+    [Test]
+    public void RoundTrip_JsonElementToStringAndBack()
+    {
+        using var doc = JsonDocument.Parse("""{"name":"Alice","number":7}""");
+        var json = _converter.ConvertToDestination(doc.RootElement);
+        var roundTrip = _converter.ConvertToSource(json);
+
+        roundTrip!.Value.GetProperty("name").GetString().Should().Be("Alice");
+        roundTrip.Value.GetProperty("number").GetInt32().Should().Be(7);
+    }
+
+    // The following two tests exercise the non-generic IConverter object-based overloads directly, which is
+    // where a copy/paste bug (issue #175) previously caused an InvalidCastException or infinite recursion
+    // (StackOverflowException) because the casts were against the wrong side's type (TDestination instead of
+    // TSource, and vice versa).
+    [Test]
+    public void IConverter_ConvertToDestination_Object_ReturnsJson()
+    {
+        IConverter converter = _converter;
+        using var doc = JsonDocument.Parse("""{"name":"Bob","number":42}""");
+
+        var result = converter.ConvertToDestination(doc.RootElement);
+
+        result.Should().Be("""{"name":"Bob","number":42}""");
+    }
+
+    [Test]
+    public void IConverter_ConvertToSource_Object_ReturnsJsonElement()
+    {
+        IConverter converter = _converter;
+
+        var result = (JsonElement?)converter.ConvertToSource("""{"name":"Bob","number":42}""");
+
+        result!.Value.GetProperty("name").GetString().Should().Be("Bob");
+        result.Value.GetProperty("number").GetInt32().Should().Be(42);
+    }
+}

--- a/tests/CoreEx.Test.Unit/Mapping/Converters/StringToBase64ConverterTests.cs
+++ b/tests/CoreEx.Test.Unit/Mapping/Converters/StringToBase64ConverterTests.cs
@@ -56,4 +56,29 @@ public class StringToBase64ConverterTests
         Action act = () => _converter.ConvertToDestination("not_base64!");
         act.Should().Throw<FormatException>();
     }
+
+    // The following two tests exercise the non-generic IConverter object-based overloads directly (see issue #175,
+    // which found the exact same defect class in JsonElementStringConverter's non-generic overloads).
+    [Test]
+    public void IConverter_ConvertToDestination_Object_ReturnsBytes()
+    {
+        IConverter converter = _converter;
+        var text = "Hello, World!";
+        var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(text));
+
+        var result = (byte[]?)converter.ConvertToDestination(base64);
+
+        System.Text.Encoding.UTF8.GetString(result!).Should().Be(text);
+    }
+
+    [Test]
+    public void IConverter_ConvertToSource_Object_ReturnsBase64String()
+    {
+        IConverter converter = _converter;
+        var bytes = System.Text.Encoding.UTF8.GetBytes("Test123");
+
+        var result = converter.ConvertToSource(bytes);
+
+        result.Should().Be(Convert.ToBase64String(bytes));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #175. `JsonElementStringConverter`'s non-generic `IConverter.ConvertToDestination(object?)`/`ConvertToSource(object?)` overrides cast to the wrong side's type, causing `InvalidCastException` or infinite recursion (`StackOverflowException`) for any caller going through the non-generic `IConverter` contract.

## Root cause and audit

Audited all 4 implementers of `IConverter<TSource,TDestination>`. Only `JsonElementStringConverter` was actually broken; `StringBase64Converter`, `EncodedStringToUInt32Converter`, and `TypeToJsonStringConverter<T>` already had correct casts, just the same duplicated hand-rolled pattern.

## Fix

Rather than just patching the one bad cast, this removes the whole duplicated pattern (as the issue suggests) so the bug class can't recur:

1. **`IConverterT.cs`** — added the two missing default interface implementations for the *base* `IConverter.ConvertToDestination(object?)` / `ConvertToSource(object?)` members on `IConverter<TSource,TDestination>`. These were previously **not** covered by any DIM anywhere in the hierarchy (the existing DIMs only satisfy the `new`-hidden slots on `ISourceConverter<TSource>`/`IDestinationConverter<TDestination>` — analogous to how `IEnumerable<T>` hides but doesn't implement `IEnumerable.GetEnumerator()`). Without this addition, deleting the structs' hand-rolled overrides would not compile.
2. Deleted the redundant hand-rolled non-generic overrides from all four converters (`JsonElementStringConverter`, `StringBase64Converter`, `EncodedStringToUInt32Converter`, `TypeToJsonStringConverter<T>`), now relying solely on the interface's default implementations.
3. Added regression tests exercising the non-generic `IConverter` path for all four converters (new `JsonElementStringConverterTests`, new `EncodedStringToUInt32ConverterTests`, extended `StringToBase64ConverterTests`), mirroring the coverage already present in `TypeToJsonStringConverterTests`.

## Testing

- `dotnet build CoreEx.sln` — succeeds, 0 errors.
- `dotnet test tests\CoreEx.Test.Unit` — 735/735 passing on net8.0, net9.0, and net10.0.

No behavioral change for any existing strongly-typed call site; verified no call site in `src/` depends on the non-generic overload being directly callable on a concretely-typed struct variable.