### PR TITLE
Release v4.0.0-preview-4

### DIFF
--- a/.github/coreex-ai-workflows.md
+++ b/.github/coreex-ai-workflows.md
@@ -14,12 +14,12 @@ This folder contains the AI artefacts that give GitHub Copilot and Claude Code a
 
 | Artefact | Path | Purpose |
 |----------|------|---------|
-| Global instructions | `copilot-instructions.md` | Auto-injected project-wide context: repo shape, conventions, house rules, generated-file ownership. Applied to every chat interaction automatically. |
+| Global instructions | In this repo: `copilot-instructions.md`. In a consumer repo generated via `dotnet new coreex-ai`: `instructions/coreex.instructions.md` (`applyTo: "**"`) — the template deliberately replaces `copilot-instructions.md` with this file; it is never generated. | Auto-injected project-wide context: repo shape, conventions, house rules, generated-file ownership. Applied to every chat interaction automatically. |
 | Area instructions | `instructions/*.instructions.md` | Scoped context injected automatically when editing a matching file type (contracts, services, repositories, controllers, tests, etc.). |
 | Agent | `agents/coreex-expert.agent.md` | Dedicated expert for CoreEx architecture and pattern guidance — explains conventions, reviews designs, and routes to the right command. |
 | Prompts | `prompts/*.prompt.md` | Deterministic, file-driven commands invoked with `/` in chat. |
 | Skills | `skills/*/SKILL.md` | Reasoning-based commands for open-ended tasks. Invoked with `/` in Claude Code; attach the `SKILL.md` via `#file:` in Copilot. |
-| Authoring guides | `INSTRUCTION_AUTHORING.md`, `SKILL_AUTHORING.md` | Standards for writing new instruction files and skills. |
+| Authoring guides | `INSTRUCTION_AUTHORING.md`, `SKILL_AUTHORING.md` — present in this repo only; not copied into consumer repos by `dotnet new coreex-ai`. | Standards for writing new instruction files and skills. |
 
 ## Agent
 

--- a/CoreEx.slnx
+++ b/CoreEx.slnx
@@ -124,8 +124,8 @@
     <Project Path="src/CoreEx.Azure.Messaging.ServiceBus/CoreEx.Azure.Messaging.ServiceBus.csproj" />
     <Project Path="src/CoreEx.Caching.FusionCache/CoreEx.Caching.FusionCache.csproj" />
     <Project Path="src/CoreEx.CodeGen/CoreEx.CodeGen.csproj" />
-    <Project Path="src/CoreEx.Data/CoreEx.Data.csproj" />
     <Project Path="src/CoreEx.Data.GraphQL/CoreEx.Data.GraphQL.csproj" />
+    <Project Path="src/CoreEx.Data/CoreEx.Data.csproj" />
     <Project Path="src/CoreEx.Database.Postgres/CoreEx.Database.Postgres.csproj" />
     <Project Path="src/CoreEx.Database.SqlServer/CoreEx.Database.SqlServer.csproj" />
     <Project Path="src/CoreEx.Database/CoreEx.Database.csproj" />
@@ -143,8 +143,8 @@
     <Project Path="tests/CoreEx.AspNetCore.Test.Unit/CoreEx.AspNetCore.Test.Unit.csproj" />
     <Project Path="tests/CoreEx.Azure.Messaging.ServiceBus.Test.Unit/CoreEx.Azure.Messaging.ServiceBus.Test.Unit.csproj" />
     <Project Path="tests/CoreEx.Caching.Redis.Test.Unit/CoreEx.Caching.Redis.Test.Unit.csproj" />
-    <Project Path="tests/CoreEx.Data.Test.Unit/CoreEx.Data.Test.Unit.csproj" />
     <Project Path="tests/CoreEx.Data.GraphQL.Test.Unit/CoreEx.Data.GraphQL.Test.Unit.csproj" />
+    <Project Path="tests/CoreEx.Data.Test.Unit/CoreEx.Data.Test.Unit.csproj" />
     <Project Path="tests/CoreEx.Database.Postgres.Test.Console/CoreEx.Database.Postgres.Test.Console.csproj" />
     <Project Path="tests/CoreEx.Database.Postgres.Test.Unit/CoreEx.Database.Postgres.Test.Unit.csproj" />
     <Project Path="tests/CoreEx.Database.SqlServer.Test.Console/CoreEx.Database.SqlServer.Test.Console.csproj" />
@@ -153,11 +153,12 @@
     <Project Path="tests/CoreEx.DomainDriven.Test.Unit/CoreEx.DomainDriven.Test.Unit.csproj" />
     <Project Path="tests/CoreEx.Events.Test.Unit/CoreEx.Events.Test.Unit.csproj" />
     <Project Path="tests/CoreEx.RefData.Test.Unit/CoreEx.RefData.Test.Unit.csproj" />
-    <Project Path="tests/CoreEx.UnitTesting.Test.Unit/CoreEx.UnitTesting.Test.Unit.csproj" />
     <Project Path="tests/CoreEx.Test.Unit/CoreEx.Test.Unit.csproj" />
+    <Project Path="tests/CoreEx.UnitTesting.Test.Unit/CoreEx.UnitTesting.Test.Unit.csproj" />
     <Project Path="tests/CoreEx.Validation.Test.Unit/CoreEx.Validation.Test.Unit.csproj" />
   </Folder>
   <Folder Name="/tools/">
+    <File Path="tools/validate-template-pack.ps1" />
     <Project Path="tools/CoreEx.Tooling.Console/CoreEx.Tooling.Console.csproj" />
   </Folder>
 </Solution>

--- a/Version.props
+++ b/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>4.0.0-preview-3</Version>
+    <Version>4.0.0-preview-4</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Publishes **v4.0.0-preview-4**. All milestone work is already on `main`; this branch bumps `Version.props` to `4.0.0-preview-4` and adds a final documentation clarification pass discovered while reviewing the release.

## Milestone

[`v4.0.0-preview-4` milestone](https://github.com/Avanade/CoreEx/milestone/3) — 4/4 closed.

| # | Title | Type |
|---|---|---|
| [#179](https://github.com/Avanade/CoreEx/pull/179) | DB layer review: outbox, EF Core concurrency/tenancy, and error-mapping fixes | PR (merged) |
| [#180](https://github.com/Avanade/CoreEx/pull/180) | Code review pass: fix bugs and expand test coverage in CoreEx and CoreEx.RefData | PR (merged) |
| [#181](https://github.com/Avanade/CoreEx/pull/181) | Code review sweep: harden every CoreEx package, close doc/reality gaps | PR (merged) |
| [#182](https://github.com/Avanade/CoreEx/pull/182) | Add Aspire AppHost template, CleanArgs API, and coreex-domain naming fixes | PR (merged) |

## This branch's own change

Documentation clarification discovered while auditing the AI workflow assets shipped by `dotnet new coreex-ai` for this release:

- `coreex-ai-workflows.md` is dual-audience (authored in this repo, copied verbatim into every consumer repo by `CoreEx.Template`), but two of its table rows described contributor-repo-only artefacts as if they existed in the generated consumer output:
  - **Global instructions** row named `copilot-instructions.md` unconditionally, even though `dotnet new coreex-ai` deliberately never generates that file — it's replaced by `instructions/coreex.instructions.md` (`applyTo: "**"`), which is CI-enforced (`validate-template-pack.ps1` asserts `copilot-instructions.md` is `FilesAbsent`).
  - **Authoring guides** row listed `INSTRUCTION_AUTHORING.md`/`SKILL_AUTHORING.md`, neither of which is copied into consumer repos.
  
  Both rows now correctly distinguish contributor-repo reality from consumer-repo reality.
- Bumped `Version.props` to `4.0.0-preview-4`.

## Test plan

- [x] `git diff` reviewed — change is scoped to `Version.props`, `.github/coreex-ai-workflows.md`, and an incidental `CoreEx.slnx` re-sort (adds `tools/validate-template-pack.ps1` as a solution item, alphabetizes a few entries)
- [x] Confirmed via `tools/validate-template-pack.ps1` scenario assertions that `copilot-instructions.md` is genuinely `FilesAbsent` from `dotnet new coreex-ai` output, and `coreex.instructions.md` is the actual replacement, before updating the doc